### PR TITLE
Rename marketplace to agent-toolkit, fix install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "agent-skills",
+  "name": "agent-toolkit",
   "description": "Claude Code plugins for software philosophy, project management, dev tools, and productivity",
   "owner": {
     "name": "Dan Mestas",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Agent Skills
+# Agent Toolkit
 
 A Claude Code plugin marketplace. Install individual plugins or the entire collection.
 
@@ -15,16 +15,22 @@ A Claude Code plugin marketplace. Install individual plugins or the entire colle
 
 ## Install
 
+Add the marketplace:
+
+```bash
+claude plugin marketplace add danmestas/agent-skills
+```
+
 Install a single plugin:
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin software-philosophy
+claude plugin install software-philosophy
 ```
 
 Install all plugins:
 
 ```bash
-claude plugin add danmestas/agent-skills
+claude plugin install software-philosophy gh-project-management project-management dev-tools apple-contacts career-interview
 ```
 
 ## License

--- a/plugins/apple-contacts/README.md
+++ b/plugins/apple-contacts/README.md
@@ -16,5 +16,6 @@ Manage Apple Contacts via the contactbook CLI on macOS.
 ## Install
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin apple-contacts
+claude plugin marketplace add danmestas/agent-skills
+claude plugin install apple-contacts
 ```

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -13,5 +13,6 @@ Development and testing utilities.
 ## Install
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin dev-tools
+claude plugin marketplace add danmestas/agent-skills
+claude plugin install dev-tools
 ```

--- a/plugins/gh-project-management/README.md
+++ b/plugins/gh-project-management/README.md
@@ -18,5 +18,6 @@ Includes 6 project templates: kanban, bug-tracker, feature-development, roadmap,
 ## Install
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin gh-project-management
+claude plugin marketplace add danmestas/agent-skills
+claude plugin install gh-project-management
 ```

--- a/plugins/project-management/README.md
+++ b/plugins/project-management/README.md
@@ -12,5 +12,6 @@ Issue tracking best practices for Linear and Jira.
 ## Install
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin project-management
+claude plugin marketplace add danmestas/agent-skills
+claude plugin install project-management
 ```

--- a/plugins/software-philosophy/README.md
+++ b/plugins/software-philosophy/README.md
@@ -16,5 +16,6 @@ Adversarial proofing for code and plans. Six complementary lenses for writing be
 ## Install
 
 ```bash
-claude plugin add danmestas/agent-skills --plugin software-philosophy
+claude plugin marketplace add danmestas/agent-skills
+claude plugin install software-philosophy
 ```


### PR DESCRIPTION
## Summary

- Renames marketplace from `agent-skills` (reserved) to `agent-toolkit` in `marketplace.json`
- Updates root README with correct two-step install (`marketplace add` then `plugin install`)
- Updates all 5 per-plugin READMEs with same fix

## Test plan

- [ ] Verify `marketplace.json` has `"name": "agent-toolkit"`
- [ ] Verify all READMEs show `claude plugin marketplace add` followed by `claude plugin install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)