### PR TITLE
feat: codex adapter

### DIFF
--- a/apm-builder/adapters/codex.ts
+++ b/apm-builder/adapters/codex.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import type {
   Adapter,
   AdapterContext,
@@ -25,7 +27,9 @@ export const codexAdapter: Adapter = {
       case 'agent':
       case 'rules':
         return emitAgentsMd(component, ctx);
-      // hook + mcp added in Tasks 8 + 9.
+      case 'hook':
+        return emitHook(component);
+      // mcp added in Task 9.
       // plugin is schema-rejected for codex (see Plan 1's validate.ts).
       default:
         throw new Error(
@@ -34,6 +38,45 @@ export const codexAdapter: Adapter = {
     }
   },
 };
+
+interface CodexHookEntry {
+  command: string;
+  matcher?: string;
+}
+
+async function emitHook(component: ComponentSource): Promise<EmittedFile[]> {
+  const { manifest, dir } = component;
+  if (!manifest.hooks) return [];
+
+  // Group entries by event, alphabetize events for determinism.
+  const events: Record<string, CodexHookEntry[]> = {};
+  const sortedEvents = Object.keys(manifest.hooks).sort();
+  for (const event of sortedEvents) {
+    const def = manifest.hooks[event]!;
+    const entry: CodexHookEntry = { command: def.command };
+    if (def.matcher !== undefined) entry.matcher = def.matcher;
+    events[event] = [entry];
+  }
+  const fragment = { hooks: events };
+
+  const files: EmittedFile[] = [
+    {
+      path: 'hooks.json',
+      content: `${JSON.stringify(fragment, null, 2)}\n`,
+    },
+  ];
+
+  // Bundle any scripts that exist inside the component dir.
+  for (const def of Object.values(manifest.hooks)) {
+    const scriptPath = path.join(dir, def.command);
+    const exists = await fs.stat(scriptPath).then(() => true).catch(() => false);
+    if (exists) {
+      const content = await fs.readFile(scriptPath);
+      files.push({ path: def.command, content, mode: 0o755 });
+    }
+  }
+  return files;
+}
 
 /**
  * Emit `AGENTS.md` exactly once across all content-bearing component invocations.

--- a/apm-builder/adapters/codex.ts
+++ b/apm-builder/adapters/codex.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_SECTION_ORDER,
   type AgentsMdSection,
 } from '../lib/agents-md.ts';
+import { renderMcpServerToml } from '../lib/toml.ts';
 
 const TARGET = 'codex' as const;
 
@@ -29,7 +30,8 @@ export const codexAdapter: Adapter = {
         return emitAgentsMd(component, ctx);
       case 'hook':
         return emitHook(component);
-      // mcp added in Task 9.
+      case 'mcp':
+        return emitMcp(component, ctx);
       // plugin is schema-rejected for codex (see Plan 1's validate.ts).
       default:
         throw new Error(
@@ -107,6 +109,32 @@ function emitAgentsMd(
     sectionOrder,
   });
   return [{ path: 'AGENTS.md', content }];
+}
+
+function emitMcp(
+  component: ComponentSource,
+  ctx: AdapterContext,
+): EmittedFile[] {
+  // Idempotency: only the alphabetically-first mcp component emits the file.
+  const allMcp = ctx.allComponents
+    .filter(
+      (c) => c.manifest.type === 'mcp' && c.manifest.targets.includes(TARGET),
+    )
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+  if (allMcp[0]?.manifest.name !== component.manifest.name) return [];
+
+  const blocks = allMcp
+    .filter((c) => c.manifest.mcp !== undefined)
+    .map((c) =>
+      renderMcpServerToml(c.manifest.name, {
+        command: c.manifest.mcp!.command,
+        args: c.manifest.mcp!.args,
+        env: c.manifest.mcp!.env,
+      }).trimEnd(),
+    );
+
+  const content = blocks.join('\n\n') + '\n';
+  return [{ path: 'codex.config.toml', content }];
 }
 
 function readSectionOrder(config: Record<string, unknown>): AgentsMdSection[] {

--- a/apm-builder/adapters/codex.ts
+++ b/apm-builder/adapters/codex.ts
@@ -1,0 +1,79 @@
+import type {
+  Adapter,
+  AdapterContext,
+  ComponentSource,
+  EmittedFile,
+} from '../lib/types.ts';
+import {
+  composeAgentsMd,
+  DEFAULT_SECTION_ORDER,
+  type AgentsMdSection,
+} from '../lib/agents-md.ts';
+
+const TARGET = 'codex' as const;
+
+export const codexAdapter: Adapter = {
+  target: TARGET,
+
+  supports(component) {
+    return component.manifest.targets.includes(TARGET);
+  },
+
+  async emit(component, ctx) {
+    switch (component.manifest.type) {
+      case 'skill':
+      case 'agent':
+      case 'rules':
+        return emitAgentsMd(component, ctx);
+      // hook + mcp added in Tasks 8 + 9.
+      // plugin is schema-rejected for codex (see Plan 1's validate.ts).
+      default:
+        throw new Error(
+          `codex adapter: type "${component.manifest.type}" not yet implemented`,
+        );
+    }
+  },
+};
+
+/**
+ * Emit `AGENTS.md` exactly once across all content-bearing component invocations.
+ * The "alphabetically-first content-bearing component targeting codex" wins;
+ * everyone else returns []. Same idempotency pattern as the claude-code rules
+ * adapter in Plan 1.
+ */
+function emitAgentsMd(
+  component: ComponentSource,
+  ctx: AdapterContext,
+): EmittedFile[] {
+  const contentBearing = ctx.allComponents
+    .filter(
+      (c) =>
+        (c.manifest.type === 'skill' ||
+          c.manifest.type === 'agent' ||
+          c.manifest.type === 'rules') &&
+        c.manifest.targets.includes(TARGET),
+    )
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+
+  if (contentBearing[0]?.manifest.name !== component.manifest.name) return [];
+
+  const sectionOrder = readSectionOrder(ctx.config);
+  const content = composeAgentsMd({
+    target: TARGET,
+    components: ctx.allComponents,
+    sectionOrder,
+  });
+  return [{ path: 'AGENTS.md', content }];
+}
+
+function readSectionOrder(config: Record<string, unknown>): AgentsMdSection[] {
+  const raw = config['agents_md_section_order'];
+  if (!Array.isArray(raw)) return DEFAULT_SECTION_ORDER;
+  const valid: AgentsMdSection[] = ['rules', 'agents', 'skills'];
+  const filtered = raw.filter((x): x is AgentsMdSection =>
+    valid.includes(x as AgentsMdSection),
+  );
+  // Fill in any missing sections at the end so we never lose content.
+  for (const s of valid) if (!filtered.includes(s)) filtered.push(s);
+  return filtered;
+}

--- a/apm-builder/adapters/index.ts
+++ b/apm-builder/adapters/index.ts
@@ -1,11 +1,13 @@
 import type { Adapter, Target } from '../lib/types.ts';
 import { claudeCodeAdapter } from './claude-code.ts';
+import { codexAdapter } from './codex.ts';
 import { geminiAdapter } from './gemini.ts';
 
 const REGISTRY: Partial<Record<Target, Adapter>> = {
   'claude-code': claudeCodeAdapter,
+  codex: codexAdapter,
   gemini: geminiAdapter,
-  // apm, codex, copilot, pi adapters land in their own plans.
+  // apm, copilot, pi adapters land in their own plans.
 };
 
 export function getAdapter(target: Target): Adapter | undefined {

--- a/apm-builder/lib/agents-md.ts
+++ b/apm-builder/lib/agents-md.ts
@@ -1,5 +1,5 @@
 import type { ComponentSource, Target } from './types.ts';
-import { topoSortRules, filterRulesForTarget } from './rules.ts';
+import { selectRules } from './rules.ts';
 
 export type AgentsMdSection = 'rules' | 'agents' | 'skills';
 export const DEFAULT_SECTION_ORDER: AgentsMdSection[] = ['rules', 'agents', 'skills'];
@@ -31,8 +31,8 @@ export function composeAgentsMd(opts: ComposeOptions): string {
   const { target, components, sectionOrder } = opts;
   const sections = new Map<AgentsMdSection, ComponentSource[]>();
 
-  // Rules: topo-sorted per the shared helper.
-  const rules = topoSortRules(filterRulesForTarget(components, target, 'project'));
+  // Rules: filtered + topo-sorted per the shared helper.
+  const rules = selectRules(components, target, 'project');
   sections.set('rules', rules);
 
   // Agents and skills: alphabetical by name, filtered to ones targeting this harness.

--- a/apm-builder/lib/agents-md.ts
+++ b/apm-builder/lib/agents-md.ts
@@ -1,0 +1,64 @@
+import type { ComponentSource, Target } from './types.ts';
+import { topoSortRules, filterRulesForTarget } from './rules.ts';
+
+export type AgentsMdSection = 'rules' | 'agents' | 'skills';
+export const DEFAULT_SECTION_ORDER: AgentsMdSection[] = ['rules', 'agents', 'skills'];
+
+export interface ComposeOptions {
+  /** Which harness target are we composing for (filter applied to components.targets). */
+  target: Target;
+  /** All discovered components. The composer filters internally. */
+  components: ComponentSource[];
+  /** Section order — typically read from apm-builder.config.yaml. */
+  sectionOrder: AgentsMdSection[];
+}
+
+/**
+ * Compose multiple content-bearing components (skill + agent + rules) into a
+ * single AGENTS.md string. Used by both the Codex and Pi adapters.
+ *
+ * Layout:
+ *   # <Section>            (one H1 per non-empty section)
+ *
+ *   ## <component-name>    (one H2 per component)
+ *
+ *   <body>
+ *
+ * Empty sections are omitted. Rules use topo-sort; agents and skills use
+ * alphabetical-by-name. Components not targeting the given harness are filtered out.
+ */
+export function composeAgentsMd(opts: ComposeOptions): string {
+  const { target, components, sectionOrder } = opts;
+  const sections = new Map<AgentsMdSection, ComponentSource[]>();
+
+  // Rules: topo-sorted per the shared helper.
+  const rules = topoSortRules(filterRulesForTarget(components, target, 'project'));
+  sections.set('rules', rules);
+
+  // Agents and skills: alphabetical by name, filtered to ones targeting this harness.
+  const agents = components
+    .filter((c) => c.manifest.type === 'agent' && c.manifest.targets.includes(target))
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+  sections.set('agents', agents);
+
+  const skills = components
+    .filter((c) => c.manifest.type === 'skill' && c.manifest.targets.includes(target))
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+  sections.set('skills', skills);
+
+  const blocks: string[] = [];
+  for (const section of sectionOrder) {
+    const items = sections.get(section) ?? [];
+    if (items.length === 0) continue;
+    const header = `# ${capitalize(section)}`;
+    const subsections = items.map(
+      (c) => `## ${c.manifest.name}\n\n${c.body.trim()}`,
+    );
+    blocks.push([header, '', subsections.join('\n\n')].join('\n'));
+  }
+  return blocks.join('\n\n').trimEnd() + '\n';
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/apm-builder/lib/toml.ts
+++ b/apm-builder/lib/toml.ts
@@ -1,0 +1,39 @@
+import TOML from '@iarna/toml';
+
+export interface McpServerSpec {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+const BARE_KEY_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Render a `[mcp_servers.<name>]` TOML table for one MCP server. Emits stable,
+ * deterministic output. Server names containing characters outside [A-Za-z0-9_-]
+ * are quoted. Inner tables (e.g., env) become inline-style for readability.
+ */
+export function renderMcpServerToml(name: string, spec: McpServerSpec): string {
+  const tableKey = BARE_KEY_RE.test(name) ? name : `"${name.replace(/"/g, '\\"')}"`;
+  const body: Record<string, unknown> = { command: spec.command };
+  if (spec.args && spec.args.length > 0) body.args = spec.args;
+  if (spec.env && Object.keys(spec.env).length > 0) body.env = spec.env;
+  // Wrap in a top-level mcp_servers.<name> table.
+  const wrapped = { mcp_servers: { [name]: body } };
+  // @iarna/toml emits sorted keys deterministically when fed a plain object;
+  // rebuild the section header line ourselves to keep the dotted-key form.
+  let raw = TOML.stringify(wrapped);
+  // Replace the implicit inline form (TOML.stringify nests sub-tables under mcp_servers
+  // using `[mcp_servers.<name>]` automatically — keep that, just normalize quoting).
+  raw = raw.replace(
+    new RegExp(`\\[mcp_servers\\.${escapeRegex(name)}\\]`),
+    `[mcp_servers.${tableKey}]`,
+  );
+  // @iarna/toml emits arrays with spaces (`[ "a", "b" ]`); normalize to compact form.
+  raw = raw.replace(/^(\s*\w+\s*=\s*)\[ (.+) \]$/gm, '$1[$2]');
+  return raw;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/apm-builder/lib/toml.ts
+++ b/apm-builder/lib/toml.ts
@@ -31,6 +31,8 @@ export function renderMcpServerToml(name: string, spec: McpServerSpec): string {
   );
   // @iarna/toml emits arrays with spaces (`[ "a", "b" ]`); normalize to compact form.
   raw = raw.replace(/^(\s*\w+\s*=\s*)\[ (.+) \]$/gm, '$1[$2]');
+  // @iarna/toml indents nested sub-tables with leading whitespace; strip it.
+  raw = raw.replace(/^[ \t]+/gm, '');
   return raw;
 }
 

--- a/apm-builder/lib/toml.ts
+++ b/apm-builder/lib/toml.ts
@@ -1,4 +1,4 @@
-import TOML from '@iarna/toml';
+import TOML, { type JsonMap } from '@iarna/toml';
 
 export interface McpServerSpec {
   command: string;
@@ -15,11 +15,11 @@ const BARE_KEY_RE = /^[A-Za-z0-9_-]+$/;
  */
 export function renderMcpServerToml(name: string, spec: McpServerSpec): string {
   const tableKey = BARE_KEY_RE.test(name) ? name : `"${name.replace(/"/g, '\\"')}"`;
-  const body: Record<string, unknown> = { command: spec.command };
+  const body: JsonMap = { command: spec.command };
   if (spec.args && spec.args.length > 0) body.args = spec.args;
   if (spec.env && Object.keys(spec.env).length > 0) body.env = spec.env;
   // Wrap in a top-level mcp_servers.<name> table.
-  const wrapped = { mcp_servers: { [name]: body } };
+  const wrapped: JsonMap = { mcp_servers: { [name]: body } };
   // @iarna/toml emits sorted keys deterministically when fed a plain object;
   // rebuild the section header line ourselves to keep the dotted-key form.
   let raw = TOML.stringify(wrapped);

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -86,4 +86,9 @@ describe('codex adapter', () => {
     });
     expect(emitted).toEqual([]);
   });
+
+  it('emits a hook component as hooks.json + bundled scripts', async () => {
+    const result = await runGolden(codexAdapter, path.join(HERE, 'codex/hook-basic'));
+    expect(result.diff).toEqual([]);
+  });
 });

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -37,4 +37,53 @@ describe('codex adapter', () => {
     const result = await runGolden(codexAdapter, path.join(HERE, 'codex/rules-basic'));
     expect(result.diff).toEqual([]);
   });
+
+  it('composes skill + agent + rules into one AGENTS.md (default order)', async () => {
+    const root = path.join(HERE, 'codex/composition');
+    const skill = await loadComponent(path.join(root, 'component'), root);
+    const agent = await loadComponent(path.join(root, 'extra/agents/code-reviewer'), root);
+    const rule = await loadComponent(path.join(root, 'extra/rules/pr-policy'), root);
+    const all = [skill, agent, rule];
+    // Invoke for every component — exactly one should emit AGENTS.md.
+    const results = await Promise.all(
+      all.map((c) =>
+        codexAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const agentsMd = results.flat().filter((f) => f.path === 'AGENTS.md');
+    expect(agentsMd).toHaveLength(1); // idempotency: only one emission across N invocations
+    const expected = await fs.readFile(path.join(root, 'expected/AGENTS.md'), 'utf8');
+    expect(agentsMd[0]?.content.toString()).toBe(expected);
+  });
+
+  it('honors codex.agents_md_section_order from config', async () => {
+    const root = path.join(HERE, 'codex/composition-custom-order');
+    const skill = await loadComponent(path.join(root, 'component'), root);
+    const all = [skill];
+    const ctx: AdapterContext = {
+      config: { agents_md_section_order: ['skills', 'rules', 'agents'] },
+      allComponents: all,
+      repoRoot: root,
+    };
+    const emitted = await codexAdapter.emit(skill, ctx);
+    const agentsMd = emitted.find((f) => f.path === 'AGENTS.md');
+    const expected = await fs.readFile(path.join(root, 'expected/AGENTS.md'), 'utf8');
+    expect(agentsMd?.content.toString()).toBe(expected);
+  });
+
+  it('returns empty array when invoked on non-first content-bearing component', async () => {
+    const root = path.join(HERE, 'codex/composition');
+    const skill = await loadComponent(path.join(root, 'component'), root);
+    const agent = await loadComponent(path.join(root, 'extra/agents/code-reviewer'), root);
+    const rule = await loadComponent(path.join(root, 'extra/rules/pr-policy'), root);
+    const all = [skill, agent, rule];
+    // sample-skill is alphabetically last; pr-policy is middle; code-reviewer first.
+    // So invoking on rule (pr-policy) should return [].
+    const emitted = await codexAdapter.emit(rule, {
+      config: {},
+      allComponents: all,
+      repoRoot: root,
+    });
+    expect(emitted).toEqual([]);
+  });
 });

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -27,4 +27,9 @@ describe('codex adapter', () => {
     expect(result.diff).toEqual([]);
     expect(result.matched).toBe(true);
   });
+
+  it('emits a single agent into AGENTS.md', async () => {
+    const result = await runGolden(codexAdapter, path.join(HERE, 'codex/agent-basic'));
+    expect(result.diff).toEqual([]);
+  });
 });

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -32,4 +32,9 @@ describe('codex adapter', () => {
     const result = await runGolden(codexAdapter, path.join(HERE, 'codex/agent-basic'));
     expect(result.diff).toEqual([]);
   });
+
+  it('emits a single rule into AGENTS.md', async () => {
+    const result = await runGolden(codexAdapter, path.join(HERE, 'codex/rules-basic'));
+    expect(result.diff).toEqual([]);
+  });
 });

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import matter from 'gray-matter';
+import { codexAdapter } from '../../adapters/codex.ts';
+import { ManifestSchema } from '../../lib/schema.ts';
+import { runGolden } from './golden.ts';
+import type { ComponentSource, AdapterContext } from '../../lib/types.ts';
+
+const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+async function loadComponent(dir: string, repoRoot: string): Promise<ComponentSource> {
+  const raw = await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8');
+  const parsed = matter(raw);
+  return {
+    dir,
+    relativeDir: path.relative(repoRoot, dir),
+    manifest: ManifestSchema.parse(parsed.data),
+    body: parsed.content,
+  };
+}
+
+describe('codex adapter', () => {
+  it('emits a single skill into AGENTS.md', async () => {
+    const result = await runGolden(codexAdapter, path.join(HERE, 'codex/skill-basic'));
+    expect(result.diff).toEqual([]);
+    expect(result.matched).toBe(true);
+  });
+});

--- a/apm-builder/tests/adapters/codex.test.ts
+++ b/apm-builder/tests/adapters/codex.test.ts
@@ -91,4 +91,20 @@ describe('codex adapter', () => {
     const result = await runGolden(codexAdapter, path.join(HERE, 'codex/hook-basic'));
     expect(result.diff).toEqual([]);
   });
+
+  it('composes multiple mcp components into one codex.config.toml', async () => {
+    const root = path.join(HERE, 'codex/mcp-basic');
+    const a = await loadComponent(path.join(root, 'component'), root);
+    const b = await loadComponent(path.join(root, 'extra/mcp/another-server'), root);
+    const all = [a, b];
+    const results = await Promise.all(
+      all.map((c) =>
+        codexAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const tomlFiles = results.flat().filter((f) => f.path === 'codex.config.toml');
+    expect(tomlFiles).toHaveLength(1); // idempotency
+    const expected = await fs.readFile(path.join(root, 'expected/codex.config.toml'), 'utf8');
+    expect(tomlFiles[0]?.content.toString().trim()).toBe(expected.trim());
+  });
 });

--- a/apm-builder/tests/adapters/codex/agent-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/agent-basic/component/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: code-reviewer
+version: 1.0.0
+description: Reviews code for quality issues
+type: agent
+targets:
+  - codex
+agent:
+  tools:
+    - Read
+    - Grep
+  model: sonnet
+---
+
+# Code Reviewer
+
+Review the code carefully.

--- a/apm-builder/tests/adapters/codex/agent-basic/expected/AGENTS.md
+++ b/apm-builder/tests/adapters/codex/agent-basic/expected/AGENTS.md
@@ -1,0 +1,7 @@
+# Agents
+
+## code-reviewer
+
+# Code Reviewer
+
+Review the code carefully.

--- a/apm-builder/tests/adapters/codex/composition-custom-order/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/composition-custom-order/component/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: only-skill
+version: 1.0.0
+description: A solo skill
+type: skill
+targets:
+  - codex
+---
+
+# Only Skill
+
+Body.

--- a/apm-builder/tests/adapters/codex/composition-custom-order/expected/AGENTS.md
+++ b/apm-builder/tests/adapters/codex/composition-custom-order/expected/AGENTS.md
@@ -1,0 +1,7 @@
+# Skills
+
+## only-skill
+
+# Only Skill
+
+Body.

--- a/apm-builder/tests/adapters/codex/composition/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/composition/component/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: sample-skill
+version: 1.0.0
+description: A sample skill
+type: skill
+targets:
+  - codex
+---
+
+# Sample Skill
+
+Skill body.

--- a/apm-builder/tests/adapters/codex/composition/expected/AGENTS.md
+++ b/apm-builder/tests/adapters/codex/composition/expected/AGENTS.md
@@ -1,0 +1,21 @@
+# Rules
+
+## pr-policy
+
+Open PRs against `main`.
+
+# Agents
+
+## code-reviewer
+
+# Code Reviewer
+
+Reviews code carefully.
+
+# Skills
+
+## sample-skill
+
+# Sample Skill
+
+Skill body.

--- a/apm-builder/tests/adapters/codex/composition/extra/agents/code-reviewer/SKILL.md
+++ b/apm-builder/tests/adapters/codex/composition/extra/agents/code-reviewer/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: code-reviewer
+version: 1.0.0
+description: Reviews code
+type: agent
+targets:
+  - codex
+---
+
+# Code Reviewer
+
+Reviews code carefully.

--- a/apm-builder/tests/adapters/codex/composition/extra/rules/pr-policy/SKILL.md
+++ b/apm-builder/tests/adapters/codex/composition/extra/rules/pr-policy/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pr-policy
+version: 1.0.0
+description: PR rules
+type: rules
+targets:
+  - codex
+scope: project
+---
+
+Open PRs against `main`.

--- a/apm-builder/tests/adapters/codex/hook-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/hook-basic/component/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: tts-announcer
+version: 1.0.0
+description: TTS announcements when Codex stops
+type: hook
+targets:
+  - codex
+hooks:
+  Stop:
+    command: hooks/announce.sh
+  PreToolUse:
+    command: hooks/audit.sh
+    matcher: Bash
+---
+
+# TTS Announcer
+
+Announces task completion via TTS.

--- a/apm-builder/tests/adapters/codex/hook-basic/component/hooks/announce.sh
+++ b/apm-builder/tests/adapters/codex/hook-basic/component/hooks/announce.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+say "done"

--- a/apm-builder/tests/adapters/codex/hook-basic/expected/hooks.json
+++ b/apm-builder/tests/adapters/codex/hook-basic/expected/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "command": "hooks/audit.sh",
+        "matcher": "Bash"
+      }
+    ],
+    "Stop": [
+      {
+        "command": "hooks/announce.sh"
+      }
+    ]
+  }
+}

--- a/apm-builder/tests/adapters/codex/hook-basic/expected/hooks/announce.sh
+++ b/apm-builder/tests/adapters/codex/hook-basic/expected/hooks/announce.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+say "done"

--- a/apm-builder/tests/adapters/codex/mcp-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/mcp-basic/component/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: my-mcp
+version: 1.0.0
+description: A custom MCP server
+type: mcp
+targets:
+  - codex
+mcp:
+  command: node
+  args:
+    - server.js
+  env:
+    LOG_LEVEL: debug
+---
+
+# My MCP
+
+Server description.

--- a/apm-builder/tests/adapters/codex/mcp-basic/expected/codex.config.toml
+++ b/apm-builder/tests/adapters/codex/mcp-basic/expected/codex.config.toml
@@ -1,0 +1,10 @@
+[mcp_servers.another-server]
+command = "python3"
+args = ["main.py"]
+
+[mcp_servers.my-mcp]
+command = "node"
+args = ["server.js"]
+
+[mcp_servers.my-mcp.env]
+LOG_LEVEL = "debug"

--- a/apm-builder/tests/adapters/codex/mcp-basic/extra/mcp/another-server/SKILL.md
+++ b/apm-builder/tests/adapters/codex/mcp-basic/extra/mcp/another-server/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: another-server
+version: 1.0.0
+description: Second MCP server
+type: mcp
+targets:
+  - codex
+mcp:
+  command: python3
+  args:
+    - main.py
+---
+
+# Another
+
+Body.

--- a/apm-builder/tests/adapters/codex/rules-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/rules-basic/component/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pr-policy
+version: 1.0.0
+description: PR rules
+type: rules
+targets:
+  - codex
+scope: project
+---
+
+Open PRs against `main`. Never push directly.

--- a/apm-builder/tests/adapters/codex/rules-basic/expected/AGENTS.md
+++ b/apm-builder/tests/adapters/codex/rules-basic/expected/AGENTS.md
@@ -1,0 +1,5 @@
+# Rules
+
+## pr-policy
+
+Open PRs against `main`. Never push directly.

--- a/apm-builder/tests/adapters/codex/skill-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/codex/skill-basic/component/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: sample-skill
+version: 1.0.0
+description: A sample skill for adapter testing
+type: skill
+targets:
+  - codex
+---
+
+# Sample Skill
+
+Body content for the sample skill.

--- a/apm-builder/tests/adapters/codex/skill-basic/expected/AGENTS.md
+++ b/apm-builder/tests/adapters/codex/skill-basic/expected/AGENTS.md
@@ -1,0 +1,7 @@
+# Skills
+
+## sample-skill
+
+# Sample Skill
+
+Body content for the sample skill.

--- a/apm-builder/tests/agents-md.test.ts
+++ b/apm-builder/tests/agents-md.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { composeAgentsMd, DEFAULT_SECTION_ORDER, type AgentsMdSection } from '../lib/agents-md.ts';
+import type { ComponentSource, Target } from '../lib/types.ts';
+
+function mk(
+  name: string,
+  type: 'skill' | 'agent' | 'rules',
+  body: string,
+  opts: Partial<ComponentSource['manifest']> = {},
+): ComponentSource {
+  return {
+    dir: `/x/${name}`,
+    relativeDir: `${type === 'rules' ? 'rules' : type === 'agent' ? 'skills' : 'skills'}/${name}`,
+    body,
+    manifest: {
+      name,
+      version: '1.0.0',
+      description: `desc ${name}`,
+      type,
+      targets: ['codex', 'pi'] as Target[],
+      ...(type === 'rules' ? { scope: 'project' as const } : {}),
+      ...opts,
+    } as ComponentSource['manifest'],
+  };
+}
+
+describe('composeAgentsMd', () => {
+  it('uses default section order: rules, agents, skills', () => {
+    expect(DEFAULT_SECTION_ORDER).toEqual<AgentsMdSection[]>(['rules', 'agents', 'skills']);
+  });
+
+  it('emits one H1 per non-empty section + H2 per component', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [
+        mk('alpha-skill', 'skill', 'Alpha body'),
+        mk('beta-agent', 'agent', 'Beta body'),
+        mk('gamma-rule', 'rules', 'Gamma body'),
+      ],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    // Rules first
+    expect(out.indexOf('# Rules')).toBeLessThan(out.indexOf('# Agents'));
+    expect(out.indexOf('# Agents')).toBeLessThan(out.indexOf('# Skills'));
+    // Sub-sections present
+    expect(out).toContain('## gamma-rule');
+    expect(out).toContain('## beta-agent');
+    expect(out).toContain('## alpha-skill');
+    // Bodies preserved
+    expect(out).toContain('Gamma body');
+  });
+
+  it('respects custom section order from config', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [
+        mk('alpha-skill', 'skill', 'A'),
+        mk('beta-agent', 'agent', 'B'),
+        mk('gamma-rule', 'rules', 'C'),
+      ],
+      sectionOrder: ['skills', 'rules', 'agents'],
+    });
+    expect(out.indexOf('# Skills')).toBeLessThan(out.indexOf('# Rules'));
+    expect(out.indexOf('# Rules')).toBeLessThan(out.indexOf('# Agents'));
+  });
+
+  it('omits empty sections entirely (no H1 with no children)', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [mk('only-skill', 'skill', 'Body')],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    expect(out).not.toContain('# Rules');
+    expect(out).not.toContain('# Agents');
+    expect(out).toContain('# Skills');
+    expect(out).toContain('## only-skill');
+  });
+
+  it('orders agents and skills alphabetically by name', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [
+        mk('zebra', 'skill', 'Z'),
+        mk('alpha', 'skill', 'A'),
+        mk('mango', 'skill', 'M'),
+      ],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    expect(out.indexOf('## alpha')).toBeLessThan(out.indexOf('## mango'));
+    expect(out.indexOf('## mango')).toBeLessThan(out.indexOf('## zebra'));
+  });
+
+  it('orders rules via topo-sort (before/after)', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [
+        mk('z-rule', 'rules', 'Z body', { before: ['a-rule'] }),
+        mk('a-rule', 'rules', 'A body'),
+      ],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    expect(out.indexOf('## z-rule')).toBeLessThan(out.indexOf('## a-rule'));
+  });
+
+  it('filters by target — components not targeting "codex" excluded', () => {
+    const skipped = mk('not-codex', 'skill', 'Body', { targets: ['gemini'] });
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [mk('included', 'skill', 'A'), skipped],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    expect(out).toContain('## included');
+    expect(out).not.toContain('## not-codex');
+  });
+
+  it('separates sections with a blank line and trims trailing whitespace', () => {
+    const out = composeAgentsMd({
+      target: 'codex',
+      components: [
+        mk('s', 'skill', 'Skill body'),
+        mk('a', 'agent', 'Agent body'),
+      ],
+      sectionOrder: DEFAULT_SECTION_ORDER,
+    });
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.includes('\n\n\n\n')).toBe(false);
+  });
+});

--- a/apm-builder/tests/integration.test.ts
+++ b/apm-builder/tests/integration.test.ts
@@ -35,3 +35,41 @@ describe('end-to-end build', () => {
     expect(JSON.parse(pluginJson).skills).toEqual(['foo']);
   });
 });
+
+describe('end-to-end build — codex', () => {
+  it('builds a mixed-component repo to dist/codex/', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-builder-codex-e2e-'));
+    const files: Record<string, string> = {
+      'apm-builder.config.yaml':
+        'codex:\n  agents_md_section_order: [rules, agents, skills]\n',
+      'skills/foo/SKILL.md':
+        '---\nname: foo\nversion: 1.0.0\ndescription: a skill\ntype: skill\ntargets: [codex]\n---\n\nFoo body.\n',
+      'rules/style/SKILL.md':
+        '---\nname: style\nversion: 1.0.0\ndescription: style rule\ntype: rules\ntargets: [codex]\nscope: project\n---\n\nUse spaces.\n',
+      'skills/hooky/SKILL.md':
+        '---\nname: hooky\nversion: 1.0.0\ndescription: a hook\ntype: hook\ntargets: [codex]\nhooks:\n  Stop:\n    command: hooks/x.sh\n---\n\nBody.\n',
+      'skills/mcpy/SKILL.md':
+        '---\nname: mcpy\nversion: 1.0.0\ndescription: an mcp\ntype: mcp\ntargets: [codex]\nmcp:\n  command: node\n  args: [s.js]\n---\n\nBody.\n',
+    };
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(repo, rel);
+      await fs.mkdir(path.dirname(full), { recursive: true });
+      await fs.writeFile(full, content);
+    }
+    const result = await runBuild({ repoRoot: repo, targets: ['codex'], outDir: 'dist' });
+    expect(result.errors.filter((e) => e.severity === 'error')).toEqual([]);
+
+    const agentsMd = await fs.readFile(path.join(repo, 'dist/codex/AGENTS.md'), 'utf8');
+    expect(agentsMd).toContain('# Rules');
+    expect(agentsMd).toContain('## style');
+    expect(agentsMd).toContain('# Skills');
+    expect(agentsMd).toContain('## foo');
+
+    const hooksJson = await fs.readFile(path.join(repo, 'dist/codex/hooks.json'), 'utf8');
+    expect(JSON.parse(hooksJson).hooks.Stop[0].command).toBe('hooks/x.sh');
+
+    const mcpToml = await fs.readFile(path.join(repo, 'dist/codex/codex.config.toml'), 'utf8');
+    expect(mcpToml).toContain('[mcp_servers.mcpy]');
+    expect(mcpToml).toContain('command = "node"');
+  });
+});

--- a/apm-builder/tests/toml.test.ts
+++ b/apm-builder/tests/toml.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { renderMcpServerToml } from '../lib/toml.ts';
+
+describe('renderMcpServerToml', () => {
+  it('emits a [mcp_servers.<name>] table with command + args + env', () => {
+    const out = renderMcpServerToml('my-mcp', {
+      command: 'node',
+      args: ['server.js', '--flag'],
+      env: { LOG_LEVEL: 'debug', API_KEY: 'xxx' },
+    });
+    expect(out).toContain('[mcp_servers.my-mcp]');
+    expect(out).toContain('command = "node"');
+    expect(out).toContain('args = ["server.js", "--flag"]');
+    expect(out).toContain('LOG_LEVEL = "debug"');
+    expect(out).toContain('API_KEY = "xxx"');
+  });
+
+  it('omits args/env when not provided', () => {
+    const out = renderMcpServerToml('simple', { command: 'python3' });
+    expect(out).toContain('command = "python3"');
+    expect(out).not.toContain('args');
+    expect(out).not.toContain('env');
+  });
+
+  it('escapes the server name when it contains characters that need quoting', () => {
+    const out = renderMcpServerToml('with.dot', { command: 'cmd' });
+    // TOML requires quoting of names containing dots.
+    expect(out).toMatch(/\[mcp_servers\."with\.dot"\]/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agent-skills",
       "version": "0.0.0",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "chokidar": "^4.0.1",
         "citty": "^0.1.6",
         "gray-matter": "^4.0.3",
@@ -501,6 +502,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "citty": "^0.1.6",
     "gray-matter": "^4.0.3",
     "yaml": "^2.6.0",


### PR DESCRIPTION
## Summary

Implements the OpenAI Codex adapter per Plan 3. Composes skill/agent/rules into a single AGENTS.md (parameterizable section order via `codex.agents_md_section_order`); emits hooks.json and codex.config.toml MCP fragments.

- AGENTS.md composer extracted to `apm-builder/lib/agents-md.ts` (Pi adapter shares this)
- `topoSortRules` lifted to `apm-builder/lib/rules.ts` (other adapter plans share)
- Idempotent emission: only the alphabetically-first content-bearing component emits AGENTS.md
- Hooks per https://developers.openai.com/codex/hooks
- MCP per https://developers.openai.com/codex/config-reference

## Spec ambiguities flagged

- Codex MCP fragment filename: chose `codex.config.toml` (matches the upstream config file's name).
- Whether Codex agent frontmatter (tools/model) surfaces in AGENTS.md: chose no per spec — agent fields appear only as descriptive sections, not as Codex-specific primitives.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — all suites pass (64 total: 39 baseline + 25 new)
- [ ] Reviewer to spot-check AGENTS.md composition order and hooks.json shape
- [ ] Resolve merge conflicts in `apm-builder/adapters/index.ts` and possibly `lib/rules.ts` against parallel PRs