### PR TITLE
Add cloudflare-email skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Skills follow the [Agent Skills format](https://github.com/anthropics/agent-skil
 |-------|-------------|
 | [doppler](skills/doppler) | Migrate `.env` files to Doppler secrets management. Detect secrets, create projects, push to Doppler, and set up multi-environment configs. |
 | [apple-contacts](skills/apple-contacts) | Manage Apple Contacts from the terminal via `contactbook` CLI. Full CRUD, group management, search by name/phone/email/org. macOS only. |
+| [cloudflare-email](skills/cloudflare-email) | Send outbound email from a Cloudflare-hosted domain via REST API or Workers binding. No SMTP — complements Email Routing for full send/receive without a mailbox provider. |
 
 ## Installation
 

--- a/skills/cloudflare-email/SKILL.md
+++ b/skills/cloudflare-email/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: cloudflare-email
+description: Use when sending outbound transactional or one-off emails from a Cloudflare-managed domain without running a mail server or paying for a mailbox provider. Triggers on needs to send email programmatically from a custom domain, send-from-my-domain requests, or replacing SMTP relays. Cloudflare Email Service is REST API + Workers only — no SMTP, so it is NOT compatible with Gmail "Send mail as", Outlook, or any SMTP client.
+---
+
+# Cloudflare Email Service (Sending)
+
+Send outbound email from a Cloudflare-hosted domain via REST API or Workers binding. Complements Cloudflare Email Routing (inbound-only) to give a domain full send/receive with no mailbox provider.
+
+## When to Use vs Not Use
+
+Use when:
+- Sending programmatically (alerts, transactional mail, one-off scripts)
+- Domain is already on Cloudflare DNS
+- You don't need a human-facing inbox / "Sent" folder
+
+Do NOT use when:
+- User wants to send from Gmail, Apple Mail, Thunderbird, or any SMTP client (Cloudflare exposes no SMTP endpoint — use Zoho/Workspace/Fastmail instead)
+- User needs IMAP, a Sent folder, or threaded reply UI
+- Sending from a domain not on Cloudflare DNS
+
+## Prerequisites
+
+1. **Domain on Cloudflare DNS** — zone active, nameservers delegated.
+2. **Email Service enabled** — Dashboard → your domain → **Email** → **Email Service** → enable. This auto-adds MX/SPF/DKIM/DMARC records on a `cf-bounce.<yourdomain>` subdomain for bounce handling and authentication. Do not delete those records.
+3. **Account ID** — dashboard sidebar, or `wrangler whoami`.
+4. **API Token** — https://dash.cloudflare.com/profile/api-tokens → Create Token → custom token with **Email Sending: Edit** permission scoped to your account. Save as `CF_API_TOKEN`.
+5. **Verified sender** — the `from` address must be on a domain where Email Service is enabled. Cloudflare rejects sends from unverified domains.
+
+```bash
+export CF_ACCOUNT_ID="your-account-id"
+export CF_API_TOKEN="your-api-token"
+```
+
+## Send via REST API
+
+```bash
+curl -sS "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/email/sending/send" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from":    "you@yourdomain.com",
+    "to":      "recipient@example.com",
+    "subject": "Subject line",
+    "text":    "Plain text body.",
+    "html":    "<p>HTML body.</p>"
+  }'
+```
+
+A `200` with `"success": true` means queued for delivery. A `400` usually means the sender domain isn't verified or Email Service isn't enabled on it.
+
+## Payload Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `from` | yes | Must be on a domain with Email Service enabled |
+| `to` | yes | Single recipient or array |
+| `subject` | yes | |
+| `text` | one of text/html required | Plain-text body |
+| `html` | one of text/html required | HTML body |
+| `cc`, `bcc` | no | Arrays of addresses |
+| `reply_to` | no | Where replies go if different from `from` |
+
+## Send from a Markdown File
+
+Common one-off: turn a hand-written markdown draft into a sent email. See `scripts/send-email.sh` in this skill for a working helper. Usage:
+
+```bash
+./send-email.sh \
+  --from you@yourdomain.com \
+  --to   recipient@example.com \
+  --subject "Subject line" \
+  --body draft.md
+```
+
+It strips markdown for the `text` field, renders minimal HTML for the `html` field, and POSTs to the API.
+
+## Send via Workers Binding
+
+When sending from a Worker, use the binding instead of the REST API — lower latency, no token management:
+
+```toml
+# wrangler.toml
+send_email = [
+  { name = "SEND_EMAIL" }
+]
+```
+
+```js
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage } from "mimetext";
+
+export default {
+  async fetch(req, env) {
+    const msg = createMimeMessage();
+    msg.setSender({ name: "App", addr: "you@yourdomain.com" });
+    msg.setRecipient("recipient@example.com");
+    msg.setSubject("Hello");
+    msg.addMessage({ contentType: "text/plain", data: "Body" });
+
+    await env.SEND_EMAIL.send(new EmailMessage(
+      "you@yourdomain.com",
+      "recipient@example.com",
+      msg.asRaw()
+    ));
+    return new Response("sent");
+  }
+}
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Sender domain not verified` | Email Service not enabled on `from` domain | Dashboard → Email → enable Email Service |
+| `Authentication error` | Token missing `Email Sending: Edit` | Recreate token with correct permission |
+| `Invalid recipient` | Typo or unroutable domain | Verify the `to` address |
+| `Missing required parameter` | No `text` and no `html` | Include at least one body field |
+| DNS records missing in dashboard | Records manually deleted | Re-enable Email Service to restore |
+
+## Receiving Replies
+
+Cloudflare Email Service handles outbound only. To receive replies:
+- Enable **Email Routing** on the same domain (separate product, same dashboard)
+- Add a routing rule: `you@yourdomain.com` → forward to a real inbox (Gmail, iCloud, etc.)
+- Replies then land in that inbox; you reply from that inbox's UI (which may itself need a Send-as alias to preserve the custom-domain `from`)
+
+## Limitations
+
+- **No SMTP.** This is the single biggest footgun — users frequently ask to point Gmail Send-as at Cloudflare. It does not work and cannot work. Redirect them to a real mailbox provider if they need SMTP.
+- **No native "Sent" folder.** Sent messages are not stored; log them yourself if audit trail matters.
+- **Per-account rate limits apply.** Check current limits in Cloudflare docs — exceed them and sends queue or reject.
+- **Bounces go to `cf-bounce.<domain>`.** Don't delete those DNS records.
+
+## References
+
+- Cloudflare docs: https://developers.cloudflare.com/email-service/
+- Get started: https://developers.cloudflare.com/email-service/get-started/send-emails/
+- Email Routing (for inbound): https://developers.cloudflare.com/email-routing/

--- a/skills/cloudflare-email/scripts/send-email.sh
+++ b/skills/cloudflare-email/scripts/send-email.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Send an email via Cloudflare Email Service REST API.
+# Requires: CF_ACCOUNT_ID and CF_API_TOKEN environment variables.
+#
+# Usage:
+#   ./send-email.sh --from you@domain.com --to dest@example.com \
+#                   --subject "Hi" --body draft.md
+#
+# The --body file is treated as plain text for the "text" field and wrapped in
+# minimal <pre> for the "html" field. For richer HTML, pass --html-body instead.
+
+set -euo pipefail
+
+FROM=""
+TO=""
+CC=""
+BCC=""
+REPLY_TO=""
+SUBJECT=""
+BODY_FILE=""
+HTML_BODY_FILE=""
+
+usage() {
+  sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)       FROM="$2"; shift 2 ;;
+    --to)         TO="$2"; shift 2 ;;
+    --cc)         CC="$2"; shift 2 ;;
+    --bcc)        BCC="$2"; shift 2 ;;
+    --reply-to)   REPLY_TO="$2"; shift 2 ;;
+    --subject)    SUBJECT="$2"; shift 2 ;;
+    --body)       BODY_FILE="$2"; shift 2 ;;
+    --html-body)  HTML_BODY_FILE="$2"; shift 2 ;;
+    -h|--help)    usage ;;
+    *) echo "Unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+: "${CF_ACCOUNT_ID:?Set CF_ACCOUNT_ID}"
+: "${CF_API_TOKEN:?Set CF_API_TOKEN}"
+[[ -n "$FROM"    ]] || { echo "--from required" >&2; exit 1; }
+[[ -n "$TO"      ]] || { echo "--to required" >&2; exit 1; }
+[[ -n "$SUBJECT" ]] || { echo "--subject required" >&2; exit 1; }
+[[ -n "$BODY_FILE" || -n "$HTML_BODY_FILE" ]] || { echo "--body or --html-body required" >&2; exit 1; }
+
+TEXT_BODY=""
+HTML_BODY=""
+if [[ -n "$BODY_FILE" ]]; then
+  TEXT_BODY="$(cat "$BODY_FILE")"
+  if [[ -z "$HTML_BODY_FILE" ]]; then
+    HTML_BODY="<pre style=\"font-family:inherit;white-space:pre-wrap\">$(python3 -c 'import html,sys; print(html.escape(sys.stdin.read()))' < "$BODY_FILE")</pre>"
+  fi
+fi
+if [[ -n "$HTML_BODY_FILE" ]]; then
+  HTML_BODY="$(cat "$HTML_BODY_FILE")"
+fi
+
+PAYLOAD="$(python3 - <<PY
+import json, os
+payload = {
+    "from": os.environ["FROM"],
+    "to":   os.environ["TO"],
+    "subject": os.environ["SUBJECT"],
+}
+if os.environ.get("TEXT_BODY"): payload["text"] = os.environ["TEXT_BODY"]
+if os.environ.get("HTML_BODY"): payload["html"] = os.environ["HTML_BODY"]
+if os.environ.get("CC"):        payload["cc"]   = [s.strip() for s in os.environ["CC"].split(",")]
+if os.environ.get("BCC"):       payload["bcc"]  = [s.strip() for s in os.environ["BCC"].split(",")]
+if os.environ.get("REPLY_TO"):  payload["reply_to"] = os.environ["REPLY_TO"]
+print(json.dumps(payload))
+PY
+)"
+
+export FROM TO SUBJECT TEXT_BODY HTML_BODY CC BCC REPLY_TO
+
+curl -sS -w "\nHTTP %{http_code}\n" \
+  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/email/sending/send" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- Adds `skills/cloudflare-email/` covering the Cloudflare Email Service REST API and Workers binding for sending outbound mail from a Cloudflare-hosted domain.
- Includes `scripts/send-email.sh` — a bash helper that takes a markdown file and posts it to the Cloudflare sending endpoint (plain text + minimal HTML).
- Explicitly calls out the biggest footgun: **Cloudflare exposes no SMTP**, so Gmail "Send mail as" / IMAP clients cannot use this service. The skill redirects those users to real mailbox providers (Zoho, Workspace, Fastmail).
- Adds the skill to the DevOps & Utilities section of the README.

## Test plan
- [ ] Review SKILL.md for accuracy against current Cloudflare docs
- [ ] Dry-run `scripts/send-email.sh --help` to confirm usage output
- [ ] Send a real test email with valid `CF_ACCOUNT_ID` / `CF_API_TOKEN` against a domain with Email Service enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)