### PR TITLE
feat: copilot cli adapter

### DIFF
--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -1,5 +1,5 @@
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
-import { renderRulesSections, selectAndSortRules } from '../lib/rules.ts';
+import { composeRulesBody, selectRules } from '../lib/rules.ts';
 
 export const copilotAdapter: Adapter = {
   target: 'copilot',
@@ -32,7 +32,7 @@ export const copilotAdapter: Adapter = {
 
 function emitInstructions(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
   // Collect all components contributing to copilot-instructions.md.
-  const rules = selectAndSortRules(ctx.allComponents, 'copilot', 'project');
+  const rules = selectRules(ctx.allComponents, 'copilot', 'project');
   const skills = ctx.allComponents
     .filter(
       (c) =>
@@ -51,7 +51,7 @@ function emitInstructions(component: ComponentSource, ctx: AdapterContext): Emit
   }
 
   const sections: string[] = [];
-  if (rules.length > 0) sections.push(`# Rules\n\n${renderRulesSections(rules)}`);
+  if (rules.length > 0) sections.push(`# Rules\n\n${composeRulesBody(rules)}`);
   if (skills.length > 0) {
     const skillSections = skills
       .map((s) => `## ${s.manifest.name}\n\n${s.body.trim()}\n`)

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -13,7 +13,8 @@ export const copilotAdapter: Adapter = {
       case 'rules':
       case 'skill':
         return emitInstructions(component, ctx);
-      // hook implementation lands in Task 6.
+      case 'hook':
+        return emitHook(component, ctx);
       default:
         throw new Error(
           `copilot adapter: type "${component.manifest.type}" not yet implemented`,
@@ -53,4 +54,27 @@ function emitInstructions(component: ComponentSource, ctx: AdapterContext): Emit
   if (sections.length === 0) return [];
   const content = sections.join('\n');
   return [{ path: 'copilot-instructions.md', content }];
+}
+
+function emitHook(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  const { manifest } = component;
+  if (!manifest.hooks) return [];
+  const hooksDir =
+    typeof ctx.config['hooks_dir'] === 'string'
+      ? (ctx.config['hooks_dir'] as string)
+      : '.github/hooks';
+  const files: EmittedFile[] = [];
+  for (const [event, def] of Object.entries(manifest.hooks)) {
+    const payload = {
+      event,
+      matcher: def.matcher ?? '*',
+      command: def.command,
+      type: 'command',
+    };
+    files.push({
+      path: `${hooksDir}/${event}-${manifest.name}.json`,
+      content: `${JSON.stringify(payload, null, 2)}\n`,
+    });
+  }
+  return files;
 }

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -1,4 +1,5 @@
-import type { Adapter } from '../lib/types.ts';
+import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
+import { isFirstRule, renderRulesSections, selectAndSortRules } from '../lib/rules.ts';
 
 export const copilotAdapter: Adapter = {
   target: 'copilot',
@@ -7,9 +8,11 @@ export const copilotAdapter: Adapter = {
     return component.manifest.targets.includes('copilot');
   },
 
-  async emit(component, _ctx) {
+  async emit(component, ctx) {
     switch (component.manifest.type) {
-      // Implementations land in Tasks 3, 4, 6.
+      case 'rules':
+        return emitRules(component, ctx);
+      // skill, hook implementations land in Tasks 4 and 6.
       default:
         throw new Error(
           `copilot adapter: type "${component.manifest.type}" not yet implemented`,
@@ -17,3 +20,15 @@ export const copilotAdapter: Adapter = {
     }
   },
 };
+
+function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  const scope = component.manifest.scope ?? 'project';
+  if (scope !== 'project') {
+    // Copilot CLI does not have a user-scoped rules concept; user-scoped rules are skipped silently.
+    return [];
+  }
+  if (!isFirstRule(component, ctx.allComponents, 'copilot', scope)) return [];
+  const rules = selectAndSortRules(ctx.allComponents, 'copilot', scope);
+  const content = `# Rules\n\n${renderRulesSections(rules)}`;
+  return [{ path: 'copilot-instructions.md', content }];
+}

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -15,9 +15,16 @@ export const copilotAdapter: Adapter = {
         return emitInstructions(component, ctx);
       case 'hook':
         return emitHook(component, ctx);
+      case 'plugin':
+      case 'agent':
+      case 'mcp':
+        throw new Error(
+          `copilot adapter: type "${component.manifest.type}" not supported by Copilot CLI ` +
+            `(see compatibility matrix in spec). Remove "copilot" from the component's targets.`,
+        );
       default:
         throw new Error(
-          `copilot adapter: type "${component.manifest.type}" not yet implemented`,
+          `copilot adapter: unknown component type "${component.manifest.type}"`,
         );
     }
   },

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -1,0 +1,19 @@
+import type { Adapter } from '../lib/types.ts';
+
+export const copilotAdapter: Adapter = {
+  target: 'copilot',
+
+  supports(component) {
+    return component.manifest.targets.includes('copilot');
+  },
+
+  async emit(component, _ctx) {
+    switch (component.manifest.type) {
+      // Implementations land in Tasks 3, 4, 6.
+      default:
+        throw new Error(
+          `copilot adapter: type "${component.manifest.type}" not yet implemented`,
+        );
+    }
+  },
+};

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -1,5 +1,5 @@
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
-import { isFirstRule, renderRulesSections, selectAndSortRules } from '../lib/rules.ts';
+import { renderRulesSections, selectAndSortRules } from '../lib/rules.ts';
 
 export const copilotAdapter: Adapter = {
   target: 'copilot',
@@ -11,8 +11,9 @@ export const copilotAdapter: Adapter = {
   async emit(component, ctx) {
     switch (component.manifest.type) {
       case 'rules':
-        return emitRules(component, ctx);
-      // skill, hook implementations land in Tasks 4 and 6.
+      case 'skill':
+        return emitInstructions(component, ctx);
+      // hook implementation lands in Task 6.
       default:
         throw new Error(
           `copilot adapter: type "${component.manifest.type}" not yet implemented`,
@@ -21,14 +22,35 @@ export const copilotAdapter: Adapter = {
   },
 };
 
-function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
-  const scope = component.manifest.scope ?? 'project';
-  if (scope !== 'project') {
-    // Copilot CLI does not have a user-scoped rules concept; user-scoped rules are skipped silently.
+function emitInstructions(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  // Collect all components contributing to copilot-instructions.md.
+  const rules = selectAndSortRules(ctx.allComponents, 'copilot', 'project');
+  const skills = ctx.allComponents
+    .filter(
+      (c) =>
+        c.manifest.type === 'skill' &&
+        c.manifest.targets.includes('copilot'),
+    )
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+
+  // Pick a canonical owner: alphabetically-first project rule, or, if no rules, alphabetically-first skill.
+  const owner = rules[0] ?? skills[0];
+  if (!owner || owner.manifest.name !== component.manifest.name) return [];
+
+  // For rule components that are user-scoped, opt out (Copilot has no user scope).
+  if (component.manifest.type === 'rules' && (component.manifest.scope ?? 'project') !== 'project') {
     return [];
   }
-  if (!isFirstRule(component, ctx.allComponents, 'copilot', scope)) return [];
-  const rules = selectAndSortRules(ctx.allComponents, 'copilot', scope);
-  const content = `# Rules\n\n${renderRulesSections(rules)}`;
+
+  const sections: string[] = [];
+  if (rules.length > 0) sections.push(`# Rules\n\n${renderRulesSections(rules)}`);
+  if (skills.length > 0) {
+    const skillSections = skills
+      .map((s) => `## ${s.manifest.name}\n\n${s.body.trim()}\n`)
+      .join('\n');
+    sections.push(`# Skills\n\n${skillSections}`);
+  }
+  if (sections.length === 0) return [];
+  const content = sections.join('\n');
   return [{ path: 'copilot-instructions.md', content }];
 }

--- a/apm-builder/adapters/index.ts
+++ b/apm-builder/adapters/index.ts
@@ -1,13 +1,15 @@
 import type { Adapter, Target } from '../lib/types.ts';
 import { claudeCodeAdapter } from './claude-code.ts';
 import { codexAdapter } from './codex.ts';
+import { copilotAdapter } from './copilot.ts';
 import { geminiAdapter } from './gemini.ts';
 
 const REGISTRY: Partial<Record<Target, Adapter>> = {
   'claude-code': claudeCodeAdapter,
   codex: codexAdapter,
+  copilot: copilotAdapter,
   gemini: geminiAdapter,
-  // apm, copilot, pi adapters land in their own plans.
+  // apm, pi adapters land in their own plans.
 };
 
 export function getAdapter(target: Target): Adapter | undefined {

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -56,4 +56,22 @@ describe('copilot adapter', () => {
     // Idempotency: emitted exactly once.
     expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
   });
+
+  it('emits rules first, then skills, in a single copilot-instructions.md', async () => {
+    const root = path.join(HERE, 'copilot/rules-and-skills');
+    const style = await loadComponent(path.join(root, 'rules/style'), root);
+    const foo = await loadComponent(path.join(root, 'skills/foo'), root);
+    const all = [style, foo];
+    const results = await Promise.all(
+      all.map((c) =>
+        copilotAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const flat = results.flat();
+    const file = flat.find((f) => f.path === 'copilot-instructions.md');
+    const expected = await fs.readFile(path.join(root, 'expected/copilot-instructions.md'), 'utf8');
+    expect(file?.content.toString()).toBe(expected);
+    // Owner is the rule (alphabetically-first rule beats alphabetically-first skill).
+    expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
+  });
 });

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -74,4 +74,21 @@ describe('copilot adapter', () => {
     // Owner is the rule (alphabetically-first rule beats alphabetically-first skill).
     expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
   });
+
+  it('emits one JSON file per hook event under .github/hooks/', async () => {
+    const root = path.join(HERE, 'copilot/hook-basic');
+    const hook = await loadComponent(path.join(root, 'component'), root);
+    const emitted = await copilotAdapter.emit(hook, {
+      config: {},
+      allComponents: [hook],
+      repoRoot: root,
+    });
+    const file = emitted.find((f) => f.path === '.github/hooks/Stop-tts-announcer.json');
+    expect(file).toBeDefined();
+    const expected = await fs.readFile(
+      path.join(root, 'expected/.github/hooks/Stop-tts-announcer.json'),
+      'utf8',
+    );
+    expect(file!.content.toString()).toBe(expected);
+  });
 });

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -108,4 +108,28 @@ describe('copilot adapter', () => {
     );
     expect(file!.content.toString()).toBe(expected);
   });
+
+  it.each(['plugin', 'agent', 'mcp'] as const)(
+    'throws a clear error when asked to emit unsupported type %s',
+    async (type) => {
+      const stub: ComponentSource = {
+        dir: '/tmp/x',
+        relativeDir: 'x',
+        body: '',
+        manifest: {
+          name: 'x',
+          version: '1.0.0',
+          description: 'd',
+          type,
+          targets: ['copilot'],
+          // Minimal type-specific fields so the schema-bypassed manifest is structurally complete:
+          ...(type === 'plugin' ? { includes: [] } : {}),
+          ...(type === 'mcp' ? { mcp: { command: 'noop' } } : {}),
+        } as ComponentSource['manifest'],
+      };
+      await expect(
+        copilotAdapter.emit(stub, { config: {}, allComponents: [stub], repoRoot: '/tmp' }),
+      ).rejects.toThrow(/copilot.*not supported/i);
+    },
+  );
 });

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import matter from 'gray-matter';
 import { copilotAdapter } from '../../adapters/copilot.ts';
 import { ManifestSchema } from '../../lib/schema.ts';
 import type { ComponentSource } from '../../lib/types.ts';
+import { runBuild } from '../../lib/build.ts';
 
 const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
 
@@ -132,4 +134,64 @@ describe('copilot adapter', () => {
       ).rejects.toThrow(/copilot.*not supported/i);
     },
   );
+});
+
+describe('copilot adapter — end-to-end via runBuild', () => {
+  it('builds rules + skills + hook into dist/copilot/', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-builder-copilot-e2e-'));
+    const files: Record<string, string> = {
+      'apm-builder.config.yaml': 'copilot:\n  hooks_dir: ".github/hooks"\n',
+      'rules/style/SKILL.md':
+        '---\nname: style\nversion: 1.0.0\ndescription: style\ntype: rules\ntargets: [copilot]\nscope: project\n---\n\nUse 2-space indent.\n',
+      'skills/foo/SKILL.md':
+        '---\nname: foo\nversion: 1.0.0\ndescription: foo\ntype: skill\ntargets: [copilot]\n---\n\nFoo body.\n',
+      'skills/tts/SKILL.md':
+        '---\nname: tts\nversion: 1.0.0\ndescription: tts\ntype: hook\ntargets: [copilot]\nhooks:\n  Stop:\n    command: hooks/announce.sh\n---\n\nHook body.\n',
+    };
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(repo, rel);
+      await fs.mkdir(path.dirname(full), { recursive: true });
+      await fs.writeFile(full, content);
+    }
+    const result = await runBuild({ repoRoot: repo, targets: ['copilot'], outDir: 'dist' });
+    // The skill warning ("⚠️ best-effort") is expected; no errors.
+    expect(result.errors.filter((e) => e.severity === 'error')).toEqual([]);
+    expect(result.errors.some((e) => e.severity === 'warning')).toBe(true);
+
+    const instructions = await fs.readFile(
+      path.join(repo, 'dist/copilot/copilot-instructions.md'),
+      'utf8',
+    );
+    expect(instructions).toContain('# Rules');
+    expect(instructions).toContain('## style');
+    expect(instructions).toContain('# Skills');
+    expect(instructions).toContain('## foo');
+
+    const hookFile = await fs.readFile(
+      path.join(repo, 'dist/copilot/.github/hooks/Stop-tts.json'),
+      'utf8',
+    );
+    expect(JSON.parse(hookFile)).toEqual({
+      event: 'Stop',
+      matcher: '*',
+      command: 'hooks/announce.sh',
+      type: 'command',
+    });
+  });
+
+  it('runBuild rejects plugin/agent/mcp targeting copilot via validator', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-builder-copilot-rej-'));
+    await fs.mkdir(path.join(repo, 'plugins/bad'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'plugins/bad/SKILL.md'),
+      '---\nname: bad\nversion: 1.0.0\ndescription: d\ntype: plugin\ntargets: [copilot]\nincludes: []\n---\n\nx\n',
+    );
+    const result = await runBuild({ repoRoot: repo, targets: ['copilot'], outDir: 'dist' });
+    expect(result.errors.some((e) => e.severity === 'error' && /plugin.*copilot/i.test(e.message))).toBe(true);
+    const distExists = await fs
+      .stat(path.join(repo, 'dist'))
+      .then(() => true)
+      .catch(() => false);
+    expect(distExists).toBe(false);
+  });
 });

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import matter from 'gray-matter';
+import { copilotAdapter } from '../../adapters/copilot.ts';
+import { ManifestSchema } from '../../lib/schema.ts';
+import type { ComponentSource } from '../../lib/types.ts';
+
+const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+async function loadComponent(dir: string, repoRoot: string): Promise<ComponentSource> {
+  const raw = await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8');
+  const parsed = matter(raw);
+  return {
+    dir,
+    relativeDir: path.relative(repoRoot, dir),
+    manifest: ManifestSchema.parse(parsed.data),
+    body: parsed.content,
+  };
+}
+
+describe('copilot adapter', () => {
+  it('composes project rules into copilot-instructions.md ordered by before/after', async () => {
+    const root = path.join(HERE, 'copilot/rules-compose');
+    const baseStyle = await loadComponent(path.join(root, 'component'), root);
+    const prPolicy = await loadComponent(path.join(root, 'extra/rules/pr-policy'), root);
+    const all = [baseStyle, prPolicy];
+    const results = await Promise.all(
+      all.map((c) =>
+        copilotAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const flat = results.flat();
+    const file = flat.find((f) => f.path === 'copilot-instructions.md');
+    const expected = await fs.readFile(path.join(root, 'expected/copilot-instructions.md'), 'utf8');
+    expect(file?.content.toString()).toBe(expected);
+    // Idempotency: the composed file should be emitted exactly once across all rules.
+    expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
+  });
+});

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -38,4 +38,22 @@ describe('copilot adapter', () => {
     // Idempotency: the composed file should be emitted exactly once across all rules.
     expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
   });
+
+  it('appends skills as ## sections under # Skills, alphabetical', async () => {
+    const root = path.join(HERE, 'copilot/skill-as-instructions');
+    const alpha = await loadComponent(path.join(root, 'component'), root);
+    const beta = await loadComponent(path.join(root, 'extra/skills/another'), root);
+    const all = [alpha, beta];
+    const results = await Promise.all(
+      all.map((c) =>
+        copilotAdapter.emit(c, { config: {}, allComponents: all, repoRoot: root }),
+      ),
+    );
+    const flat = results.flat();
+    const file = flat.find((f) => f.path === 'copilot-instructions.md');
+    const expected = await fs.readFile(path.join(root, 'expected/copilot-instructions.md'), 'utf8');
+    expect(file?.content.toString()).toBe(expected);
+    // Idempotency: emitted exactly once.
+    expect(flat.filter((f) => f.path === 'copilot-instructions.md').length).toBe(1);
+  });
 });

--- a/apm-builder/tests/adapters/copilot.test.ts
+++ b/apm-builder/tests/adapters/copilot.test.ts
@@ -91,4 +91,21 @@ describe('copilot adapter', () => {
     );
     expect(file!.content.toString()).toBe(expected);
   });
+
+  it('honors hooks_dir override from repo config and preserves matcher', async () => {
+    const root = path.join(HERE, 'copilot/hook-custom-dir');
+    const hook = await loadComponent(path.join(root, 'component'), root);
+    const emitted = await copilotAdapter.emit(hook, {
+      config: { hooks_dir: '.copilot/hooks' },
+      allComponents: [hook],
+      repoRoot: root,
+    });
+    const file = emitted.find((f) => f.path === '.copilot/hooks/PreToolUse-guard.json');
+    expect(file).toBeDefined();
+    const expected = await fs.readFile(
+      path.join(root, 'expected/.copilot/hooks/PreToolUse-guard.json'),
+      'utf8',
+    );
+    expect(file!.content.toString()).toBe(expected);
+  });
 });

--- a/apm-builder/tests/adapters/copilot/hook-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/hook-basic/component/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: tts-announcer
+version: 1.0.0
+description: TTS announcements
+type: hook
+targets:
+  - copilot
+hooks:
+  Stop:
+    command: hooks/announce.sh
+---
+
+# TTS Announcer
+
+Announces task completion.

--- a/apm-builder/tests/adapters/copilot/hook-basic/expected/.github/hooks/Stop-tts-announcer.json
+++ b/apm-builder/tests/adapters/copilot/hook-basic/expected/.github/hooks/Stop-tts-announcer.json
@@ -1,0 +1,6 @@
+{
+  "event": "Stop",
+  "matcher": "*",
+  "command": "hooks/announce.sh",
+  "type": "command"
+}

--- a/apm-builder/tests/adapters/copilot/hook-custom-dir/component/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/hook-custom-dir/component/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: guard
+version: 1.0.0
+description: Pre-tool-use guard
+type: hook
+targets:
+  - copilot
+hooks:
+  PreToolUse:
+    matcher: "Bash"
+    command: scripts/guard.sh
+---
+
+# Guard
+
+Refuses dangerous Bash invocations.

--- a/apm-builder/tests/adapters/copilot/hook-custom-dir/expected/.copilot/hooks/PreToolUse-guard.json
+++ b/apm-builder/tests/adapters/copilot/hook-custom-dir/expected/.copilot/hooks/PreToolUse-guard.json
@@ -1,0 +1,6 @@
+{
+  "event": "PreToolUse",
+  "matcher": "Bash",
+  "command": "scripts/guard.sh",
+  "type": "command"
+}

--- a/apm-builder/tests/adapters/copilot/rules-and-skills/expected/copilot-instructions.md
+++ b/apm-builder/tests/adapters/copilot/rules-and-skills/expected/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Rules
+
+## style
+
+Use 2-space indent.
+
+# Skills
+
+## foo
+
+Foo skill body.

--- a/apm-builder/tests/adapters/copilot/rules-and-skills/rules/style/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/rules-and-skills/rules/style/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: style
+version: 1.0.0
+description: Style guidelines
+type: rules
+targets:
+  - copilot
+scope: project
+---
+
+Use 2-space indent.

--- a/apm-builder/tests/adapters/copilot/rules-and-skills/skills/foo/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/rules-and-skills/skills/foo/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: foo
+version: 1.0.0
+description: Foo skill
+type: skill
+targets:
+  - copilot
+---
+
+Foo skill body.

--- a/apm-builder/tests/adapters/copilot/rules-compose/component/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/rules-compose/component/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: base-style
+version: 1.0.0
+description: Base coding style
+type: rules
+targets:
+  - copilot
+scope: project
+---
+
+Always prefer dependency injection.

--- a/apm-builder/tests/adapters/copilot/rules-compose/expected/copilot-instructions.md
+++ b/apm-builder/tests/adapters/copilot/rules-compose/expected/copilot-instructions.md
@@ -1,0 +1,9 @@
+# Rules
+
+## base-style
+
+Always prefer dependency injection.
+
+## pr-policy
+
+Open PRs against main.

--- a/apm-builder/tests/adapters/copilot/rules-compose/extra/rules/pr-policy/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/rules-compose/extra/rules/pr-policy/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: pr-policy
+version: 1.0.0
+description: PR rules
+type: rules
+targets:
+  - copilot
+scope: project
+after:
+  - base-style
+---
+
+Open PRs against main.

--- a/apm-builder/tests/adapters/copilot/skill-as-instructions/component/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/skill-as-instructions/component/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: alpha-skill
+version: 1.0.0
+description: First skill
+type: skill
+targets:
+  - copilot
+---
+
+Alpha body content.

--- a/apm-builder/tests/adapters/copilot/skill-as-instructions/expected/copilot-instructions.md
+++ b/apm-builder/tests/adapters/copilot/skill-as-instructions/expected/copilot-instructions.md
@@ -1,0 +1,9 @@
+# Skills
+
+## alpha-skill
+
+Alpha body content.
+
+## beta-skill
+
+Beta body content.

--- a/apm-builder/tests/adapters/copilot/skill-as-instructions/extra/skills/another/SKILL.md
+++ b/apm-builder/tests/adapters/copilot/skill-as-instructions/extra/skills/another/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: beta-skill
+version: 1.0.0
+description: Second skill
+type: skill
+targets:
+  - copilot
+---
+
+Beta body content.


### PR DESCRIPTION
## Summary

Implements the GitHub Copilot CLI adapter per Plan 5. Composes rules + skills into a single copilot-instructions.md (Copilot has no native skill primitive; skills emit as appended instruction sections); hooks emit one JSON file per event per https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks.

- Rules and skills compose into copilot-instructions.md via shared `apm-builder/lib/rules.ts` topo-sort
- One hook file per event at `<hooks_dir>/<event>-<name>.json` (default `.github/hooks/`, configurable via `copilot.hooks_dir`)
- Defense-in-depth rejection of plugin/agent/mcp types in the adapter

## Spec ambiguities flagged

- **H1 vs H2 in copilot-instructions.md**: chose H1 (`# Rules` / `# Skills` as top-level headers, individual rules/skills as `## name`). A real-world smoke test in Copilot CLI is suggested to confirm Copilot parses the dual-H1 layout cleanly; if not, fall back to H2 and reserve H1 for the document title.
- **User-scoped rules**: silently skipped because Copilot CLI has no user-scope concept. Could warn at validate time instead — flagged for follow-up.

## Test plan

- [x] `npx tsc --noEmit` clean, `npm test` passes (49 tests)
- [ ] Reviewer to spot-check copilot-instructions.md structure
- [ ] Resolve merge conflicts in `apm-builder/adapters/index.ts` and `lib/rules.ts`