### PR TITLE
Add knowledge-base skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ Skills follow the [Agent Skills format](https://github.com/anthropics/agent-skil
 | [deterministic-simulation-testing](skills/deterministic-simulation-testing) | Collapse distributed systems into single-threaded simulations with controlled non-determinism. BUGGIFY fault injection, VOPR patterns, invariant checking. |
 | [midscene-testing](skills/midscene-testing) | Screenshot-driven browser smoke testing via Midscene's headless Puppeteer mode. Ad-hoc UI validation, Datastar/HTMX/SSE testing, report consolidation. |
 
+### Web Frameworks
+
+| Skill | Description |
+|-------|-------------|
+| [datastar-tao](skills/datastar-tao) | The Tao of Datastar — philosophy for hypermedia-driven web apps. Backend owns state, SSE, HTML-over-the-wire, DOM morphing. |
+| [datastar-patterns](skills/datastar-patterns) | Datastar UI implementation patterns — search, inline editing, infinite scroll, file upload, validation, bulk operations, polling. |
+
+### Observability
+
+| Skill | Description |
+|-------|-------------|
+| [signoz-dashboard-builder](skills/signoz-dashboard-builder) | Create and update SigNoz dashboards via MCP API. Panels for metrics, logs, traces, and Claude Code telemetry. |
+
+### Knowledge Management
+
+| Skill | Description |
+|-------|-------------|
+| [knowledge-base](skills/knowledge-base) | LLM-maintained knowledge bases as Obsidian-compatible wikis. Ingest sources, query accumulated research, lint for consistency. |
+
 ### DevOps & Utilities
 
 | Skill | Description |
@@ -85,6 +104,8 @@ Audit the DX of this CLI tool                          # triggers dx-audit
 Set up a GitHub project board for this repo            # triggers gh-project-setup
 Create a Jira issue for ABC-123                        # triggers atlassian-cli-jira
 Migrate my .env files to Doppler                       # triggers doppler
+Build a Datastar search component                      # triggers datastar-patterns
+Ingest this article into my research wiki              # triggers knowledge-base
 ```
 
 ## Skill Structure

--- a/skills/datastar-patterns/SKILL.md
+++ b/skills/datastar-patterns/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: datastar-patterns
+description: Use when implementing UI patterns with Datastar — search, inline editing, infinite scroll, file upload, validation, bulk operations, polling, lazy loading, progress indicators, or keyboard shortcuts. Triggers on data-* attributes, @get/@post/@put/@patch helpers, SSE response formatting, or any "how do I do X in Datastar" implementation question.
+---
+
+# Datastar Patterns
+
+Concrete implementation patterns for Datastar. For architecture decisions, see `datastar-tao`.
+
+## Quick Reference: Attributes
+
+| Attribute | Purpose | Example |
+|-----------|---------|---------|
+| `data-on:<event>` | Event handler | `data-on:click="@get('/endpoint')"` |
+| `data-bind:<signal>` | Two-way input binding | `data-bind:search` |
+| `data-signals` | Initialize signals | `data-signals="{count: 0}"` |
+| `data-signals__ifmissing` | Initialize only if absent | `data-signals__ifmissing="{count: 0}"` |
+| `data-text` | Set element text content | `data-text="$count"` |
+| `data-attr:<attr>` | Set HTML attribute reactively | `data-attr:disabled="$_fetching"` |
+| `data-effect` | Run expression on signal change | `data-effect="$selections; $_all = $selections.every(Boolean)"` |
+| `data-indicator:<signal>` | Set signal true during requests | `data-indicator:_fetching` |
+| `data-init` | Run expression on element init | `data-init="@get('/updates')"` |
+| `data-on:intersect` | Trigger when element enters viewport | `data-on:intersect="@get('/more')"` |
+| `data-on:interval` | Trigger on a timer | `data-on-interval__duration.5s="@get('/poll')"` |
+
+## Quick Reference: Modifiers
+
+| Modifier | Effect | Example |
+|----------|--------|---------|
+| `__debounce.Nms` | Delay until input pauses | `data-on:input__debounce.200ms` |
+| `__throttle.Nms` | Rate-limit execution | `data-on:scroll__throttle.100ms` |
+| `__duration.Ns` | Set interval period | `data-on-interval__duration.5s` |
+| `__window` | Listen on window, not element | `data-on:keydown__window` |
+| `.leading` | Execute immediately on first tick | `data-on-interval__duration.5s.leading` |
+
+## Quick Reference: SSE Response Format
+
+| Event | Data Fields | Purpose |
+|-------|-------------|---------|
+| `datastar-patch-elements` | `elements`, `selector` (opt), `mode` (opt) | Update DOM fragments |
+| `datastar-patch-signals` | `signals` (JSON) | Update client signals |
+
+Merge modes: `outer` (default — replace element by ID), `append`, `prepend`, `remove`.
+
+## Patterns
+
+### Active Search
+
+Debounced input that queries the server as the user types.
+
+```html
+<input type="text" placeholder="Search..."
+       data-bind:search
+       data-on:input__debounce.200ms="@get('/search')" />
+<div id="results"><!-- server replaces this --></div>
+```
+
+```go
+func handleSearch(w http.ResponseWriter, r *http.Request) {
+    query := r.URL.Query().Get("search")
+    results := db.Search(query)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("results", results))
+}
+```
+
+### Click to Edit
+
+Inline record editing — toggle between view and edit mode.
+
+```html
+<!-- View mode -->
+<div id="contact">
+    <p>Name: John Doe</p>
+    <button data-on:click="@get('/contact/edit')"
+            data-indicator:_fetching
+            data-attr:disabled="$_fetching">Edit</button>
+</div>
+
+<!-- Edit mode (returned by server) -->
+<div id="contact">
+    <input type="text" data-bind:name />
+    <button data-on:click="@put('/contact')"
+            data-indicator:_fetching
+            data-attr:disabled="$_fetching">Save</button>
+    <button data-on:click="@get('/contact/cancel')">Cancel</button>
+</div>
+```
+
+```go
+func handleContactEdit(w http.ResponseWriter, r *http.Request) {
+    contact := db.GetContact(r)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("contact-edit", contact))
+}
+
+func handleContactSave(w http.ResponseWriter, r *http.Request) {
+    contact := datastar.ReadSignals[Contact](r)
+    db.SaveContact(contact)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("contact-view", contact))
+}
+```
+
+> Signal data automatically becomes the request body — no `<form>` element needed.
+
+### Inline Validation
+
+Server-side field validation triggered as the user types.
+
+```html
+<input type="email" required
+       aria-live="polite"
+       data-bind:email
+       data-on:keydown__debounce.500ms="@post('/validate')" />
+<p id="email-error"></p>
+```
+
+```go
+func handleValidate(w http.ResponseWriter, r *http.Request) {
+    form := datastar.ReadSignals[FormData](r)
+    errors := validate(form)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("form-errors", errors))
+}
+```
+
+> Use `aria-live="polite"` so screen readers announce validation updates.
+
+### Bulk Update
+
+Checkbox selection with array signals for batch operations.
+
+```html
+<div data-signals__ifmissing="{selections: Array(4).fill(false)}">
+    <table>
+        <thead><tr>
+            <th><input type="checkbox" data-bind:_all
+                       data-on:change="$selections = Array(4).fill($_all)"
+                       data-effect="$selections; $_all = $selections.every(Boolean)" /></th>
+            <th>Name</th><th>Status</th>
+        </tr></thead>
+        <tbody>
+            <tr><td><input type="checkbox" data-bind:selections /></td>
+                <td>Joe Smith</td><td>Active</td></tr>
+            <!-- more rows -->
+        </tbody>
+    </table>
+    <button data-on:click="@put('/activate')"
+            data-indicator:_fetching
+            data-attr:disabled="$_fetching">Activate</button>
+</div>
+```
+
+```go
+func handleActivate(w http.ResponseWriter, r *http.Request) {
+    signals := datastar.ReadSignals[BulkSignals](r)
+    db.ActivateByIndex(signals.Selections)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("table", db.GetAll()))
+}
+```
+
+> The master checkbox uses `data-effect` to stay in sync with individual row selections.
+
+### Infinite Scroll
+
+Sentinel element triggers loading when it enters the viewport.
+
+```html
+<div id="items">
+    <!-- existing items -->
+    <div id="sentinel"
+         data-on:intersect="@get('/items?page=2')">
+        Loading...
+    </div>
+</div>
+```
+
+```go
+func handleItems(w http.ResponseWriter, r *http.Request) {
+    page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+    items := db.GetPage(page)
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("items", items))
+    if db.HasMore(page) {
+        sse.PatchElements(renderTemplate("sentinel", page+1))
+    }
+}
+```
+
+> The server returns a new sentinel with the next page number. When no more pages exist, omit the sentinel to stop loading.
+
+### Load More
+
+Button-triggered append with offset tracking.
+
+```html
+<div id="list">
+    <div>Item 1</div>
+</div>
+<button id="load-more"
+        data-signals:offset="1"
+        data-on:click="@get('/more')">Load more</button>
+```
+
+```go
+func handleMore(w http.ResponseWriter, r *http.Request) {
+    offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(
+        datastar.WithSelector("#list"),
+        datastar.WithMergeMode(datastar.Append),
+        renderTemplate("item", db.GetItem(offset)),
+    )
+    if offset+1 >= maxItems {
+        sse.PatchElements(datastar.WithSelector("#load-more"), datastar.WithMergeMode(datastar.Remove))
+    } else {
+        sse.PatchSignals(fmt.Sprintf(`{"offset": %d}`, offset+1))
+    }
+}
+```
+
+> Use `mode: append` for the list container. Use `mode: remove` on the button when all items are loaded.
+
+### Lazy Tabs
+
+Tab content loads on demand when clicked.
+
+```html
+<div id="tabs">
+    <div role="tablist">
+        <button role="tab" aria-selected="true"
+                data-on:click="@get('/tabs/0')">Tab 0</button>
+        <button role="tab" aria-selected="false"
+                data-on:click="@get('/tabs/1')">Tab 1</button>
+    </div>
+    <div role="tabpanel" id="tab-content">
+        <!-- server replaces this -->
+    </div>
+</div>
+```
+
+```go
+func handleTab(w http.ResponseWriter, r *http.Request) {
+    tabIndex := chi.URLParam(r, "index")
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(renderTemplate("tab-panel", getTabData(tabIndex)))
+    sse.PatchElements(renderTemplate("tab-bar", tabIndex)) // updates aria-selected
+}
+```
+
+> The server returns both the tab panel content and the updated tab bar with correct `aria-selected` states.
+
+### File Upload
+
+File binding with automatic base64 encoding.
+
+```html
+<input type="file" data-bind:files multiple />
+<button data-on:click="$files.length && @post('/upload')"
+        data-attr:disabled="!$files.length">Upload</button>
+```
+
+```go
+func handleUpload(w http.ResponseWriter, r *http.Request) {
+    signals := datastar.ReadSignals[FileSignals](r)
+    for _, file := range signals.Files {
+        data, _ := base64.StdEncoding.DecodeString(file.Data)
+        os.WriteFile(file.Name, data, 0644)
+    }
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(`<div id="status">Upload complete</div>`)
+}
+```
+
+> Files are automatically base64-encoded by Datastar. Keep files under 1MB.
+
+### Progress Bar
+
+Long-running operation with SSE-streamed progress updates.
+
+```html
+<div id="progress"
+     data-init="@get('/progress', {openWhenHidden: true})">
+    <!-- server streams updates here -->
+</div>
+```
+
+```go
+func handleProgress(w http.ResponseWriter, r *http.Request) {
+    sse := datastar.NewSSE(w, r)
+    for pct := 0; pct <= 100; pct += 10 {
+        sse.PatchElements(fmt.Sprintf(
+            `<div id="progress" data-init="@get('/progress', {openWhenHidden: true})">%d%%</div>`,
+            pct,
+        ))
+        time.Sleep(500 * time.Millisecond)
+    }
+    sse.PatchElements(`<div id="progress">Done!</div>`)
+}
+```
+
+> Use `{openWhenHidden: true}` to keep the SSE connection alive when the tab is backgrounded.
+
+### Polling
+
+Backend-controlled polling with dynamic frequency.
+
+```html
+<div id="time"
+     data-on-interval__duration.5s="@get('/poll')">
+    <!-- server replaces with current time -->
+</div>
+```
+
+```go
+func handlePoll(w http.ResponseWriter, r *http.Request) {
+    now := time.Now()
+    duration := 5
+    if now.Second() >= 50 {
+        duration = 1 // speed up in last 10 seconds
+    }
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(fmt.Sprintf(
+        `<div id="time" data-on-interval__duration.%ds="@get('/poll')">%s</div>`,
+        duration, now.Format("15:04:05"),
+    ))
+}
+```
+
+> The backend controls polling frequency by returning a new `__duration` value in the response. Don't add `.leading` in SSE responses — it causes an immediate re-fire.
+
+### Keyboard Shortcuts
+
+Global keyboard event handling.
+
+```html
+<div data-on:keydown__window="
+    (evt.key === 'Enter' || (evt.ctrlKey && evt.key === 'l'))
+    && (evt.preventDefault(), @get('/action'))
+">
+</div>
+```
+
+> Access the event via `evt`. Use `evt.key` for key names, `evt.ctrlKey`/`evt.shiftKey`/`evt.altKey` for modifiers. Call `evt.preventDefault()` to suppress default browser behavior.
+
+### Event Bubbling (DRY)
+
+Single parent listener instead of N duplicate handlers.
+
+```html
+<div data-on:click="
+    evt.target.tagName === 'BUTTON'
+    && ($id = evt.target.dataset.id)
+    && @get('/action')
+">
+    <button data-id="1">Item 1</button>
+    <button data-id="2">Item 2</button>
+    <button data-id="3">Item 3</button>
+</div>
+```
+
+> Attach one listener to the parent. Use `evt.target.dataset.id` to identify which child was clicked. Avoids duplicating the same `data-on:click` on every button.
+
+### Backend Redirect
+
+Server-driven page navigation via SSE.
+
+```html
+<button data-on:click="@get('/redirect')">Go</button>
+<div id="indicator"></div>
+```
+
+```go
+func handleRedirect(w http.ResponseWriter, r *http.Request) {
+    sse := datastar.NewSSE(w, r)
+    sse.PatchElements(`<div id="indicator">Redirecting in 3 seconds...</div>`)
+    time.Sleep(3 * time.Second)
+    sse.Redirect("/target")
+}
+```
+
+> Wrap redirects in `setTimeout` for Firefox back-button compatibility if not using the SDK helper.
+
+## Pattern Picker
+
+| Task | Pattern |
+|------|---------|
+| User types, results update live | Active Search |
+| Show a record, edit inline | Click to Edit |
+| Validate fields as user types | Inline Validation |
+| Select multiple rows, act on them | Bulk Update |
+| Content loads as user scrolls down | Infinite Scroll |
+| "Load more" button appends items | Load More |
+| Tab content loads on demand | Lazy Tabs |
+| Upload files to the server | File Upload |
+| Long-running operation with progress | Progress Bar |
+| Periodic data refresh | Polling |
+| Global keyboard shortcuts | Keyboard Shortcuts |
+| Many buttons with the same action | Event Bubbling (DRY) |
+| Navigate user from the backend | Backend Redirect |

--- a/skills/datastar-tao/SKILL.md
+++ b/skills/datastar-tao/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: datastar-tao
+description: Use when building hypermedia-driven web applications, server-rendered UIs, or any frontend where the backend should own state. Use when choosing between SPA and server-driven architecture. Use when reviewing frontend code for unnecessary client-side state, optimistic updates, or client-side routing. Triggers on requests involving SSE, HTML-over-the-wire, DOM morphing, HTMX, Datastar, signals, or backend-first frontend design.
+---
+
+# The Tao of Datastar
+
+Principles from the [Datastar](https://data-star.dev/) project's philosophy for building maintainable, high-performance web applications. The central thesis: **"The backend is the source of truth. The frontend is a projection of it."**
+
+Every architecture decision must be judged by whether it keeps state on the server, leverages the platform, and avoids reinventing what the browser already does well.
+
+## Core Principles
+
+### 1. Backend Owns State
+
+Most state belongs on the server. The frontend is exposed to the user — it can be tampered with, fall out of sync, or lose context on refresh. The backend is the single source of truth for application state.
+
+**Client-heavy (bad):**
+
+```typescript
+// Frontend manages its own "truth" — duplicates backend logic,
+// drifts on stale data, breaks on refresh
+const [users, setUsers] = useState<User[]>([]);
+const [filters, setFilters] = useState({ role: "admin", active: true });
+const [sortBy, setSortBy] = useState("name");
+const [page, setPage] = useState(1);
+
+// Now you need: sync logic, cache invalidation, optimistic rollback,
+// conflict resolution, offline handling...
+const filteredUsers = useMemo(() =>
+  users
+    .filter(u => u.role === filters.role && u.active === filters.active)
+    .sort((a, b) => a[sortBy].localeCompare(b[sortBy]))
+    .slice((page - 1) * 20, page * 20),
+  [users, filters, sortBy, page]
+);
+```
+
+**Server-owned (good):**
+
+```go
+// Backend computes the view, sends the result as HTML
+func handleUsers(w http.ResponseWriter, r *http.Request) {
+    role := r.URL.Query().Get("role")
+    users := db.GetUsers(role, "active", "name", 1)
+    // Template renders the final HTML — one source of truth
+    tmpl.Execute(w, users)
+}
+```
+
+```html
+<!-- Frontend sends intent, receives rendered result -->
+<div data-on-change="$$get('/users?role=admin')">
+  <!-- Server returns the filtered, sorted, paginated HTML -->
+</div>
+```
+
+### 2. Start with the Defaults
+
+The default configuration exists because it covers the majority of use cases. Before changing a default, ask: "Am I solving a real problem, or am I guessing about a future one?" Most custom configurations are premature optimization or cargo-culting from SPA patterns that don't apply.
+
+### 3. Patch, Don't Replace
+
+Since the backend owns truth, it drives the frontend by patching — adding, updating, and removing HTML elements and signals. Send the minimal change, not the entire page. The server knows what changed; let it tell the client exactly what to update.
+
+**Full replacement (bad):**
+
+```typescript
+// Replaces entire container — destroys scroll position, focus,
+// animations, and any transient UI state
+container.innerHTML = await fetch("/users").then(r => r.text());
+```
+
+**Targeted patch (good):**
+
+```html
+<!-- Server sends only the changed fragment -->
+<div id="user-42" data-merge-fragments>
+  <span class="status">Active</span>
+</div>
+<!-- Morphing updates just this element, preserving everything else -->
+```
+
+### 4. Use Signals Sparingly
+
+Signals (reactive client-side state) are the escape hatch, not the default. Overusing signals means you're rebuilding a state manager on the frontend — the exact problem backend-first architecture avoids.
+
+**Good uses of signals:**
+- Toggling element visibility (accordion, dropdown)
+- Binding form inputs before submission
+- Transient UI state that has no business meaning (hover, focus)
+
+**Bad uses of signals:**
+- Filtering, sorting, or paginating data client-side
+- Caching server responses
+- Duplicating business logic that belongs on the server
+
+**Rule of thumb:** If the signal's value would matter after a page refresh, it belongs on the backend.
+
+### 5. In Morph We Trust
+
+DOM morphing (updating only the parts of the DOM that actually changed) is the key enabler. It lets you send large HTML fragments — even the entire page — without losing scroll position, focus state, CSS transitions, or form input. This is what makes "just send HTML" viable at scale.
+
+Morphing means you don't need:
+- Virtual DOM diffing
+- Component-level re-rendering
+- Key-based reconciliation
+- Manual DOM manipulation
+
+Send the HTML. The morpher handles the rest.
+
+### 6. SSE for Reads, HTTP for Writes (CQRS)
+
+Separate read and write channels. Use Server-Sent Events (SSE) as a single long-lived connection for receiving updates from the backend. Use standard HTTP requests for writes.
+
+```
+┌─────────┐         SSE (reads)          ┌─────────┐
+│         │ ◄──────────────────────────── │         │
+│ Browser │                               │ Server  │
+│         │ ──── POST/PUT/DELETE ────────► │         │
+└─────────┘      (writes)                 └─────────┘
+```
+
+**Why this works:**
+- One persistent connection for all real-time updates
+- Zero to N events per SSE response — patch elements, patch signals, execute scripts
+- Writes are standard HTTP — simple, cacheable, debuggable
+- No WebSocket complexity, no bidirectional protocol to manage
+
+### 7. Compression is Your Superpower
+
+HTML + SSE + Brotli compression achieves ratios of 200:1 or higher. Repetitive HTML structures (tables, lists, repeated components) compress spectacularly. This means "send more HTML" is often cheaper on the wire than "send JSON and reconstruct on the client."
+
+Don't optimize by sending less HTML. Optimize by enabling compression and sending the right HTML.
+
+### 8. Use Your Templating Language
+
+Your backend language already has a templating system. Use it. Keep your rendering DRY with partials, layouts, and components on the server side. Don't build a second component system on the frontend.
+
+**Two component systems (bad):**
+
+```typescript
+// Server renders a shell, client renders components
+// Now you maintain two template systems, two data flows
+const UserCard = ({ user }) => (
+  <div className="card">
+    <h3>{user.name}</h3>
+    <p>{user.role}</p>
+  </div>
+);
+```
+
+**One component system (good):**
+
+```go
+// Server renders everything — one system, one source of truth
+{{ define "user-card" }}
+<div class="card" id="user-{{ .ID }}">
+  <h3>{{ .Name }}</h3>
+  <p>{{ .Role }}</p>
+</div>
+{{ end }}
+```
+
+### 9. Don't Reinvent the Browser
+
+**Page navigation:** Use `<a>` tags. The browser has handled navigation for 30 years. Client-side routing is a complexity tax you pay to solve problems the browser already solved.
+
+**Browser history:** The browser tracks history automatically. The moment you manage history yourself (pushState, replaceState, custom back-button handling), you're adding complexity that fights the platform.
+
+**Forms:** Use `<form>` elements. They handle validation, submission, accessibility, and keyboard interaction out of the box.
+
+**Scroll, focus, viewport:** These are browser-managed state. Don't track them in your application state.
+
+### 10. Honest UIs Over Optimistic Updates
+
+Optimistic updates show the user a lie — "this succeeded" before it actually has. When the backend disagrees, you need rollback logic, conflict resolution, and error recovery that's harder to build correctly than the optimistic update itself.
+
+**Dishonest (bad):**
+
+```typescript
+// Show success immediately, pray the server agrees
+const handleLike = () => {
+  setLiked(true);           // Lie to user
+  setCount(count + 1);      // Lie harder
+  api.like(postId).catch(() => {
+    setLiked(false);        // Awkward rollback
+    setCount(count);        // Hope state is consistent
+    toast.error("Failed");  // User already scrolled away
+  });
+};
+```
+
+**Honest (good):**
+
+```html
+<!-- Show a loading indicator, confirm from server -->
+<button data-on-click="$$post('/posts/42/like')"
+        data-indicator="#like-spinner">
+  Like
+  <span id="like-spinner" class="spinner" hidden></span>
+</button>
+<!-- Server confirms with updated HTML — truth, not hope -->
+```
+
+Use loading indicators to show the user that an action is in progress. Confirm success only when the backend confirms it.
+
+### 11. Accessibility is Non-Negotiable
+
+The web should be accessible to everyone. A backend-first architecture has a natural advantage: server-rendered HTML is inherently more accessible than client-rendered JavaScript. But you still need to:
+
+- Use semantic HTML (`<nav>`, `<main>`, `<article>`, `<button>`)
+- Apply ARIA attributes where semantic HTML isn't sufficient
+- Ensure keyboard navigation works
+- Test with screen readers
+- Maintain focus management when the DOM morphs
+
+## Red Flags
+
+| Red Flag | What It Means |
+|----------|---------------|
+| `useState` for server-owned data | State belongs on the backend — you're duplicating truth |
+| Client-side filtering/sorting | The server should compute and send the result |
+| Client-side routing library | You're reinventing the browser's navigation |
+| `pushState` / history management | Let the browser handle history — you're fighting the platform |
+| Optimistic updates with rollback | Honest loading indicators are simpler and more correct |
+| JSON API consumed by frontend templates | Send HTML, not data — eliminate the client-side render step |
+| Multiple state management libraries | Signals are the escape hatch, not the architecture |
+| WebSocket for simple request/response | SSE for reads + HTTP for writes covers most cases |
+| Frontend form validation duplicating backend | Validate on the server, render errors in the response |
+| Custom component framework on the client | Use your backend templating — one component system |
+
+## Reasoning Flow
+
+When this skill is active, follow these steps:
+
+1. **Identify the state** — Where does each piece of state live? Classify as server-owned (business data, user records, permissions) or client-transient (UI toggles, focus, animation).
+2. **Move state to the server** — Any state classified as server-owned must be managed on the backend. The frontend receives it as rendered HTML.
+3. **Spot platform reinvention** — Are you rebuilding navigation, history, forms, or scroll management? Use the browser's built-in capabilities.
+4. **Choose the right channel** — Reads via SSE (real-time, server-pushed). Writes via standard HTTP (POST/PUT/DELETE).
+5. **Patch, don't replace** — Send minimal HTML fragments. Let morphing handle the DOM update.
+6. **Be honest** — Use loading indicators instead of optimistic updates. Confirm success from the server.
+7. **Check accessibility** — Semantic HTML, ARIA, keyboard nav, screen reader compatibility.
+
+## Common Mistakes
+
+| Mistake | Tao Fix |
+|---------|---------|
+| "We need React for this" | Do you? Server-rendered HTML + morphing handles most UIs without a framework. |
+| "Let's cache this on the client" | The server is the cache. Fetch current state when you need it. |
+| "We need client-side routing for SPA feel" | Morphing + SSE gives you SPA-like updates without client-side routing. |
+| "Let's add optimistic updates for responsiveness" | Loading indicators are honest and simpler. The server confirms truth. |
+| "We need WebSockets for real-time" | SSE handles server-to-client updates. HTTP handles client-to-server. Simpler. |
+| "Let's add a state management library" | If you need one, you've put too much state on the client. Move it back. |
+| "We need to manage browser history" | Let the browser do it. Use `<a>` tags and server redirects. |
+| "JSON APIs are more flexible" | Flexible for whom? HTML responses eliminate an entire rendering layer. |
+| "Send less data to optimize performance" | Enable Brotli compression. HTML compresses at 200:1. Send the right HTML. |

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: knowledge-base
+description: Use when building, maintaining, ingesting into, querying, or health-checking a markdown knowledge base or wiki. Use when the user wants to compile sources into structured knowledge, maintain an Obsidian wiki, ingest documents, ask questions against accumulated research, or run health checks on interlinked markdown pages. Triggers on requests involving knowledge bases, wiki maintenance, source ingestion, research compilation, Obsidian wiki workflows, or LLM-maintained documentation.
+---
+
+# Knowledge Base
+
+Build and maintain personal knowledge bases as Obsidian-compatible markdown wikis. The LLM writes and maintains all wiki content. The human curates sources, asks questions, and directs exploration.
+
+## Philosophy
+
+**The LLM writes the wiki.** You summarize, cross-reference, file, and maintain. The human reads, curates sources, asks questions, and thinks about what it means.
+
+**Knowledge compounds.** Every ingest updates existing pages, creates new ones, and strengthens cross-references. Query outputs get filed back into the wiki. The wiki gets richer with every interaction — nothing is re-derived from scratch.
+
+**Structure emerges.** No prescribed schema. Self-organize as content comes in. Create index pages, categories, and groupings as they become useful. Maintain your own conventions and evolve them.
+
+**Vault-agnostic.** Operate on any directory of markdown files. Don't assume a specific layout, naming convention, or pre-existing files. Read what's there and adapt.
+
+## Required Context
+
+You need two things:
+1. **Wiki root** — the directory where wiki markdown lives
+2. **Sources path** — where raw source documents live (if applicable)
+
+These are passed as arguments or exist in conversation context.
+
+## Routing
+
+Determine which operation to run from context:
+
+| Context | Action |
+|---|---|
+| Source file provided or file watcher event | Read `references/ingest.md`, then `references/conventions.md` |
+| User asks a question or requests analysis | Read `references/query.md`, then `references/conventions.md` |
+| Cron trigger or health check request | Read `references/lint.md`, then `references/conventions.md` |
+| New or empty wiki | Bootstrap: survey what exists, create initial MOC, then proceed with the triggered operation |
+
+Always read `references/conventions.md` for Obsidian-native patterns to follow.
+
+## Tools
+
+This skill works with whatever tools are available. It does not require any specific MCP server or plugin, but benefits from:
+
+- **Obsidian skills plugin** — for Obsidian-specific markdown, canvas, and bases support
+- **Excalidraw MCP** — for creating architecture diagrams, relationship maps, and concept visualizations
+- **File system access** — for reading sources and writing wiki pages (Read, Write, Edit tools)
+- **Web search** — for filling gaps identified during lint or query
+- **Search tools** — CLI search over wiki pages at larger scale (e.g., qmd, ripgrep)
+
+Use what's available. The core workflow (read sources, write wiki pages, maintain links) works with just basic file tools.
+
+## Scale
+
+Index-based navigation (MOC + wikilink traversal) works well at moderate scale (~100s of sources, ~100s of pages, ~400K+ words). No RAG infrastructure needed. If the wiki outgrows index navigation, consider adding a search tool the LLM can shell out to.

--- a/skills/knowledge-base/references/conventions.md
+++ b/skills/knowledge-base/references/conventions.md
@@ -1,0 +1,64 @@
+# Obsidian-Native Conventions
+
+Patterns to follow when creating and maintaining wiki pages. These are defaults — adapt to whatever conventions already exist in a vault rather than overwriting established patterns.
+
+## Linking
+
+- Use `[[wikilinks]]` for all internal links, never standard markdown links
+- Use `[[page name|display text]]` when the link text should differ from the page name
+- Use `![[embed]]` to embed content from other pages or images
+- Every page should have at least one inbound link — no orphans
+
+## Frontmatter
+
+YAML frontmatter on every wiki page. Common fields include `tags`, `sources`, `created`, `updated` — but the LLM decides what's useful for the domain and evolves the schema as the wiki grows.
+
+```yaml
+---
+tags:
+  - concept
+sources:
+  - "[[source page]]"
+created: 2026-04-12
+updated: 2026-04-12
+---
+```
+
+## Tags
+
+- Use for categorization: `#concept`, `#entity`, `#source`, `#analysis`, etc.
+- Let tag taxonomy emerge from content — don't pre-define a rigid hierarchy
+- Tags in frontmatter (`tags: [concept]`) are preferred over inline `#tags` for queryability
+
+## Images and Diagrams
+
+- Store images in a consistent location (e.g., `assets/` or alongside pages)
+- Reference with Obsidian embed syntax: `![[image.png]]`
+- Use Excalidraw for architecture diagrams, relationship maps, concept visualizations when the tools are available
+- When ingesting sources with images: read text first, then view referenced images separately for additional context
+
+## Index / Map of Content
+
+- Maintain at least one MOC (Map of Content) page as the wiki entry point
+- Create sub-MOCs as the wiki grows and natural categories emerge
+- MOC pages list wiki pages with `[[wikilinks]]` and one-line summaries
+- The LLM reads the MOC first when navigating the wiki
+
+## Log
+
+- Append-only chronological record of wiki operations
+- Parseable entry format: `## [YYYY-MM-DD] operation | Description`
+- Operations: `ingest`, `query`, `lint`, `reorganize`
+- Useful for understanding wiki evolution and what's been done recently
+
+## Page Naming
+
+- Descriptive, title-case: `Machine Learning`, `Project Architecture`
+- No date prefixes unless the page is inherently temporal (meeting notes, journal entries)
+- Prefer specific names over generic: `Transformer Architecture` over `Architecture`
+
+## Structure
+
+- Let structure emerge — create directories and groupings as they become useful
+- No prescribed hierarchy — the LLM organizes based on content
+- Move pages and restructure as the wiki grows; update all wikilinks when doing so

--- a/skills/knowledge-base/references/ingest.md
+++ b/skills/knowledge-base/references/ingest.md
@@ -1,0 +1,87 @@
+# Ingest Workflow
+
+Process a new source document into the wiki. This workflow runs when a source is provided, a file watcher fires, or the user asks to ingest something.
+
+## Inputs
+
+- **Source:** path to the document to ingest (article, paper, notes, data, image)
+- **Wiki root:** path to the wiki directory
+
+## Workflow
+
+### 1. Read the source
+
+Read the full source document. If it references images, note them for separate viewing.
+
+For different source types:
+- **Markdown/text:** read directly
+- **PDF:** read with PDF support, note page numbers for citations
+- **Images:** view and describe; these may be the primary content (diagrams, charts, screenshots)
+- **Code/repos:** focus on README, architecture docs, key interfaces
+
+### 2. Survey the wiki
+
+Read the MOC/index if one exists. Scan page titles and frontmatter to understand:
+- What topics are already covered
+- What entities and concepts have pages
+- What structure and conventions are in use
+- What tags are in use
+
+If the wiki is empty or new, note this — you'll bootstrap structure as you ingest.
+
+### 3. Extract and identify
+
+From the source, identify:
+- **Entities:** people, projects, organizations, tools, specific things with names
+- **Concepts:** ideas, patterns, principles, techniques, theories
+- **Claims:** specific assertions, data points, findings, conclusions
+- **Relationships:** how entities and concepts connect to each other and to existing wiki content
+
+### 4. Update the wiki
+
+For each extracted item:
+
+**If a wiki page already exists:**
+- Update it with new information from this source
+- Add the source to the page's `sources` frontmatter
+- Flag any contradictions: "Source A claims X, but Source B claims Y"
+- Add new cross-references to related pages
+
+**If no wiki page exists:**
+- Create a new page with frontmatter, content, and `[[wikilinks]]` to related existing pages
+- Use the conventions in `references/conventions.md`
+
+A single source typically touches 10-15+ wiki pages. This is expected.
+
+### 5. Update the MOC
+
+Add new pages to the MOC with one-line summaries. Create the MOC if this is the first ingest. Reorganize MOC sections if the new content shifts the wiki's structure.
+
+### 6. Update the log
+
+Append an entry:
+```
+## [YYYY-MM-DD] ingest | Source Title
+- Created: [[Page A]], [[Page B]], [[Page C]]
+- Updated: [[Page D]], [[Page E]]
+- Contradictions found: [brief description, if any]
+- Source location: path/to/source
+```
+
+Create the log if this is the first ingest.
+
+### 7. Report
+
+Summarize what happened:
+- Pages created (with links)
+- Pages updated (with what changed)
+- Contradictions found
+- Suggestions for follow-up (related sources to look for, questions raised)
+
+## Headless operation
+
+When triggered by a file watcher with no human in the loop:
+- Follow the full workflow above
+- Make conservative choices (don't reorganize large sections of the wiki)
+- Log everything — the human reviews the log later
+- If a source is ambiguous or contradicts existing content significantly, note it in the log rather than making a judgment call

--- a/skills/knowledge-base/references/lint.md
+++ b/skills/knowledge-base/references/lint.md
@@ -1,0 +1,76 @@
+# Lint Workflow
+
+Health-check the wiki for consistency, completeness, and quality. This workflow runs on a cron schedule or when the user requests a review.
+
+## Inputs
+
+- **Wiki root:** path to the wiki directory
+
+## Workflow
+
+### 1. Scan the wiki
+
+Read all wiki pages. Build a mental model of:
+- All pages and their wikilinks (inbound and outbound)
+- Frontmatter fields and tags in use
+- The MOC structure
+- The log (recent activity)
+
+### 2. Check for issues
+
+**Structural:**
+- Orphan pages: pages with no inbound `[[wikilinks]]` (nothing links to them)
+- Broken wikilinks: `[[links]]` whose target page doesn't exist
+- Missing MOC entries: pages that exist but aren't listed in any MOC
+- Dead-end pages: pages with no outbound links to other wiki pages
+
+**Content:**
+- Contradictions: pages that make conflicting claims about the same thing
+- Stale content: claims that newer sources have superseded (check source dates)
+- Thin pages: pages with minimal content that could be expanded or merged
+- Duplicate coverage: multiple pages covering the same topic that should be consolidated
+
+**Completeness:**
+- Mentioned but missing: concepts, entities, or topics referenced in text but lacking their own page
+- Missing cross-references: pages that discuss related topics but don't link to each other
+- Source gaps: areas where the wiki's coverage is thin and new sources would help
+
+**Consistency:**
+- Frontmatter inconsistencies: pages using different field names or formats for the same metadata
+- Tag inconsistencies: similar tags that should be unified (e.g., `#ml` vs `#machine-learning`)
+- Naming inconsistencies: similar pages with inconsistent naming patterns
+
+### 3. Auto-fix safe issues
+
+Fix automatically without human input:
+- Add missing cross-references where the connection is clear
+- Fix broken wikilinks where the intended target is obvious (e.g., typo, renamed page)
+- Standardize frontmatter format across pages
+- Add orphan pages to the appropriate MOC
+
+### 4. Report issues needing judgment
+
+Create a lint report (can be a wiki page itself):
+- Contradictions with context from both sides
+- Suggested page merges or splits
+- Data gaps with suggested sources to look for
+- New questions the wiki raises but doesn't answer
+- Candidate topics for new pages
+
+### 5. Update the log
+
+```
+## [YYYY-MM-DD] lint | Health check
+- Pages scanned: N
+- Auto-fixed: [list of fixes]
+- Issues found: [summary]
+- Suggestions: [key recommendations]
+```
+
+## Cron operation
+
+When triggered by a cron job with no human in the loop:
+- Run the full scan and auto-fix safe issues
+- Write the lint report to the wiki as a page (e.g., `Lint Report YYYY-MM-DD`)
+- Log everything
+- Don't make structural changes (reorganizing, merging, splitting) — flag them for human review

--- a/skills/knowledge-base/references/query.md
+++ b/skills/knowledge-base/references/query.md
@@ -1,0 +1,55 @@
+# Query Workflow
+
+Answer questions, generate analysis, and produce outputs from the wiki. This workflow runs when the user asks a question or requests analysis against the knowledge base.
+
+## Inputs
+
+- **Question or request:** what the user wants to know or produce
+- **Wiki root:** path to the wiki directory
+
+## Workflow
+
+### 1. Navigate the wiki
+
+Read the MOC/index to find relevant pages. Follow `[[wikilinks]]` from those pages to gather related context. Go as deep as needed — follow chains of links until you have enough context to answer well.
+
+If the wiki has a search tool available (CLI or MCP), use it. Otherwise, the MOC + wikilink traversal is sufficient at moderate scale.
+
+### 2. Synthesize
+
+Build the answer from wiki content. Cite wiki pages using `[[wikilinks]]` so the user can trace your reasoning. If the answer requires information not in the wiki, say so — suggest sources that could fill the gap.
+
+### 3. Choose output format
+
+Match the format to the question:
+
+| Question type | Format |
+|---|---|
+| Factual question | Direct answer with `[[citations]]` |
+| Comparison | Markdown table |
+| Overview/summary | Markdown page |
+| Architecture/relationships | Excalidraw diagram (if available) |
+| Presentation | Marp slide deck |
+| Data/trends | Chart image (matplotlib or similar) |
+| Timeline | Chronological markdown or diagram |
+
+Default to markdown. Use richer formats when they genuinely serve the question better.
+
+### 4. File valuable outputs
+
+If the output is worth keeping — a substantive analysis, a useful comparison, a connection discovered, a synthesis that took real work — offer to file it as a new wiki page.
+
+This is how explorations compound in the knowledge base. A question you asked last month becomes a page that informs answers to future questions.
+
+When filing:
+- Add appropriate frontmatter and tags
+- Cross-link to the pages that informed the analysis
+- Update the MOC
+- Append to the log: `## [YYYY-MM-DD] query | Question summary → filed as [[Page Name]]`
+
+### 5. Suggest follow-ups
+
+Based on what you found (and didn't find), suggest:
+- Related questions worth exploring
+- Gaps in the wiki that new sources could fill
+- Connections between pages that aren't currently linked


### PR DESCRIPTION
## Summary
- New `knowledge-base` skill for building LLM-maintained Obsidian-compatible wikis
- Three operations: ingest (process sources into wiki pages), query (Q&A with filed outputs), lint (health check)
- Progressive disclosure: core SKILL.md routes to detailed reference workflows
- Designed for automation — works headlessly via file watchers and cron
- README updated with knowledge-base, datastar, and signoz skills

## Test plan
- [ ] Install skill and verify it triggers on knowledge base requests
- [ ] Test ingest workflow against a sample source document
- [ ] Test query workflow against a populated wiki
- [ ] Test lint workflow against a wiki with known issues
- [ ] Verify routing table references match actual filenames