### PR TITLE
feat: pi adapter

### DIFF
--- a/apm-builder/adapters/index.ts
+++ b/apm-builder/adapters/index.ts
@@ -4,6 +4,7 @@ import { claudeCodeAdapter } from './claude-code.ts';
 import { codexAdapter } from './codex.ts';
 import { copilotAdapter } from './copilot.ts';
 import { geminiAdapter } from './gemini.ts';
+import { piAdapter } from './pi.ts';
 
 const REGISTRY: Partial<Record<Target, Adapter>> = {
   'claude-code': claudeCodeAdapter,
@@ -11,7 +12,7 @@ const REGISTRY: Partial<Record<Target, Adapter>> = {
   codex: codexAdapter,
   copilot: copilotAdapter,
   gemini: geminiAdapter,
-  // pi adapter lands in its own plan.
+  pi: piAdapter,
 };
 
 export function getAdapter(target: Target): Adapter | undefined {

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -227,8 +227,136 @@ Or add to \`.pi/settings.json\`:
 ${rows.join('\n')}
 `;
 }
-function emitHookExtension(_component: ComponentSource): EmittedFile[] {
-  throw new Error('not implemented (Task 7)');
+// Map Plan-1 hook event names (Claude Code style) to Pi ExtensionAPI event
+// names. Best-effort mapping; revise as Pi's event surface evolves.
+const HOOK_EVENT_MAP: Record<string, string> = {
+  Stop: 'turn_end',
+  SubagentStop: 'agent_end',
+  PreToolUse: 'pre_tool_use',
+  PostToolUse: 'post_tool_use',
+  SessionStart: 'session_start',
+  SessionEnd: 'session_shutdown',
+  UserPromptSubmit: 'message_start',
+  Notification: 'notification',
+};
+
+function emitHookExtension(component: ComponentSource): EmittedFile[] {
+  const { manifest } = component;
+  if (!manifest.hooks) return [];
+  const extDir = `.pi/extensions/${manifest.name}`;
+
+  const files: EmittedFile[] = [];
+
+  files.push({
+    path: `${extDir}/package.json`,
+    content: `${JSON.stringify(
+      {
+        name: manifest.name,
+        version: manifest.version,
+        description: manifest.description,
+        main: 'index.ts',
+        type: 'module',
+        peerDependencies: { '@mariozechner/pi-coding-agent': '*' },
+      },
+      null,
+      2,
+    )}\n`,
+  });
+
+  files.push({
+    path: `${extDir}/index.ts`,
+    content: renderHookExtensionTs(manifest),
+  });
+
+  files.push({
+    path: `${extDir}/README.md`,
+    content: renderHookReadme(manifest),
+  });
+
+  return files;
+}
+
+function renderHookExtensionTs(
+  manifest: ComponentSource['manifest'],
+): string {
+  const fnIdent = toCamelCase(manifest.name) + 'Extension';
+  const handlers: string[] = [];
+
+  for (const [event, def] of Object.entries(manifest.hooks ?? {})) {
+    const piEvent = HOOK_EVENT_MAP[event] ?? event.toLowerCase();
+    const matcherCheck = def.matcher
+      ? `    if (event.tool !== ${JSON.stringify(def.matcher)}) return;\n`
+      : '';
+    handlers.push(
+      `  pi.on(${JSON.stringify(piEvent)}, async (event, _ctx) => {\n` +
+        `    // Mirrors source hook: ${event} → ${def.command}` +
+        (def.matcher ? ` (matcher: "${def.matcher}")` : '') +
+        '\n' +
+        matcherCheck +
+        `    const script = resolve(__dirname, ${JSON.stringify(def.command)});\n` +
+        `    spawn(script, [], { stdio: "inherit" });\n` +
+        `  });\n`,
+    );
+  }
+
+  return `import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+// Auto-generated from skill component "${manifest.name}".
+// Source: see README.md for the canonical SKILL.md path.
+//
+// Pi has no JSON-config hooks; this scaffold registers each declared event
+// programmatically via the ExtensionAPI. Customize the body of each handler
+// or replace the script invocation as needed.
+
+export default function ${fnIdent}(pi: ExtensionAPI) {
+${handlers.join('\n')}}
+`;
+}
+
+function renderHookReadme(manifest: ComponentSource['manifest']): string {
+  return `# ${manifest.name} (Pi extension scaffold)
+
+${manifest.description}
+
+This is an **auto-generated TypeScript extension** for the Pi coding agent.
+Source: \`${manifest.name}\` (type: hook) from the agent-skills monorepo.
+
+## Manual install step required
+
+Pi extensions need a runtime. After this scaffold is emitted, you must run:
+
+\`\`\`bash
+cd .pi/extensions/${manifest.name}
+npm install
+\`\`\`
+
+Then register the extension in \`.pi/settings.json\`:
+
+\`\`\`json
+{
+  "extensions": [".pi/extensions/${manifest.name}/index.ts"]
+}
+\`\`\`
+
+## Customizing
+
+The scaffold registers each Pi event from the source SKILL.md's \`hooks:\` block.
+Edit \`index.ts\` to change the behavior. The original shell scripts (if any)
+should be placed under \`hooks/\` next to \`index.ts\` and will be invoked via
+\`spawn\`.
+
+## Why TypeScript?
+
+Pi hooks are programmatic, not JSON-configured. The Pi \`ExtensionAPI\` exposes
+events like \`turn_end\`, \`post_tool_use\`, \`session_start\`, etc. — see
+[pi-coding-agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#extensions).
+`;
+}
+
+function toCamelCase(s: string): string {
+  return s.replace(/-([a-z0-9])/g, (_, ch) => ch.toUpperCase());
 }
 function emitMcpStub(_component: ComponentSource): EmittedFile[] {
   throw new Error('not implemented (Task 8)');

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -1,0 +1,50 @@
+import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
+
+export const piAdapter: Adapter = {
+  target: 'pi',
+
+  supports(component) {
+    return component.manifest.targets.includes('pi');
+  },
+
+  async emit(component, ctx) {
+    switch (component.manifest.type) {
+      case 'skill':
+        return emitSkill(component);
+      case 'agent':
+      case 'rules':
+        return emitAgentsMdContribution(component, ctx);
+      case 'plugin':
+        return emitPluginPackage(component, ctx);
+      case 'hook':
+        return emitHookExtension(component);
+      case 'mcp':
+        return emitMcpStub(component);
+      default:
+        throw new Error(`pi adapter: type "${component.manifest.type}" not supported`);
+    }
+  },
+};
+
+// Stubs replaced in Tasks 4-8:
+function emitSkill(_component: ComponentSource): EmittedFile[] {
+  throw new Error('not implemented (Task 4)');
+}
+function emitAgentsMdContribution(
+  _component: ComponentSource,
+  _ctx: AdapterContext,
+): EmittedFile[] {
+  throw new Error('not implemented (Task 5)');
+}
+function emitPluginPackage(
+  _component: ComponentSource,
+  _ctx: AdapterContext,
+): EmittedFile[] {
+  throw new Error('not implemented (Task 6)');
+}
+function emitHookExtension(_component: ComponentSource): EmittedFile[] {
+  throw new Error('not implemented (Task 7)');
+}
+function emitMcpStub(_component: ComponentSource): EmittedFile[] {
+  throw new Error('not implemented (Task 8)');
+}

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
 import { composeAgentsMd } from '../lib/agents-md.ts';
 
@@ -69,10 +70,162 @@ function emitAgentsMdContribution(
   return [{ path: '.pi/AGENTS.md', content }];
 }
 function emitPluginPackage(
-  _component: ComponentSource,
-  _ctx: AdapterContext,
+  component: ComponentSource,
+  ctx: AdapterContext,
 ): EmittedFile[] {
-  throw new Error('not implemented (Task 6)');
+  const { manifest } = component;
+  const pkgDir = manifest.name; // emitted at dist/pi/<pkgDir>/
+  const keyword = (ctx.config?.package_keyword as string | undefined) ?? 'pi-package';
+
+  // Resolve included skills (we only bundle skills; non-skill includes are
+  // flagged by the validator at Plan 1 Task 5, but we tolerate them here by skipping).
+  const includedSkills: ComponentSource[] = [];
+  for (const inc of manifest.includes ?? []) {
+    const resolvedDir = path.normalize(path.join(component.relativeDir, inc));
+    const targetComponent = ctx.allComponents.find((c) => c.relativeDir === resolvedDir);
+    if (targetComponent && targetComponent.manifest.type === 'skill') {
+      includedSkills.push(targetComponent);
+    }
+  }
+
+  const files: EmittedFile[] = [];
+
+  // package.json
+  const pkgJson: Record<string, unknown> = {
+    name: manifest.name,
+    version: manifest.version,
+    description: manifest.description,
+    main: 'src/index.ts',
+    type: 'module',
+  };
+  if (manifest.author) pkgJson.author = manifest.author;
+  if (manifest.license) pkgJson.license = manifest.license;
+  pkgJson.keywords = ['pi', keyword];
+  pkgJson.peerDependencies = { '@mariozechner/pi-coding-agent': '*' };
+  files.push({
+    path: `${pkgDir}/package.json`,
+    content: `${JSON.stringify(pkgJson, null, 2)}\n`,
+  });
+
+  // src/index.ts (extension entrypoint)
+  files.push({
+    path: `${pkgDir}/src/index.ts`,
+    content: renderExtensionEntrypoint(),
+  });
+
+  // README
+  files.push({
+    path: `${pkgDir}/README.md`,
+    content: renderPackageReadme(manifest.name, manifest.description, includedSkills),
+  });
+
+  // Each included skill: re-emit at <pkg>/skills/<skill>/SKILL.md with stripped frontmatter
+  for (const sk of includedSkills) {
+    const fm = ['---', `name: ${sk.manifest.name}`, `description: ${sk.manifest.description}`, '---'].join('\n');
+    files.push({
+      path: `${pkgDir}/skills/${sk.manifest.name}/SKILL.md`,
+      content: `${fm}\n\n${sk.body.trimStart()}`,
+    });
+  }
+
+  return files;
+}
+
+function renderExtensionEntrypoint(): string {
+  return `import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, resolve } from "path";
+
+interface SkillMeta {
+  name: string;
+  description: string;
+  content: string;
+}
+
+function loadSkills(skillsDir: string): SkillMeta[] {
+  if (!existsSync(skillsDir)) return [];
+  const skills: SkillMeta[] = [];
+  for (const dir of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const skillFile = join(skillsDir, dir.name, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
+    const raw = readFileSync(skillFile, "utf-8");
+    const match = raw.match(/^---\\n([\\s\\S]*?)\\n---\\n([\\s\\S]*)$/);
+    if (!match) continue;
+    const frontmatter = match[1];
+    const content = match[2].trim();
+    const name = frontmatter.match(/name:\\s*(.+)/)?.[1]?.trim() || dir.name;
+    const description = frontmatter.match(/description:\\s*(.+)/)?.[1]?.trim() || "";
+    skills.push({ name, description, content });
+  }
+  return skills;
+}
+
+export default function plugin(pi: ExtensionAPI) {
+  const extensionRoot = resolve(__dirname, "..");
+  const skillsDir = join(extensionRoot, "skills");
+  const skills = loadSkills(skillsDir);
+
+  pi.registerCommand("skill", {
+    description: "Invoke a bundled skill by name",
+    getArgumentCompletions: (prefix) =>
+      skills
+        .filter((s) => s.name.startsWith(prefix))
+        .map((s) => ({ value: s.name, label: \`\${s.name} — \${s.description}\` })),
+    handler: async (args, ctx) => {
+      const skillName = args.trim();
+      const skill = skills.find((s) => s.name === skillName);
+      if (!skill) {
+        ctx.ui.notify(\`Skill not found: \${skillName}\`, "error");
+        return;
+      }
+      pi.sendUserMessage(\`Using skill: \${skill.name}\\n\\n\${skill.content}\`, { deliverAs: "steer" });
+    },
+  });
+
+  pi.registerCommand("skills", {
+    description: "List bundled skills",
+    handler: async (_args, ctx) => {
+      const list = skills.map((s) => \`  \${s.name} — \${s.description}\`).join("\\n");
+      ctx.ui.notify(\`Available skills:\\n\${list}\`, "info");
+    },
+  });
+}
+`;
+}
+
+function renderPackageReadme(
+  name: string,
+  description: string,
+  skills: ComponentSource[],
+): string {
+  const rows = skills.map(
+    (s) => `| ${s.manifest.name} | ${s.manifest.description} |`,
+  );
+  return `# ${name}
+
+${description}
+
+## Install
+
+\`\`\`bash
+pi install <git-url>
+\`\`\`
+
+Or add to \`.pi/settings.json\`:
+
+\`\`\`json
+{
+  "extensions": ["<absolute-path>/src/index.ts"]
+}
+\`\`\`
+
+## Skills
+
+| Name | Description |
+|------|-------------|
+${rows.join('\n')}
+`;
 }
 function emitHookExtension(_component: ComponentSource): EmittedFile[] {
   throw new Error('not implemented (Task 7)');

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -26,9 +26,18 @@ export const piAdapter: Adapter = {
   },
 };
 
-// Stubs replaced in Tasks 4-8:
-function emitSkill(_component: ComponentSource): EmittedFile[] {
-  throw new Error('not implemented (Task 4)');
+function emitSkill(component: ComponentSource): EmittedFile[] {
+  const { manifest, body } = component;
+  // Pi skills follow the Agent Skills standard: frontmatter is just
+  // name + description. All other manifest fields are stripped during emission
+  // (version, type, targets, etc. are infrastructure metadata, not skill content).
+  const frontmatter = ['---', `name: ${manifest.name}`, `description: ${manifest.description}`, '---'].join('\n');
+  return [
+    {
+      path: `.pi/skills/${manifest.name}/SKILL.md`,
+      content: `${frontmatter}\n\n${body.trimStart()}`,
+    },
+  ];
 }
 function emitAgentsMdContribution(
   _component: ComponentSource,

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -1,4 +1,5 @@
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
+import { composeAgentsMd } from '../lib/agents-md.ts';
 
 export const piAdapter: Adapter = {
   target: 'pi',
@@ -9,8 +10,14 @@ export const piAdapter: Adapter = {
 
   async emit(component, ctx) {
     switch (component.manifest.type) {
-      case 'skill':
-        return emitSkill(component);
+      case 'skill': {
+        // Pi loads both .pi/skills/*/SKILL.md (canonical skill discovery) and
+        // .pi/AGENTS.md (always-on context). The AGENTS.md `# Skills` section
+        // is a listing for visibility, not the actual skill loader.
+        const skillFiles = emitSkill(component);
+        const agentsMdFiles = emitAgentsMdContribution(component, ctx);
+        return [...skillFiles, ...agentsMdFiles];
+      }
       case 'agent':
       case 'rules':
         return emitAgentsMdContribution(component, ctx);
@@ -40,10 +47,26 @@ function emitSkill(component: ComponentSource): EmittedFile[] {
   ];
 }
 function emitAgentsMdContribution(
-  _component: ComponentSource,
-  _ctx: AdapterContext,
+  component: ComponentSource,
+  ctx: AdapterContext,
 ): EmittedFile[] {
-  throw new Error('not implemented (Task 5)');
+  // Determine the alphabetically-first eligible contributor across rules+agents+skills.
+  // Only that one emits the file; others contribute via the shared composer and return [].
+  const contributors = ctx.allComponents.filter(
+    (c) =>
+      c.manifest.targets.includes('pi') &&
+      (c.manifest.type === 'rules' ||
+        c.manifest.type === 'agent' ||
+        c.manifest.type === 'skill'),
+  );
+  if (contributors.length === 0) return [];
+  const leader = [...contributors].sort((a, b) =>
+    a.manifest.name.localeCompare(b.manifest.name),
+  )[0];
+  if (!leader || leader.manifest.name !== component.manifest.name) return [];
+
+  const content = composeAgentsMd(contributors, 'pi', ctx.config as never);
+  return [{ path: '.pi/AGENTS.md', content }];
 }
 function emitPluginPackage(
   _component: ComponentSource,

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -66,7 +66,11 @@ function emitAgentsMdContribution(
   )[0];
   if (!leader || leader.manifest.name !== component.manifest.name) return [];
 
-  const content = composeAgentsMd(contributors, 'pi', ctx.config as never);
+  const content = composeAgentsMd({
+    target: 'pi',
+    components: ctx.allComponents,
+    sectionOrder: ['rules', 'agents', 'skills'],
+  });
   return [{ path: '.pi/AGENTS.md', content }];
 }
 function emitPluginPackage(

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -358,6 +358,28 @@ events like \`turn_end\`, \`post_tool_use\`, \`session_start\`, etc. — see
 function toCamelCase(s: string): string {
   return s.replace(/-([a-z0-9])/g, (_, ch) => ch.toUpperCase());
 }
-function emitMcpStub(_component: ComponentSource): EmittedFile[] {
-  throw new Error('not implemented (Task 8)');
+// EXPERIMENTAL: Pi has no native MCP support as of pi-coding-agent v0.x
+// (see README §"No MCP"). The format below is a stub for forward-compat; it
+// preserves the canonical source through the build but Pi will not read it.
+// Revise when upstream Pi defines a real MCP format.
+function emitMcpStub(component: ComponentSource): EmittedFile[] {
+  const { manifest } = component;
+  if (!manifest.mcp) return [];
+  const stub = {
+    _note:
+      'EXPERIMENTAL — Pi does not natively support MCP as of this writing (see https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#no-mcp). This file\'s format is pending; it is emitted so the canonical source is preserved across the build, not because Pi reads it. Track upstream Pi MCP support and revise the adapter when the format is defined.',
+    mcpServers: {
+      [manifest.name]: {
+        command: manifest.mcp.command,
+        ...(manifest.mcp.args ? { args: manifest.mcp.args } : {}),
+        ...(manifest.mcp.env ? { env: manifest.mcp.env } : {}),
+      },
+    },
+  };
+  return [
+    {
+      path: '.pi/mcp.experimental.json',
+      content: `${JSON.stringify(stub, null, 2)}\n`,
+    },
+  ];
 }

--- a/apm-builder/tests/adapters/pi-integration.test.ts
+++ b/apm-builder/tests/adapters/pi-integration.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { runBuild } from '../../lib/build.ts';
+
+async function setupRepo(structure: Record<string, string>): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-e2e-'));
+  for (const [rel, content] of Object.entries(structure)) {
+    const full = path.join(tmp, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+  return tmp;
+}
+
+describe('pi adapter end-to-end via runBuild', () => {
+  it('emits a mixed-component repo to dist/pi/', async () => {
+    const repo = await setupRepo({
+      'apm-builder.config.yaml':
+        'pi:\n  package_keyword: pi-package\n  agents_md_section_order: [rules, agents, skills]\n',
+      'skills/foo/SKILL.md':
+        '---\nname: foo\nversion: 1.0.0\ndescription: a skill\ntype: skill\ntargets: [pi]\n---\n\nFoo body.\n',
+      'rules/style/SKILL.md':
+        '---\nname: style\nversion: 1.0.0\ndescription: style rule\ntype: rules\ntargets: [pi]\nscope: project\n---\n\nUse spaces.\n',
+    });
+
+    const result = await runBuild({
+      repoRoot: repo,
+      targets: ['pi'],
+      outDir: 'dist',
+    });
+    expect(result.errors.filter((e) => e.severity === 'error')).toEqual([]);
+
+    const skillOut = await fs.readFile(
+      path.join(repo, 'dist/pi/.pi/skills/foo/SKILL.md'),
+      'utf8',
+    );
+    expect(skillOut).toContain('name: foo');
+    expect(skillOut).toContain('Foo body.');
+
+    const agentsMd = await fs.readFile(path.join(repo, 'dist/pi/.pi/AGENTS.md'), 'utf8');
+    expect(agentsMd).toContain('# Rules');
+    expect(agentsMd).toContain('## style');
+    expect(agentsMd).toContain('# Skills');
+    expect(agentsMd).toContain('## foo');
+  });
+});

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -88,6 +88,11 @@ describe('pi adapter', () => {
     expect(result.diff).toEqual([]);
   });
 
+  it('emits an experimental mcp stub with a pending-format note', async () => {
+    const result = await runGolden(piAdapter, path.join(HERE, 'pi/mcp-stub'));
+    expect(result.diff).toEqual([]);
+  });
+
   it('plugin package.json matches pi-powers shape', async () => {
     const snapshotPkg = JSON.parse(
       await fs.readFile(path.join(HERE, 'pi/_pi-powers-snapshot/package.json'), 'utf8'),

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -83,6 +83,11 @@ describe('pi adapter', () => {
     expect(readme).toContain('| ousterhout |');
   });
 
+  it('emits a TS extension scaffold for hook components', async () => {
+    const result = await runGolden(piAdapter, path.join(HERE, 'pi/hook-extension'));
+    expect(result.diff).toEqual([]);
+  });
+
   it('plugin package.json matches pi-powers shape', async () => {
     const snapshotPkg = JSON.parse(
       await fs.readFile(path.join(HERE, 'pi/_pi-powers-snapshot/package.json'), 'utf8'),

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { piAdapter } from '../../adapters/pi.ts';
+import { runGolden } from './golden.ts';
 
-describe('pi adapter shell', () => {
+const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+describe('pi adapter', () => {
   it('declares target = pi', () => {
     expect(piAdapter.target).toBe('pi');
   });
@@ -20,5 +25,11 @@ describe('pi adapter shell', () => {
       } as never,
     });
     expect(ok).toBe(true);
+  });
+
+  it('emits a skill into .pi/skills/<name>/SKILL.md with stripped frontmatter', async () => {
+    const result = await runGolden(piAdapter, path.join(HERE, 'pi/skill-basic'));
+    expect(result.diff).toEqual([]);
+    expect(result.matched).toBe(true);
   });
 });

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { piAdapter } from '../../adapters/pi.ts';
+
+describe('pi adapter shell', () => {
+  it('declares target = pi', () => {
+    expect(piAdapter.target).toBe('pi');
+  });
+
+  it('supports() honors the targets list', () => {
+    const ok = piAdapter.supports({
+      dir: '/x',
+      relativeDir: 'skills/x',
+      body: '',
+      manifest: {
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['pi'],
+      } as never,
+    });
+    expect(ok).toBe(true);
+  });
+});

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -48,6 +48,51 @@ describe('pi adapter', () => {
     expect(result.matched).toBe(true);
   });
 
+  it('emits a Pi-package directory for plugin components', async () => {
+    const root = path.join(HERE, 'pi/plugin-package');
+    const plugin = await loadComponent(path.join(root, 'component'), root);
+    const skill = await loadComponent(path.join(root, 'sibling-skill'), root);
+    const all = [plugin, skill];
+
+    const emitted = await piAdapter.emit(plugin, {
+      config: { package_keyword: 'pi-package' },
+      allComponents: all,
+      repoRoot: root,
+    });
+    const byPath = new Map(emitted.map((f) => [f.path, f.content.toString()]));
+
+    // package.json
+    const pkg = JSON.parse(byPath.get('superpowers-philosophy/package.json')!);
+    expect(pkg.name).toBe('superpowers-philosophy');
+    expect(pkg.keywords).toEqual(['pi', 'pi-package']);
+    expect(pkg.main).toBe('src/index.ts');
+    expect(pkg.peerDependencies['@mariozechner/pi-coding-agent']).toBe('*');
+
+    // src/index.ts uses ExtensionAPI
+    const idx = byPath.get('superpowers-philosophy/src/index.ts');
+    expect(idx).toContain('@mariozechner/pi-coding-agent');
+    expect(idx).toContain('pi.registerCommand("skill"');
+
+    // included skill copied with stripped frontmatter
+    const skillMd = byPath.get('superpowers-philosophy/skills/ousterhout/SKILL.md');
+    expect(skillMd).toMatch(/^---\nname: ousterhout\ndescription: /);
+    expect(skillMd).toContain('# Ousterhout');
+
+    // README
+    const readme = byPath.get('superpowers-philosophy/README.md');
+    expect(readme).toContain('| ousterhout |');
+  });
+
+  it('plugin package.json matches pi-powers shape', async () => {
+    const snapshotPkg = JSON.parse(
+      await fs.readFile(path.join(HERE, 'pi/_pi-powers-snapshot/package.json'), 'utf8'),
+    );
+    for (const key of ['name', 'version', 'description', 'main', 'type', 'keywords', 'peerDependencies']) {
+      expect(snapshotPkg).toHaveProperty(key);
+    }
+    expect(snapshotPkg.keywords).toContain('pi');
+  });
+
   it('composes rules + agents + skills into .pi/AGENTS.md', async () => {
     const root = path.join(HERE, 'pi/agents-md-compose');
     const components = await Promise.all([

--- a/apm-builder/tests/adapters/pi.test.ts
+++ b/apm-builder/tests/adapters/pi.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import fs from 'node:fs/promises';
+import matter from 'gray-matter';
 import { piAdapter } from '../../adapters/pi.ts';
+import { ManifestSchema } from '../../lib/schema.ts';
+import type { ComponentSource } from '../../lib/types.ts';
 import { runGolden } from './golden.ts';
 
 const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+async function loadComponent(dir: string, repoRoot: string): Promise<ComponentSource> {
+  const raw = await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8');
+  const parsed = matter(raw);
+  return {
+    dir,
+    relativeDir: path.relative(repoRoot, dir),
+    manifest: ManifestSchema.parse(parsed.data),
+    body: parsed.content,
+  };
+}
 
 describe('pi adapter', () => {
   it('declares target = pi', () => {
@@ -31,5 +46,33 @@ describe('pi adapter', () => {
     const result = await runGolden(piAdapter, path.join(HERE, 'pi/skill-basic'));
     expect(result.diff).toEqual([]);
     expect(result.matched).toBe(true);
+  });
+
+  it('composes rules + agents + skills into .pi/AGENTS.md', async () => {
+    const root = path.join(HERE, 'pi/agents-md-compose');
+    const components = await Promise.all([
+      loadComponent(path.join(root, 'components/r-base-style'), root),
+      loadComponent(path.join(root, 'components/r-pr-policy'), root),
+      loadComponent(path.join(root, 'components/a-code-reviewer'), root),
+      loadComponent(path.join(root, 'components/s-tdd'), root),
+    ]);
+
+    const results = await Promise.all(
+      components.map((c) =>
+        piAdapter.emit(c, {
+          config: { agents_md_section_order: ['rules', 'agents', 'skills'] },
+          allComponents: components,
+          repoRoot: root,
+        }),
+      ),
+    );
+    const flat = results.flat();
+    const agentsMd = flat.find((f) => f.path === '.pi/AGENTS.md');
+    const expected = await fs.readFile(path.join(root, 'expected/.pi/AGENTS.md'), 'utf8');
+    expect(agentsMd?.content.toString()).toBe(expected);
+
+    // Idempotent: only one .pi/AGENTS.md should be emitted across all calls.
+    const count = flat.filter((f) => f.path === '.pi/AGENTS.md').length;
+    expect(count).toBe(1);
   });
 });

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/README.md
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/README.md
@@ -1,0 +1,29 @@
+# Pi Powers
+
+[Superpowers](https://github.com/obra/superpowers) ported to [Pi coding agent](https://github.com/badlogic/pi-mono).
+
+12 structured workflow skills that enforce development discipline: TDD, brainstorming, debugging, code review, subagent execution, and more.
+
+## Install
+
+```bash
+pi install /path/to/pi-powers
+```
+
+Or add to `.pi/settings.json`:
+```json
+{
+  "extensions": ["/path/to/pi-powers/src/index.ts"]
+}
+```
+
+## What You Get
+
+**Commands:**
+- `/skill <name>` — invoke a skill by name
+- `/skills` — list all available skills
+
+**Tool:**
+- `use-skill` — the agent can invoke skills programmatically
+
+<!-- TRUNCATED for fixture — see SOURCE.md for canonical reference -->

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/SOURCE.md
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/SOURCE.md
@@ -1,0 +1,20 @@
+# pi-powers snapshot — format reference
+
+Source: https://github.com/danmestas/pi-powers
+Commit: 9a6ca74a232e615dfae807a8ca60cfbe18cf106e
+Captured: 2026-04-26
+Purpose: This directory is a read-only reference for the file layout
+expected by `pi install <pkg>`. The Pi adapter goldens (in sibling
+fixture dirs) emit output that conforms to this shape.
+
+Files retained:
+- package.json — package metadata, "pi" keyword, "main": "src/index.ts"
+- README.md    — install instructions
+- src/index.ts — TypeScript extension entrypoint using ExtensionAPI
+- skills/<name>/SKILL.md — frontmatter (name, description) + markdown body
+
+Skill bodies truncated. Format-relevant fields preserved verbatim.
+
+DO NOT EDIT this directory by hand. Re-run the snapshot procedure in
+the plan (`docs/superpowers/plans/2026-04-26-pi-adapter.md`, Task 1)
+to refresh against a newer pi-powers commit.

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/package.json
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pi-powers",
+  "version": "0.1.0",
+  "description": "Superpowers skills ported to Pi coding agent — TDD, debugging, brainstorming, code review, and structured workflows",
+  "main": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "typescript": "^5.0.0"
+  },
+  "keywords": ["pi", "coding-agent", "superpowers", "skills", "tdd", "debugging"],
+  "license": "MIT"
+}

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/skills/brainstorming/SKILL.md
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/skills/brainstorming/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: brainstorming
+description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+---
+
+# Brainstorming Ideas Into Designs
+
+<!-- TRUNCATED for fixture — frontmatter is the format reference, not body content -->

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/skills/test-driven-development/SKILL.md
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/skills/test-driven-development/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix, before writing implementation code
+---
+
+# Test-Driven Development (TDD)
+
+## Overview
+
+<!-- TRUNCATED for fixture — frontmatter is the format reference, not body content -->

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/snapshot.test.ts
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/snapshot.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+const HERE = path.resolve(fileURLToPath(import.meta.url), '..');
+
+describe('pi-powers snapshot — Pi package format reference', () => {
+  it('package.json declares the "pi" keyword and a "main" entry', async () => {
+    const pkg = JSON.parse(await fs.readFile(path.join(HERE, 'package.json'), 'utf8'));
+    expect(pkg.keywords).toContain('pi');
+    expect(pkg.main).toBe('src/index.ts');
+  });
+
+  it('SKILL.md uses frontmatter with name + description (Claude Code-compatible)', async () => {
+    const skill = await fs.readFile(
+      path.join(HERE, 'skills/test-driven-development/SKILL.md'),
+      'utf8',
+    );
+    expect(skill.startsWith('---\n')).toBe(true);
+    expect(skill).toMatch(/^name:\s*test-driven-development/m);
+    expect(skill).toMatch(/^description:\s*\S/m);
+  });
+
+  it('extension entrypoint imports ExtensionAPI from @mariozechner/pi-coding-agent', async () => {
+    const idx = await fs.readFile(path.join(HERE, 'src/index.ts'), 'utf8');
+    expect(idx).toContain('@mariozechner/pi-coding-agent');
+    expect(idx).toMatch(/ExtensionAPI/);
+  });
+
+  it('skills directory lives at package root (not under .pi/)', async () => {
+    const stat = await fs.stat(path.join(HERE, 'skills'));
+    expect(stat.isDirectory()).toBe(true);
+    const hasPiDir = await fs
+      .stat(path.join(HERE, '.pi'))
+      .then(() => true)
+      .catch(() => false);
+    expect(hasPiDir).toBe(false);
+  });
+});

--- a/apm-builder/tests/adapters/pi/_pi-powers-snapshot/src/index.ts
+++ b/apm-builder/tests/adapters/pi/_pi-powers-snapshot/src/index.ts
@@ -1,0 +1,54 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, resolve } from "path";
+import { Type } from "@sinclair/typebox";
+
+interface SkillMeta {
+  name: string;
+  description: string;
+  content: string;
+}
+
+function loadSkills(skillsDir: string): SkillMeta[] {
+  if (!existsSync(skillsDir)) return [];
+  const skills: SkillMeta[] = [];
+  for (const dir of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const skillFile = join(skillsDir, dir.name, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
+    const raw = readFileSync(skillFile, "utf-8");
+    const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!match) continue;
+    const frontmatter = match[1];
+    const content = match[2].trim();
+    const name = frontmatter.match(/name:\s*(.+)/)?.[1]?.trim() || dir.name;
+    const description = frontmatter.match(/description:\s*(.+)/)?.[1]?.trim() || "";
+    skills.push({ name, description, content });
+  }
+  return skills;
+}
+
+export default function piPowers(pi: ExtensionAPI) {
+  const extensionRoot = resolve(__dirname, "..");
+  const skillsDir = join(extensionRoot, "skills");
+  const skills = loadSkills(skillsDir);
+
+  pi.registerCommand("skill", {
+    description: "Invoke a superpowers skill by name",
+    getArgumentCompletions: (prefix) =>
+      skills
+        .filter((s) => s.name.startsWith(prefix))
+        .map((s) => ({ value: s.name, label: `${s.name} — ${s.description}` })),
+    handler: async (args, ctx) => {
+      const skillName = args.trim();
+      const skill = skills.find((s) => s.name === skillName);
+      if (!skill) {
+        ctx.ui.notify(`Skill not found: ${skillName}`, "error");
+        return;
+      }
+      pi.sendUserMessage(`Using skill: ${skill.name}\n\n${skill.content}`, { deliverAs: "steer" });
+    },
+  });
+
+  // <!-- TRUNCATED for fixture — see SOURCE.md for canonical pi-powers source -->
+}

--- a/apm-builder/tests/adapters/pi/agents-md-compose/components/a-code-reviewer/SKILL.md
+++ b/apm-builder/tests/adapters/pi/agents-md-compose/components/a-code-reviewer/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-reviewer
+version: 1.0.0
+description: Reviews code
+type: agent
+targets: [pi]
+agent:
+  tools: [Read, Grep, Bash]
+---
+
+Review the code for issues.

--- a/apm-builder/tests/adapters/pi/agents-md-compose/components/r-base-style/SKILL.md
+++ b/apm-builder/tests/adapters/pi/agents-md-compose/components/r-base-style/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: base-style
+version: 1.0.0
+description: Base coding style
+type: rules
+targets: [pi]
+scope: project
+---
+
+Use kebab-case directory names.

--- a/apm-builder/tests/adapters/pi/agents-md-compose/components/r-pr-policy/SKILL.md
+++ b/apm-builder/tests/adapters/pi/agents-md-compose/components/r-pr-policy/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pr-policy
+version: 1.0.0
+description: PR rules
+type: rules
+targets: [pi]
+scope: project
+after: [base-style]
+---
+
+Open PRs against main; never push directly.

--- a/apm-builder/tests/adapters/pi/agents-md-compose/components/s-tdd/SKILL.md
+++ b/apm-builder/tests/adapters/pi/agents-md-compose/components/s-tdd/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: tdd
+version: 1.0.0
+description: Test-driven development
+type: skill
+targets: [pi]
+---
+
+Write the test first.

--- a/apm-builder/tests/adapters/pi/agents-md-compose/expected/.pi/AGENTS.md
+++ b/apm-builder/tests/adapters/pi/agents-md-compose/expected/.pi/AGENTS.md
@@ -1,0 +1,21 @@
+# Rules
+
+## base-style
+
+Use kebab-case directory names.
+
+## pr-policy
+
+Open PRs against main; never push directly.
+
+# Agents
+
+## code-reviewer
+
+Review the code for issues.
+
+# Skills
+
+## tdd
+
+Write the test first.

--- a/apm-builder/tests/adapters/pi/hook-extension/component/SKILL.md
+++ b/apm-builder/tests/adapters/pi/hook-extension/component/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: tts-announcer
+version: 1.0.0
+description: Announces task completion via TTS
+type: hook
+targets: [pi]
+hooks:
+  Stop:
+    command: hooks/announce.sh
+  PostToolUse:
+    command: hooks/log.sh
+    matcher: "Bash"
+---
+
+# TTS Announcer
+
+A hook that runs a shell script on task completion.

--- a/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/README.md
+++ b/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/README.md
@@ -1,0 +1,36 @@
+# tts-announcer (Pi extension scaffold)
+
+Announces task completion via TTS
+
+This is an **auto-generated TypeScript extension** for the Pi coding agent.
+Source: `tts-announcer` (type: hook) from the agent-skills monorepo.
+
+## Manual install step required
+
+Pi extensions need a runtime. After this scaffold is emitted, you must run:
+
+```bash
+cd .pi/extensions/tts-announcer
+npm install
+```
+
+Then register the extension in `.pi/settings.json`:
+
+```json
+{
+  "extensions": [".pi/extensions/tts-announcer/index.ts"]
+}
+```
+
+## Customizing
+
+The scaffold registers each Pi event from the source SKILL.md's `hooks:` block.
+Edit `index.ts` to change the behavior. The original shell scripts (if any)
+should be placed under `hooks/` next to `index.ts` and will be invoked via
+`spawn`.
+
+## Why TypeScript?
+
+Pi hooks are programmatic, not JSON-configured. The Pi `ExtensionAPI` exposes
+events like `turn_end`, `post_tool_use`, `session_start`, etc. — see
+[pi-coding-agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#extensions).

--- a/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/index.ts
+++ b/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/index.ts
@@ -1,0 +1,25 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+// Auto-generated from skill component "tts-announcer".
+// Source: see README.md for the canonical SKILL.md path.
+//
+// Pi has no JSON-config hooks; this scaffold registers each declared event
+// programmatically via the ExtensionAPI. Customize the body of each handler
+// or replace the script invocation as needed.
+
+export default function ttsAnnouncerExtension(pi: ExtensionAPI) {
+  pi.on("turn_end", async (event, _ctx) => {
+    // Mirrors source hook: Stop → hooks/announce.sh
+    const script = resolve(__dirname, "hooks/announce.sh");
+    spawn(script, [], { stdio: "inherit" });
+  });
+
+  pi.on("post_tool_use", async (event, _ctx) => {
+    // Mirrors source hook: PostToolUse → hooks/log.sh (matcher: "Bash")
+    if (event.tool !== "Bash") return;
+    const script = resolve(__dirname, "hooks/log.sh");
+    spawn(script, [], { stdio: "inherit" });
+  });
+}

--- a/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/package.json
+++ b/apm-builder/tests/adapters/pi/hook-extension/expected/.pi/extensions/tts-announcer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tts-announcer",
+  "version": "1.0.0",
+  "description": "Announces task completion via TTS",
+  "main": "index.ts",
+  "type": "module",
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  }
+}

--- a/apm-builder/tests/adapters/pi/mcp-stub/component/SKILL.md
+++ b/apm-builder/tests/adapters/pi/mcp-stub/component/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: filesystem-mcp
+version: 1.0.0
+description: Filesystem MCP server (experimental on Pi)
+type: mcp
+targets: [pi]
+mcp:
+  command: node
+  args:
+    - server.js
+  env:
+    LOG_LEVEL: info
+---
+
+# Filesystem MCP
+
+Server description.

--- a/apm-builder/tests/adapters/pi/mcp-stub/expected/.pi/mcp.experimental.json
+++ b/apm-builder/tests/adapters/pi/mcp-stub/expected/.pi/mcp.experimental.json
@@ -1,0 +1,14 @@
+{
+  "_note": "EXPERIMENTAL — Pi does not natively support MCP as of this writing (see https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#no-mcp). This file's format is pending; it is emitted so the canonical source is preserved across the build, not because Pi reads it. Track upstream Pi MCP support and revise the adapter when the format is defined.",
+  "mcpServers": {
+    "filesystem-mcp": {
+      "command": "node",
+      "args": [
+        "server.js"
+      ],
+      "env": {
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}

--- a/apm-builder/tests/adapters/pi/plugin-package/component/SKILL.md
+++ b/apm-builder/tests/adapters/pi/plugin-package/component/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: superpowers-philosophy
+version: 1.0.0
+description: Philosophy skills bundle for Pi
+type: plugin
+targets: [pi]
+includes:
+  - ../sibling-skill
+author: dan@example.com
+license: MIT
+---
+
+# Superpowers Philosophy
+
+Bundle of philosophy skills for Pi.

--- a/apm-builder/tests/adapters/pi/plugin-package/sibling-skill/SKILL.md
+++ b/apm-builder/tests/adapters/pi/plugin-package/sibling-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: ousterhout
+version: 1.0.0
+description: Ousterhout principles
+type: skill
+targets: [pi]
+---
+
+# Ousterhout
+
+Principles.

--- a/apm-builder/tests/adapters/pi/skill-basic/component/SKILL.md
+++ b/apm-builder/tests/adapters/pi/skill-basic/component/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: sample
+version: 1.0.0
+description: A sample skill for Pi adapter testing
+type: skill
+targets:
+  - pi
+---
+
+# Sample
+
+Body content.

--- a/apm-builder/tests/adapters/pi/skill-basic/expected/.pi/AGENTS.md
+++ b/apm-builder/tests/adapters/pi/skill-basic/expected/.pi/AGENTS.md
@@ -1,0 +1,7 @@
+# Skills
+
+## sample
+
+# Sample
+
+Body content.

--- a/apm-builder/tests/adapters/pi/skill-basic/expected/.pi/skills/sample/SKILL.md
+++ b/apm-builder/tests/adapters/pi/skill-basic/expected/.pi/skills/sample/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: sample
+description: A sample skill for Pi adapter testing
+---
+
+# Sample
+
+Body content.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,10 @@
     "verbatimModuleSyntax": true
   },
   "include": ["apm-builder/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "apm-builder/tests/adapters/pi/_pi-powers-snapshot/src/**",
+    "apm-builder/tests/adapters/pi/**/expected/**"
+  ]
 }


### PR DESCRIPTION
## Summary

Implements the Pi coding agent (badlogic/pi-mono) adapter per Plan 6. Format authority: real pi-powers snapshot under `apm-builder/tests/adapters/pi/_pi-powers-snapshot/` (read-only fixture, captured from `danmestas/pi-powers@9a6ca74`).

- Skills emit at `.pi/skills/<name>/SKILL.md`
- Plugin emits npm-publishable Pi-package with `pi-package` keyword (configurable via `pi.package_keyword`)
- Agents/rules/skills compose into `.pi/AGENTS.md` via shared `apm-builder/lib/agents-md.ts`
- Hooks scaffold a TS extension package at `.pi/extensions/<name>/` (with README documenting the manual `npm install`)
- MCP stub with experimental/pending-format comment per spec

## Spec ambiguities flagged

- **Pi MCP** is `⚠️ TBD` per spec and explicitly unsupported by Pi (`pi-coding-agent` README §"No MCP"). Stub format provisional — file emitted at `.pi/mcp.experimental.json` with inline `_note` flagging that Pi will not read it.
- **Hook event-name mapping** (`Stop`→`turn_end`, `PostToolUse`→`post_tool_use`, etc.) is best-effort, centralized in `HOOK_EVENT_MAP` in `apm-builder/adapters/pi.ts`. Revise as Pi's event surface evolves.

## Test plan

- [x] `npx tsc --noEmit` clean, `npm test` passes (57/57 tests)
- [x] Pi-powers snapshot fixture validates package shape against real reference (4 snapshot tests, plus structural assertions in pi.test.ts)
- [ ] Reviewer to spot-check the .pi/extensions/ scaffold output
- [ ] Resolve merge conflicts in `apm-builder/adapters/index.ts`, `lib/agents-md.ts` if Plan 3 (Codex) lands first