### PR TITLE
feat: gemini adapter

### DIFF
--- a/apm-builder/adapters/claude-code.ts
+++ b/apm-builder/adapters/claude-code.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import YAML from 'yaml';
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
+import { selectRules, composeRulesBody, isOwnerOfRulesFile } from '../lib/rules.ts';
 
 function yamlValue(v: string): string {
   // Use yaml.stringify to safely encode a single scalar (with quoting if needed).
@@ -68,16 +69,10 @@ function emitAgent(component: ComponentSource): EmittedFile[] {
 }
 
 function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  if (!isOwnerOfRulesFile(component, ctx.allComponents, 'claude-code')) return [];
   const scope = component.manifest.scope ?? 'project';
-  const allRules = ctx.allComponents
-    .filter((c) => c.manifest.type === 'rules' && c.manifest.targets.includes('claude-code'))
-    .filter((c) => (c.manifest.scope ?? 'project') === scope);
-  if (allRules.length === 0) return []; // defensive: should be unreachable since the calling component is itself in allRules
-  const sorted = topoSortRules(allRules);
-  if (sorted[0]?.manifest.name !== component.manifest.name) return [];
-
-  const sections = sorted.map((r) => `## ${r.manifest.name}\n\n${r.body.trim()}\n`);
-  const content = sections.join('\n');
+  const sorted = selectRules(ctx.allComponents, 'claude-code', scope);
+  const content = composeRulesBody(sorted);
   const filename = scope === 'user' ? '.claude/CLAUDE.md' : 'CLAUDE.md';
   return [{ path: filename, content }];
 }
@@ -147,35 +142,3 @@ function emitPlugin(component: ComponentSource, ctx: AdapterContext): EmittedFil
   ];
 }
 
-function topoSortRules(rules: ComponentSource[]): ComponentSource[] {
-  const byName = new Map(rules.map((r) => [r.manifest.name, r]));
-  const edges = new Map<string, Set<string>>();
-  for (const r of rules) edges.set(r.manifest.name, new Set());
-  for (const r of rules) {
-    for (const before of r.manifest.before ?? []) {
-      if (byName.has(before)) edges.get(r.manifest.name)?.add(before);
-    }
-    for (const after of r.manifest.after ?? []) {
-      if (byName.has(after)) edges.get(after)?.add(r.manifest.name);
-    }
-  }
-  const inDegree = new Map<string, number>(rules.map((r) => [r.manifest.name, 0]));
-  for (const targets of edges.values()) {
-    for (const t of targets) inDegree.set(t, (inDegree.get(t) ?? 0) + 1);
-  }
-  const queue = [...rules.map((r) => r.manifest.name)]
-    .filter((n) => inDegree.get(n) === 0)
-    .sort();
-  const result: ComponentSource[] = [];
-  while (queue.length > 0) {
-    queue.sort();
-    const next = queue.shift()!;
-    const r = byName.get(next);
-    if (r) result.push(r);
-    for (const dep of edges.get(next) ?? []) {
-      inDegree.set(dep, (inDegree.get(dep) ?? 0) - 1);
-      if (inDegree.get(dep) === 0) queue.push(dep);
-    }
-  }
-  return result;
-}

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import type {
   Adapter,
   ComponentSource,
@@ -9,6 +11,25 @@ import {
   composeRulesBody,
   isOwnerOfRulesFile,
 } from '../lib/rules.ts';
+
+const GEMINI_EVENTS = new Set([
+  'SessionStart',
+  'BeforeAgent',
+  'BeforeToolSelection',
+  'BeforeTool',
+  'AfterModel',
+  'AfterAgent',
+]);
+
+function validateGeminiHookEvent(event: string, componentName: string): void {
+  if (!GEMINI_EVENTS.has(event)) {
+    throw new Error(
+      `gemini adapter: hook event "${event}" on component "${componentName}" is not a Gemini event. ` +
+        `Valid events: ${[...GEMINI_EVENTS].join(', ')}. ` +
+        `(Note: Gemini does NOT use Claude Code's PreToolUse/PostToolUse — they are not aliases.)`,
+    );
+  }
+}
 
 export const geminiAdapter: Adapter = {
   target: 'gemini',
@@ -23,7 +44,9 @@ export const geminiAdapter: Adapter = {
         return emitSkill(component);
       case 'rules':
         return emitRules(component, ctx);
-      // Tasks 4-5 add: hook, mcp.
+      case 'hook':
+        return emitHook(component);
+      // Task 5 adds: mcp.
       // agent and plugin are schema-rejected by validate.ts (compatibility matrix).
       default:
         throw new Error(
@@ -75,4 +98,61 @@ function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile
   // installer's responsibility to relocate).
   const filename = scope === 'user' ? '.gemini/GEMINI.md' : 'GEMINI.md';
   return [{ path: filename, content }];
+}
+
+async function emitHook(component: ComponentSource): Promise<EmittedFile[]> {
+  const { manifest, dir } = component;
+  if (!manifest.hooks) return [];
+
+  const fragment: {
+    _comment: string;
+    hooks: Record<string, Array<{ matcher: string; command: string }>>;
+  } = {
+    _comment:
+      'Gemini hook contract: scripts referenced below MUST emit valid JSON on ' +
+      'stdout. Use stderr for any logging. See https://geminicli.com/docs/hooks/',
+    hooks: {},
+  };
+  const files: EmittedFile[] = [];
+
+  for (const [event, def] of Object.entries(manifest.hooks)) {
+    validateGeminiHookEvent(event, manifest.name);
+    fragment.hooks[event] ??= [];
+    fragment.hooks[event]!.push({
+      matcher: def.matcher ?? '*',
+      command: `\${GEMINI_PROJECT_DIR}/${def.command}`,
+    });
+
+    // Bundle the referenced script if it lives inside the component dir.
+    const scriptPath = path.join(dir, def.command);
+    const scriptExists = await fs.stat(scriptPath).then(() => true).catch(() => false);
+    if (scriptExists) {
+      const content = await fs.readFile(scriptPath);
+      // Heuristic: smell-test for the JSON-on-stdout contract — script must
+      // begin with a shebang AND contain "json" (case-insensitive) somewhere
+      // in the first 1KB. The adapter cannot fully verify the contract
+      // without executing the script.
+      const head = content.subarray(0, 1024).toString('utf8');
+      const looksOk = head.startsWith('#!') && /json/i.test(head);
+      if (!looksOk) {
+        throw new Error(
+          `gemini adapter: hook script "${def.command}" on component "${manifest.name}" ` +
+            `does not appear to honor Gemini's JSON-on-stdout contract ` +
+            `(no shebang or no mention of JSON in first 1KB). ` +
+            `See https://geminicli.com/docs/hooks/ — stdout must be valid JSON, ` +
+            `logs go to stderr.`,
+        );
+      }
+      // Only emit each unique script once across multiple events.
+      if (!files.some((f) => f.path === def.command)) {
+        files.push({ path: def.command, content, mode: 0o755 });
+      }
+    }
+  }
+
+  files.push({
+    path: '.gemini/settings.fragment.json',
+    content: `${JSON.stringify(fragment, null, 2)}\n`,
+  });
+  return files;
 }

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -46,7 +46,8 @@ export const geminiAdapter: Adapter = {
         return emitRules(component, ctx);
       case 'hook':
         return emitHook(component);
-      // Task 5 adds: mcp.
+      case 'mcp':
+        return emitMcp(component);
       // agent and plugin are schema-rejected by validate.ts (compatibility matrix).
       default:
         throw new Error(
@@ -155,4 +156,24 @@ async function emitHook(component: ComponentSource): Promise<EmittedFile[]> {
     content: `${JSON.stringify(fragment, null, 2)}\n`,
   });
   return files;
+}
+
+function emitMcp(component: ComponentSource): EmittedFile[] {
+  const { manifest } = component;
+  if (!manifest.mcp) return [];
+  const fragment = {
+    mcpServers: {
+      [manifest.name]: {
+        command: manifest.mcp.command,
+        ...(manifest.mcp.args ? { args: manifest.mcp.args } : {}),
+        ...(manifest.mcp.env ? { env: manifest.mcp.env } : {}),
+      },
+    },
+  };
+  return [
+    {
+      path: '.gemini/settings.fragment.json',
+      content: `${JSON.stringify(fragment, null, 2)}\n`,
+    },
+  ];
 }

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -2,7 +2,13 @@ import type {
   Adapter,
   ComponentSource,
   EmittedFile,
+  AdapterContext,
 } from '../lib/types.ts';
+import {
+  selectRules,
+  composeRulesBody,
+  isOwnerOfRulesFile,
+} from '../lib/rules.ts';
 
 export const geminiAdapter: Adapter = {
   target: 'gemini',
@@ -11,11 +17,13 @@ export const geminiAdapter: Adapter = {
     return component.manifest.targets.includes('gemini');
   },
 
-  async emit(component, _ctx) {
+  async emit(component, ctx) {
     switch (component.manifest.type) {
       case 'skill':
         return emitSkill(component);
-      // Tasks 3-5 add: rules, hook, mcp.
+      case 'rules':
+        return emitRules(component, ctx);
+      // Tasks 4-5 add: hook, mcp.
       // agent and plugin are schema-rejected by validate.ts (compatibility matrix).
       default:
         throw new Error(
@@ -55,4 +63,16 @@ function emitSkill(component: ComponentSource): EmittedFile[] {
       content: `${bodyFrontmatter}\n\n${body.trimStart()}`,
     },
   ];
+}
+
+function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  if (!isOwnerOfRulesFile(component, ctx.allComponents, 'gemini')) return [];
+  const scope = component.manifest.scope ?? 'project';
+  const sorted = selectRules(ctx.allComponents, 'gemini', scope);
+  const content = composeRulesBody(sorted);
+  // Project scope: GEMINI.md at repo root. User scope: ~/.gemini/GEMINI.md
+  // (path here is relative to dist/gemini/; the user-scope path is the
+  // installer's responsibility to relocate).
+  const filename = scope === 'user' ? '.gemini/GEMINI.md' : 'GEMINI.md';
+  return [{ path: filename, content }];
 }

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -1,0 +1,58 @@
+import type {
+  Adapter,
+  ComponentSource,
+  EmittedFile,
+} from '../lib/types.ts';
+
+export const geminiAdapter: Adapter = {
+  target: 'gemini',
+
+  supports(component) {
+    return component.manifest.targets.includes('gemini');
+  },
+
+  async emit(component, _ctx) {
+    switch (component.manifest.type) {
+      case 'skill':
+        return emitSkill(component);
+      // Tasks 3-5 add: rules, hook, mcp.
+      // agent and plugin are schema-rejected by validate.ts (compatibility matrix).
+      default:
+        throw new Error(
+          `gemini adapter: type "${component.manifest.type}" is not supported on Gemini`,
+        );
+    }
+  },
+};
+
+function emitSkill(component: ComponentSource): EmittedFile[] {
+  const { manifest, body } = component;
+
+  // Metadata: loaded at session start, used by Gemini's skill index.
+  const metadata = {
+    name: manifest.name,
+    version: manifest.version,
+    description: manifest.description,
+    ...(manifest.tags ? { tags: manifest.tags } : {}),
+    body_path: 'skill.md',
+  };
+
+  // Skill body: loaded only when Gemini calls activate_skill.
+  const bodyFrontmatter = [
+    '---',
+    `name: ${manifest.name}`,
+    `description: ${manifest.description}`,
+    '---',
+  ].join('\n');
+
+  return [
+    {
+      path: `skills/${manifest.name}/metadata.json`,
+      content: `${JSON.stringify(metadata, null, 2)}\n`,
+    },
+    {
+      path: `skills/${manifest.name}/skill.md`,
+      content: `${bodyFrontmatter}\n\n${body.trimStart()}`,
+    },
+  ];
+}

--- a/apm-builder/adapters/index.ts
+++ b/apm-builder/adapters/index.ts
@@ -1,9 +1,11 @@
 import type { Adapter, Target } from '../lib/types.ts';
 import { claudeCodeAdapter } from './claude-code.ts';
+import { geminiAdapter } from './gemini.ts';
 
 const REGISTRY: Partial<Record<Target, Adapter>> = {
   'claude-code': claudeCodeAdapter,
-  // apm, codex, gemini, copilot, pi adapters land in Plans 2-6.
+  gemini: geminiAdapter,
+  // apm, codex, copilot, pi adapters land in their own plans.
 };
 
 export function getAdapter(target: Target): Adapter | undefined {

--- a/apm-builder/lib/rules.ts
+++ b/apm-builder/lib/rules.ts
@@ -1,0 +1,78 @@
+import type { ComponentSource, Target } from './types.ts';
+
+/**
+ * Topologically sort rule components using before/after frontmatter, with
+ * alphabetical tiebreak. Pure function — same input always yields same output.
+ */
+export function topoSortRules(rules: ComponentSource[]): ComponentSource[] {
+  // Edge x → y means "x must appear before y".
+  const byName = new Map(rules.map((r) => [r.manifest.name, r]));
+  const edges = new Map<string, Set<string>>();
+  for (const r of rules) edges.set(r.manifest.name, new Set());
+  for (const r of rules) {
+    for (const before of r.manifest.before ?? []) {
+      if (byName.has(before)) edges.get(r.manifest.name)?.add(before);
+    }
+    for (const after of r.manifest.after ?? []) {
+      if (byName.has(after)) edges.get(after)?.add(r.manifest.name);
+    }
+  }
+  const inDegree = new Map<string, number>(rules.map((r) => [r.manifest.name, 0]));
+  for (const targets of edges.values()) {
+    for (const t of targets) inDegree.set(t, (inDegree.get(t) ?? 0) + 1);
+  }
+  const queue = rules
+    .map((r) => r.manifest.name)
+    .filter((n) => inDegree.get(n) === 0)
+    .sort();
+  const result: ComponentSource[] = [];
+  while (queue.length > 0) {
+    queue.sort();
+    const next = queue.shift()!;
+    const r = byName.get(next);
+    if (r) result.push(r);
+    for (const dep of edges.get(next) ?? []) {
+      inDegree.set(dep, (inDegree.get(dep) ?? 0) - 1);
+      if (inDegree.get(dep) === 0) queue.push(dep);
+    }
+  }
+  return result;
+}
+
+/**
+ * Filter ctx.allComponents down to rules of a given target/scope, sorted.
+ */
+export function selectRules(
+  all: ComponentSource[],
+  target: Target,
+  scope: 'project' | 'user',
+): ComponentSource[] {
+  const filtered = all
+    .filter((c) => c.manifest.type === 'rules' && c.manifest.targets.includes(target))
+    .filter((c) => (c.manifest.scope ?? 'project') === scope);
+  return topoSortRules(filtered);
+}
+
+/**
+ * Compose a rules body — `## <name>` headers separating each rule's body.
+ * Output ends with a single trailing newline.
+ */
+export function composeRulesBody(rules: ComponentSource[]): string {
+  const sections = rules.map((r) => `## ${r.manifest.name}\n\n${r.body.trim()}\n`);
+  return sections.join('\n');
+}
+
+/**
+ * Returns true if the given rule is the alphabetically-first rule of its
+ * scope+target tuple. Adapters use this to make rule emission idempotent —
+ * only one rule "owns" the file, others contribute via composition.
+ */
+export function isOwnerOfRulesFile(
+  component: ComponentSource,
+  all: ComponentSource[],
+  target: Target,
+): boolean {
+  const scope = component.manifest.scope ?? 'project';
+  const sorted = selectRules(all, target, scope);
+  return sorted[0]?.manifest.name === component.manifest.name;
+}

--- a/apm-builder/tests/adapters/gemini.test.ts
+++ b/apm-builder/tests/adapters/gemini.test.ts
@@ -77,4 +77,9 @@ describe('gemini adapter', () => {
       runGolden(geminiAdapter, path.join(HERE, 'gemini/hook-bad-stdout')),
     ).rejects.toThrow(/JSON-on-stdout/);
   });
+
+  it('emits an mcp component as .gemini/settings fragment with mcpServers', async () => {
+    const result = await runGolden(geminiAdapter, path.join(HERE, 'gemini/mcp-basic'));
+    expect(result.diff).toEqual([]);
+  });
 });

--- a/apm-builder/tests/adapters/gemini.test.ts
+++ b/apm-builder/tests/adapters/gemini.test.ts
@@ -45,4 +45,36 @@ describe('gemini adapter', () => {
     const count = results.flat().filter((f) => f.path === 'GEMINI.md').length;
     expect(count).toBe(1);
   });
+
+  it('emits a hook component with .gemini/settings fragment + script', async () => {
+    const result = await runGolden(geminiAdapter, path.join(HERE, 'gemini/hook-basic'));
+    expect(result.diff).toEqual([]);
+  });
+
+  it('rejects a Claude Code event name (PreToolUse) on a Gemini hook', async () => {
+    const root = path.join(HERE, 'gemini/hook-basic');
+    const fakeManifest = {
+      name: 'bad',
+      version: '1.0.0',
+      description: 'd',
+      type: 'hook' as const,
+      targets: ['gemini' as const],
+      hooks: { PreToolUse: { command: 'hooks/x.sh' } },
+    };
+    const fake: ComponentSource = {
+      dir: root,
+      relativeDir: 'hooks/bad',
+      body: '',
+      manifest: fakeManifest as ComponentSource['manifest'],
+    };
+    await expect(
+      geminiAdapter.emit(fake, { config: {}, allComponents: [fake], repoRoot: root }),
+    ).rejects.toThrow(/PreToolUse/);
+  });
+
+  it('rejects a hook script that does not honor the JSON-on-stdout contract', async () => {
+    await expect(
+      runGolden(geminiAdapter, path.join(HERE, 'gemini/hook-bad-stdout')),
+    ).rejects.toThrow(/JSON-on-stdout/);
+  });
 });

--- a/apm-builder/tests/adapters/gemini.test.ts
+++ b/apm-builder/tests/adapters/gemini.test.ts
@@ -1,15 +1,48 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import fs from 'node:fs/promises';
+import matter from 'gray-matter';
 import { geminiAdapter } from '../../adapters/gemini.ts';
+import { ManifestSchema } from '../../lib/schema.ts';
+import type { ComponentSource } from '../../lib/types.ts';
 import { runGolden } from './golden.ts';
 
 const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+async function loadComponent(dir: string, repoRoot: string): Promise<ComponentSource> {
+  const raw = await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8');
+  const parsed = matter(raw);
+  return {
+    dir,
+    relativeDir: path.relative(repoRoot, dir),
+    manifest: ManifestSchema.parse(parsed.data),
+    body: parsed.content,
+  };
+}
 
 describe('gemini adapter', () => {
   it('emits a skill with metadata.json + skill.md', async () => {
     const result = await runGolden(geminiAdapter, path.join(HERE, 'gemini/skill-basic'));
     expect(result.diff).toEqual([]);
     expect(result.matched).toBe(true);
+  });
+
+  it('composes rules into a single GEMINI.md ordered by before/after', async () => {
+    const root = path.join(HERE, 'gemini/rules-compose');
+    const baseStyle = await loadComponent(path.join(root, 'component'), root);
+    const prPolicy = await loadComponent(path.join(root, 'extra/rules/pr-policy'), root);
+    const all = [baseStyle, prPolicy];
+    const results = await Promise.all(
+      all.map((c) =>
+        geminiAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const geminiMd = results.flat().find((f) => f.path === 'GEMINI.md');
+    const expected = await fs.readFile(path.join(root, 'expected/GEMINI.md'), 'utf8');
+    expect(geminiMd?.content.toString()).toBe(expected);
+    // Idempotent: only one rule emits the file.
+    const count = results.flat().filter((f) => f.path === 'GEMINI.md').length;
+    expect(count).toBe(1);
   });
 });

--- a/apm-builder/tests/adapters/gemini.test.ts
+++ b/apm-builder/tests/adapters/gemini.test.ts
@@ -82,4 +82,42 @@ describe('gemini adapter', () => {
     const result = await runGolden(geminiAdapter, path.join(HERE, 'gemini/mcp-basic'));
     expect(result.diff).toEqual([]);
   });
+
+  it('throws a clear error when emitting an agent (validator should have caught it)', async () => {
+    const fake: ComponentSource = {
+      dir: '/tmp/fake',
+      relativeDir: 'agents/fake',
+      body: 'body',
+      manifest: {
+        name: 'fake',
+        version: '1.0.0',
+        description: 'd',
+        type: 'agent',
+        targets: ['gemini'],
+        agent: { tools: ['Read'] },
+      } as ComponentSource['manifest'],
+    };
+    await expect(
+      geminiAdapter.emit(fake, { config: {}, allComponents: [fake], repoRoot: '/tmp/fake' }),
+    ).rejects.toThrow(/not supported on Gemini/);
+  });
+
+  it('throws a clear error when emitting a plugin', async () => {
+    const fake: ComponentSource = {
+      dir: '/tmp/fake',
+      relativeDir: 'plugins/fake',
+      body: 'body',
+      manifest: {
+        name: 'fake',
+        version: '1.0.0',
+        description: 'd',
+        type: 'plugin',
+        targets: ['gemini'],
+        includes: [],
+      } as ComponentSource['manifest'],
+    };
+    await expect(
+      geminiAdapter.emit(fake, { config: {}, allComponents: [fake], repoRoot: '/tmp/fake' }),
+    ).rejects.toThrow(/not supported on Gemini/);
+  });
 });

--- a/apm-builder/tests/adapters/gemini.test.ts
+++ b/apm-builder/tests/adapters/gemini.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { geminiAdapter } from '../../adapters/gemini.ts';
+import { runGolden } from './golden.ts';
+
+const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+describe('gemini adapter', () => {
+  it('emits a skill with metadata.json + skill.md', async () => {
+    const result = await runGolden(geminiAdapter, path.join(HERE, 'gemini/skill-basic'));
+    expect(result.diff).toEqual([]);
+    expect(result.matched).toBe(true);
+  });
+});

--- a/apm-builder/tests/adapters/gemini/hook-bad-stdout/component/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/hook-bad-stdout/component/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: bad-hook
+version: 1.0.0
+description: Bad hook that logs plain text
+type: hook
+targets:
+  - gemini
+hooks:
+  BeforeTool:
+    command: hooks/log.sh
+---
+
+# Bad Hook

--- a/apm-builder/tests/adapters/gemini/hook-bad-stdout/component/hooks/log.sh
+++ b/apm-builder/tests/adapters/gemini/hook-bad-stdout/component/hooks/log.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "started tool"

--- a/apm-builder/tests/adapters/gemini/hook-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/hook-basic/component/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: tool-guard
+version: 1.0.0
+description: Validate tool calls before execution
+type: hook
+targets:
+  - gemini
+hooks:
+  BeforeTool:
+    command: hooks/before-tool.sh
+  SessionStart:
+    command: hooks/before-tool.sh
+---
+
+# Tool Guard
+
+Inspects every tool call before Gemini executes it.

--- a/apm-builder/tests/adapters/gemini/hook-basic/component/hooks/before-tool.sh
+++ b/apm-builder/tests/adapters/gemini/hook-basic/component/hooks/before-tool.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Gemini hook contract: stdout MUST be valid JSON. Logging via stderr only.
+echo '{"action":"allow"}'

--- a/apm-builder/tests/adapters/gemini/hook-basic/expected/.gemini/settings.fragment.json
+++ b/apm-builder/tests/adapters/gemini/hook-basic/expected/.gemini/settings.fragment.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Gemini hook contract: scripts referenced below MUST emit valid JSON on stdout. Use stderr for any logging. See https://geminicli.com/docs/hooks/",
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "command": "${GEMINI_PROJECT_DIR}/hooks/before-tool.sh"
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "command": "${GEMINI_PROJECT_DIR}/hooks/before-tool.sh"
+      }
+    ]
+  }
+}

--- a/apm-builder/tests/adapters/gemini/hook-basic/expected/hooks/before-tool.sh
+++ b/apm-builder/tests/adapters/gemini/hook-basic/expected/hooks/before-tool.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Gemini hook contract: stdout MUST be valid JSON. Logging via stderr only.
+echo '{"action":"allow"}'

--- a/apm-builder/tests/adapters/gemini/integration.test.ts
+++ b/apm-builder/tests/adapters/gemini/integration.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { runBuild } from '../../../lib/build.ts';
+
+describe('gemini end-to-end build', () => {
+  it('builds skill + rules + hook + mcp into dist/gemini/', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-builder-gemini-e2e-'));
+    const files: Record<string, string> = {
+      'apm-builder.config.yaml':
+        'gemini:\n  user_settings_path: "~/.gemini/settings.json"\n',
+      'skills/foo/SKILL.md':
+        '---\nname: foo\nversion: 1.0.0\ndescription: a skill\ntype: skill\ntargets: [gemini]\n---\n\nFoo body.\n',
+      'rules/style/SKILL.md':
+        '---\nname: style\nversion: 1.0.0\ndescription: style rule\ntype: rules\ntargets: [gemini]\nscope: project\n---\n\nUse spaces.\n',
+      'rules/pr-policy/SKILL.md':
+        '---\nname: pr-policy\nversion: 1.0.0\ndescription: PR rule\ntype: rules\ntargets: [gemini]\nscope: project\nafter: [style]\n---\n\nOpen PRs.\n',
+      'skills/mcp-server/SKILL.md':
+        '---\nname: mcp-server\nversion: 1.0.0\ndescription: an mcp\ntype: mcp\ntargets: [gemini]\nmcp:\n  command: node\n  args: [server.js]\n---\n\nMCP body.\n',
+    };
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(repo, rel);
+      await fs.mkdir(path.dirname(full), { recursive: true });
+      await fs.writeFile(full, content);
+    }
+    const result = await runBuild({ repoRoot: repo, targets: ['gemini'], outDir: 'dist' });
+    expect(result.errors.filter((e) => e.severity === 'error')).toEqual([]);
+
+    // Skill emitted as metadata.json + skill.md.
+    const metadata = JSON.parse(
+      await fs.readFile(path.join(repo, 'dist/gemini/skills/foo/metadata.json'), 'utf8'),
+    );
+    expect(metadata.name).toBe('foo');
+    expect(metadata.body_path).toBe('skill.md');
+    const skillBody = await fs.readFile(path.join(repo, 'dist/gemini/skills/foo/skill.md'), 'utf8');
+    expect(skillBody).toContain('Foo body.');
+
+    // Rules composed in alphabetical-with-after order: style → pr-policy.
+    const geminiMd = await fs.readFile(path.join(repo, 'dist/gemini/GEMINI.md'), 'utf8');
+    expect(geminiMd.indexOf('## style')).toBeLessThan(geminiMd.indexOf('## pr-policy'));
+
+    // MCP fragment present.
+    const mcpFragment = JSON.parse(
+      await fs.readFile(path.join(repo, 'dist/gemini/.gemini/settings.fragment.json'), 'utf8'),
+    );
+    expect(mcpFragment.mcpServers['mcp-server'].command).toBe('node');
+  });
+});

--- a/apm-builder/tests/adapters/gemini/mcp-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/mcp-basic/component/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: my-mcp
+version: 1.0.0
+description: A custom MCP server for Gemini
+type: mcp
+targets:
+  - gemini
+mcp:
+  command: node
+  args:
+    - server.js
+  env:
+    LOG_LEVEL: debug
+---
+
+# My MCP
+
+Server description.

--- a/apm-builder/tests/adapters/gemini/mcp-basic/expected/.gemini/settings.fragment.json
+++ b/apm-builder/tests/adapters/gemini/mcp-basic/expected/.gemini/settings.fragment.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "node",
+      "args": [
+        "server.js"
+      ],
+      "env": {
+        "LOG_LEVEL": "debug"
+      }
+    }
+  }
+}

--- a/apm-builder/tests/adapters/gemini/rules-compose/component/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/rules-compose/component/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: base-style
+version: 1.0.0
+description: Base coding style
+type: rules
+targets:
+  - gemini
+scope: project
+---
+
+Always prefer dependency injection.

--- a/apm-builder/tests/adapters/gemini/rules-compose/expected/GEMINI.md
+++ b/apm-builder/tests/adapters/gemini/rules-compose/expected/GEMINI.md
@@ -1,0 +1,7 @@
+## base-style
+
+Always prefer dependency injection.
+
+## pr-policy
+
+Open PRs against main.

--- a/apm-builder/tests/adapters/gemini/rules-compose/extra/rules/pr-policy/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/rules-compose/extra/rules/pr-policy/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: pr-policy
+version: 1.0.0
+description: PR rules
+type: rules
+targets:
+  - gemini
+scope: project
+after:
+  - base-style
+---
+
+Open PRs against main.

--- a/apm-builder/tests/adapters/gemini/skill-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/gemini/skill-basic/component/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: sample
+version: 1.0.0
+description: A sample skill for the gemini adapter
+type: skill
+targets:
+  - gemini
+tags:
+  - example
+  - test
+---
+
+# Sample
+
+Body content for the on-demand activate_skill load.

--- a/apm-builder/tests/adapters/gemini/skill-basic/expected/skills/sample/metadata.json
+++ b/apm-builder/tests/adapters/gemini/skill-basic/expected/skills/sample/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "sample",
+  "version": "1.0.0",
+  "description": "A sample skill for the gemini adapter",
+  "tags": [
+    "example",
+    "test"
+  ],
+  "body_path": "skill.md"
+}

--- a/apm-builder/tests/adapters/gemini/skill-basic/expected/skills/sample/skill.md
+++ b/apm-builder/tests/adapters/gemini/skill-basic/expected/skills/sample/skill.md
@@ -1,0 +1,8 @@
+---
+name: sample
+description: A sample skill for the gemini adapter
+---
+
+# Sample
+
+Body content for the on-demand activate_skill load.

--- a/apm-builder/tests/rules.test.ts
+++ b/apm-builder/tests/rules.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { topoSortRules, composeRulesBody } from '../lib/rules.ts';
+import type { ComponentSource } from '../lib/types.ts';
+
+function rule(name: string, opts: { before?: string[]; after?: string[]; body?: string } = {}): ComponentSource {
+  return {
+    dir: `/x/${name}`,
+    relativeDir: `rules/${name}`,
+    body: opts.body ?? `Body of ${name}.`,
+    manifest: {
+      name,
+      version: '1.0.0',
+      description: `${name} rule`,
+      type: 'rules',
+      targets: ['claude-code', 'gemini'],
+      scope: 'project',
+      ...(opts.before ? { before: opts.before } : {}),
+      ...(opts.after ? { after: opts.after } : {}),
+    } as ComponentSource['manifest'],
+  };
+}
+
+describe('topoSortRules', () => {
+  it('orders alphabetically when no before/after', () => {
+    const sorted = topoSortRules([rule('charlie'), rule('alpha'), rule('bravo')]);
+    expect(sorted.map((r) => r.manifest.name)).toEqual(['alpha', 'bravo', 'charlie']);
+  });
+
+  it('honors before: relations', () => {
+    const sorted = topoSortRules([
+      rule('zulu', { before: ['alpha'] }),
+      rule('alpha'),
+    ]);
+    expect(sorted.map((r) => r.manifest.name)).toEqual(['zulu', 'alpha']);
+  });
+
+  it('honors after: relations', () => {
+    const sorted = topoSortRules([
+      rule('alpha'),
+      rule('zulu', { after: ['alpha'] }),
+    ]);
+    expect(sorted.map((r) => r.manifest.name)).toEqual(['alpha', 'zulu']);
+  });
+
+  it('falls back to alphabetical for tied nodes', () => {
+    const sorted = topoSortRules([
+      rule('charlie', { after: ['root'] }),
+      rule('bravo', { after: ['root'] }),
+      rule('root'),
+    ]);
+    expect(sorted.map((r) => r.manifest.name)).toEqual(['root', 'bravo', 'charlie']);
+  });
+});
+
+describe('composeRulesBody', () => {
+  it('joins sections with ## <name> headers', () => {
+    const out = composeRulesBody([rule('alpha', { body: 'Use spaces.' }), rule('bravo', { body: 'Open PRs.' })]);
+    expect(out).toContain('## alpha\n\nUse spaces.');
+    expect(out).toContain('## bravo\n\nOpen PRs.');
+  });
+});

--- a/apm-builder/tests/validate.test.ts
+++ b/apm-builder/tests/validate.test.ts
@@ -95,3 +95,24 @@ describe('validateComponents', () => {
     expect(errors.some((e) => e.severity === 'warning' && /empty includes/i.test(e.message))).toBe(true);
   });
 });
+
+describe('validateComponents — Gemini-specific rejections', () => {
+  it('rejects agent type targeting gemini', () => {
+    const errors = validateComponents([
+      mk({
+        name: 'rev',
+        type: 'agent',
+        targets: ['gemini'],
+        agent: { tools: ['Read'], model: 'gemini-2.0-flash' },
+      }),
+    ]);
+    expect(errors.some((e) => e.severity === 'error' && /agent.*gemini/i.test(e.message))).toBe(true);
+  });
+
+  it('rejects plugin type targeting gemini', () => {
+    const errors = validateComponents([
+      mk({ name: 'pl', type: 'plugin', targets: ['gemini'], includes: [] }),
+    ]);
+    expect(errors.some((e) => e.severity === 'error' && /plugin.*gemini/i.test(e.message))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Google Gemini CLI adapter per Plan 4. Two-stage skill emission models Gemini's `activate_skill` semantics; composes rules into GEMINI.md; emits .gemini/settings.fragment.json for hooks/MCP.

- Skill emits both `metadata.json` (loaded at session start) and `skill.md` (loaded on activate)
- GEMINI.md via shared `apm-builder/lib/rules.ts` topo-sort
- Hooks validate Gemini's lifecycle event names (SessionStart/BeforeAgent/BeforeToolSelection/BeforeTool/AfterModel/AfterAgent), reject Claude Code event aliases
- Hooks contract documented inline (JSON-on-stdout, logging via stderr only)

## Spec ambiguities flagged

(Copy from plan: project vs user GEMINI.md path — mirrored Claude Code convention. Hook script JSON-on-stdout enforcement is heuristic.)

## Test plan

- [x] `npx tsc --noEmit` clean, `npm test` passes
- [ ] Reviewer to spot-check Gemini frontmatter shape on emitted skills
- [ ] Resolve `apm-builder/adapters/index.ts` and `lib/rules.ts` merge conflicts vs parallel PRs