### PR TITLE
feat(apm-builder): add category field to SKILL.md schema + tag seed skills

### DIFF
--- a/apm-builder/lib/docs.ts
+++ b/apm-builder/lib/docs.ts
@@ -5,22 +5,54 @@ export const COMPONENTS_BEGIN = '<!-- AUTO-GENERATED: COMPONENTS -->';
 /** Marker that closes the auto-generated component table region. */
 export const COMPONENTS_END = '<!-- /AUTO-GENERATED: COMPONENTS -->';
 
+const TABLE_HEADER = [
+  '| Name | Type | Version | Description | Targets |',
+  '|------|------|---------|-------------|---------|',
+];
+
+const UNCATEGORIZED = 'Uncategorized';
+
+function rowFor(c: ComponentSource): string {
+  const targets = [...c.manifest.targets].sort().join(', ');
+  return `| ${c.manifest.name} | ${c.manifest.type} | ${c.manifest.version} | ${c.manifest.description} | ${targets} |`;
+}
+
 /**
- * Render the components markdown table (header + rows). Excludes the surrounding
- * markers so that callers can splice it inside an existing README between
- * `COMPONENTS_BEGIN` and `COMPONENTS_END`.
+ * Render the components markdown table (header + rows), grouped by
+ * `category.primary`. Components with no category appear under "Uncategorized"
+ * (always rendered last). Within each group rows are sorted alphabetically by
+ * name. Excludes the surrounding markers so that callers can splice the result
+ * between `COMPONENTS_BEGIN` and `COMPONENTS_END`.
  */
 export function renderComponentsTable(components: ComponentSource[]): string {
-  const sorted = [...components].sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
-  const rows = sorted.map((c) => {
-    const targets = [...c.manifest.targets].sort().join(', ');
-    return `| ${c.manifest.name} | ${c.manifest.type} | ${c.manifest.version} | ${c.manifest.description} | ${targets} |`;
-  });
-  return [
-    '| Name | Type | Version | Description | Targets |',
-    '|------|------|---------|-------------|---------|',
-    ...rows,
-  ].join('\n');
+  const groups = new Map<string, ComponentSource[]>();
+  for (const c of components) {
+    const key = c.manifest.category?.primary ?? UNCATEGORIZED;
+    const list = groups.get(key) ?? [];
+    list.push(c);
+    groups.set(key, list);
+  }
+
+  const categoryKeys = [...groups.keys()]
+    .filter((k) => k !== UNCATEGORIZED)
+    .sort();
+  const orderedKeys = groups.has(UNCATEGORIZED)
+    ? [...categoryKeys, UNCATEGORIZED]
+    : categoryKeys;
+
+  const sections: string[] = [];
+  for (const key of orderedKeys) {
+    const rows = (groups.get(key) ?? [])
+      .slice()
+      .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name))
+      .map(rowFor);
+    sections.push(`### ${key}`, '', ...TABLE_HEADER, ...rows);
+    sections.push('');
+  }
+
+  // Trim a single trailing blank to avoid double newlines at the section end.
+  if (sections[sections.length - 1] === '') sections.pop();
+  return sections.join('\n');
 }
 
 /** Default README emitted when no existing README (or no markers) is found. */

--- a/apm-builder/lib/schema.ts
+++ b/apm-builder/lib/schema.ts
@@ -4,6 +4,27 @@ import { COMPONENT_TYPES, TARGETS, type ComponentType, type Target } from './typ
 const SEMVER_RE = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
 const NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+export const CATEGORIES = [
+  'economy',
+  'workflow',
+  'backpressure',
+  'tooling',
+  'integrations',
+  'context-management',
+  'memory-management',
+  'evolution',
+] as const;
+export type Category = typeof CATEGORIES[number];
+
+const CategoryBlock = z
+  .object({
+    primary: z.enum(CATEGORIES as unknown as [Category, ...Category[]]),
+    secondary: z
+      .array(z.enum(CATEGORIES as unknown as [Category, ...Category[]]))
+      .optional(),
+  })
+  .strict();
+
 const HookEntry = z.object({
   command: z.string().min(1),
   matcher: z.string().optional(),
@@ -26,6 +47,7 @@ export const ManifestSchema = z
     name: z.string().regex(NAME_RE, 'name must be kebab-case lowercase'),
     version: z.string().regex(SEMVER_RE, 'version must be valid semver'),
     description: z.string().min(1),
+    category: CategoryBlock.optional(),
     type: z.enum(COMPONENT_TYPES as unknown as [ComponentType, ...ComponentType[]]),
     targets: z.array(z.enum(TARGETS as unknown as [Target, ...Target[]])).min(1),
     author: z.string().optional(),

--- a/apm-builder/lib/types.ts
+++ b/apm-builder/lib/types.ts
@@ -4,6 +4,12 @@ export type ComponentType = typeof COMPONENT_TYPES[number];
 export const TARGETS = ['claude-code', 'apm', 'codex', 'gemini', 'copilot', 'pi'] as const;
 export type Target = typeof TARGETS[number];
 
+// Re-export the Category type so callers depending on `types.ts` get the full
+// public surface in one import. The canonical list lives in `schema.ts` to
+// keep the Zod enum and the TypeScript type derived from a single source.
+export type { Category } from './schema.ts';
+import type { Category } from './schema.ts';
+
 export interface ComponentSource {
   /** Absolute path to the component dir (contains the component's manifest file — typically `SKILL.md`). */
   dir: string;
@@ -27,6 +33,7 @@ export interface ComponentManifest {
   name: string;
   version: string;
   description: string;
+  category?: { primary: Category; secondary?: Category[] };
   type: ComponentType;
   targets: Target[];
   author?: string;

--- a/apm-builder/lib/validate.ts
+++ b/apm-builder/lib/validate.ts
@@ -131,6 +131,19 @@ export function validateComponents(components: ComponentSource[]): ValidationErr
     }
   }
 
+  // Soft nudge: skills missing a category get a warning to encourage tagging.
+  // Not an error — the field is optional during the migration to canonical SKILL.md.
+  for (const c of components) {
+    if (c.manifest.type !== 'skill') continue;
+    if (!c.manifest.category) {
+      errors.push({
+        severity: 'warning',
+        componentName: c.manifest.name,
+        message: 'skill is missing a category — add `category: { primary: <category> }` to frontmatter',
+      });
+    }
+  }
+
   return errors;
 }
 

--- a/apm-builder/tests/build.test.ts
+++ b/apm-builder/tests/build.test.ts
@@ -21,7 +21,7 @@ describe('runBuild', () => {
         '---\nname: sample\nversion: 1.0.0\ndescription: d\ntype: skill\ntargets: [claude-code]\n---\n\nBody.\n',
     });
     const result = await runBuild({ repoRoot: repo, targets: ['claude-code'], outDir: 'dist' });
-    expect(result.errors).toEqual([]);
+    expect(result.errors.filter((e) => e.severity === 'error')).toEqual([]);
     const out = await fs.readFile(
       path.join(repo, 'dist/claude-code/skills/sample/SKILL.md'),
       'utf8',

--- a/apm-builder/tests/docs.test.ts
+++ b/apm-builder/tests/docs.test.ts
@@ -143,3 +143,73 @@ describe('updateReadme', () => {
     expect(md).toContain('| foo |');
   });
 });
+
+describe('renderComponentsTable category grouping', () => {
+  const tooling: ComponentSource = {
+    dir: '/t',
+    relativeDir: 'skills/tooly',
+    body: '',
+    manifest: {
+      name: 'tooly',
+      version: '1.0.0',
+      description: 'A tooling skill',
+      type: 'skill',
+      targets: ['claude-code'],
+      category: { primary: 'tooling' },
+    } as ComponentSource['manifest'],
+  };
+  const backpressure: ComponentSource = {
+    dir: '/b',
+    relativeDir: 'skills/backy',
+    body: '',
+    manifest: {
+      name: 'backy',
+      version: '1.0.0',
+      description: 'A backpressure skill',
+      type: 'skill',
+      targets: ['claude-code'],
+      category: { primary: 'backpressure' },
+    } as ComponentSource['manifest'],
+  };
+  const uncategorized: ComponentSource = {
+    dir: '/u',
+    relativeDir: 'skills/uncatted',
+    body: '',
+    manifest: {
+      name: 'uncatted',
+      version: '1.0.0',
+      description: 'No category',
+      type: 'skill',
+      targets: ['claude-code'],
+    } as ComponentSource['manifest'],
+  };
+
+  it('renders a category heading for each primary group', () => {
+    const md = renderComponentsTable([tooling, backpressure, uncategorized]);
+    expect(md).toMatch(/backpressure/i);
+    expect(md).toMatch(/tooling/i);
+    // Skills without category go under an "Uncategorized" group.
+    expect(md).toMatch(/Uncategorized/i);
+  });
+
+  it('groups primaries alphabetically and uncategorized last', () => {
+    const md = renderComponentsTable([uncategorized, tooling, backpressure]);
+    const idxBack = md.toLowerCase().indexOf('backpressure');
+    const idxTool = md.toLowerCase().indexOf('tooling');
+    const idxUncat = md.toLowerCase().indexOf('uncategorized');
+    expect(idxBack).toBeGreaterThan(-1);
+    expect(idxTool).toBeGreaterThan(idxBack);
+    expect(idxUncat).toBeGreaterThan(idxTool);
+  });
+
+  it('puts each component row under its own primary heading', () => {
+    const md = renderComponentsTable([tooling, backpressure]);
+    const idxBackHeading = md.toLowerCase().indexOf('backpressure');
+    const idxBackyRow = md.indexOf('| backy |');
+    const idxToolHeading = md.toLowerCase().indexOf('tooling');
+    const idxToolyRow = md.indexOf('| tooly |');
+    expect(idxBackHeading).toBeLessThan(idxBackyRow);
+    expect(idxBackyRow).toBeLessThan(idxToolHeading);
+    expect(idxToolHeading).toBeLessThan(idxToolyRow);
+  });
+});

--- a/apm-builder/tests/schema.test.ts
+++ b/apm-builder/tests/schema.test.ts
@@ -57,4 +57,66 @@ describe('ManifestSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  describe('category field', () => {
+    it('accepts manifest with category.primary only', () => {
+      const result = ManifestSchema.safeParse({
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+        category: { primary: 'economy' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts manifest with primary and secondary[]', () => {
+      const result = ManifestSchema.safeParse({
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+        category: { primary: 'tooling', secondary: ['economy'] },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects unknown category value', () => {
+      const result = ManifestSchema.safeParse({
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+        category: { primary: 'not-a-real-category' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects category block without primary', () => {
+      const result = ManifestSchema.safeParse({
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+        category: { secondary: ['economy'] },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown value in secondary array', () => {
+      const result = ManifestSchema.safeParse({
+        name: 'x',
+        version: '1.0.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+        category: { primary: 'tooling', secondary: ['nope'] },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/apm-builder/tests/validate.test.ts
+++ b/apm-builder/tests/validate.test.ts
@@ -20,7 +20,7 @@ function mk(overrides: Partial<ComponentSource['manifest']>): ComponentSource {
 
 describe('validateComponents', () => {
   it('passes for a single valid skill', () => {
-    const errors = validateComponents([mk({})]);
+    const errors = validateComponents([mk({ category: { primary: 'tooling' } })]);
     expect(errors).toEqual([]);
   });
 
@@ -93,6 +93,28 @@ describe('validateComponents', () => {
       mk({ name: 'pl', type: 'plugin', targets: ['claude-code'], includes: [] }),
     ]);
     expect(errors.some((e) => e.severity === 'warning' && /empty includes/i.test(e.message))).toBe(true);
+  });
+});
+
+describe('validateComponents category warnings', () => {
+  it('warns when a skill has no category field', () => {
+    const errors = validateComponents([mk({ name: 'untagged', type: 'skill' })]);
+    const warn = errors.find(
+      (e) => e.severity === 'warning' && /category/i.test(e.message),
+    );
+    expect(warn).toBeDefined();
+    expect(warn!.componentName).toBe('untagged');
+  });
+
+  it('does not warn when a skill has a category', () => {
+    const errors = validateComponents([
+      mk({
+        name: 'tagged',
+        type: 'skill',
+        category: { primary: 'tooling' },
+      }),
+    ]);
+    expect(errors.filter((e) => /category/i.test(e.message))).toEqual([]);
   });
 });
 

--- a/skills/apm-builder/SKILL.md
+++ b/skills/apm-builder/SKILL.md
@@ -7,6 +7,8 @@ description: >
   "init a hook/agent/rules/plugin", "run apm-builder", or any work on the
   multi-harness skill emission pipeline (Claude Code, APM, Codex, Gemini,
   Copilot CLI, Pi targets).
+category:
+  primary: tooling
 type: skill
 targets:
   - claude-code

--- a/skills/cloudflare-email/SKILL.md
+++ b/skills/cloudflare-email/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: cloudflare-email
 description: Use when sending outbound transactional or one-off emails from a Cloudflare-managed domain without running a mail server or paying for a mailbox provider. Triggers on needs to send email programmatically from a custom domain, send-from-my-domain requests, or replacing SMTP relays. Cloudflare Email Service is REST API + Workers only — no SMTP, so it is NOT compatible with Gmail "Send mail as", Outlook, or any SMTP client.
+category:
+  primary: integrations
 ---
 
 # Cloudflare Email Service (Sending)

--- a/skills/dx-audit/SKILL.md
+++ b/skills/dx-audit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: dx-audit
 description: Use when evaluating developer experience or user experience, assessing usability of a CLI/SDK/API/UI, scoring project ergonomics, identifying friction in workflows, or when asked to audit DX or UX. Triggers on "DX score", "UX audit", "developer experience", "user experience", "workflow friction", "usability audit", "how hard is it to use this".
+category:
+  primary: backpressure
 ---
 
 # Experience Audit (DX / UX)

--- a/skills/gh-project-shared/SKILL.md
+++ b/skills/gh-project-shared/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: gh-project-shared
 description: "Shared utilities for GitHub project management. Not directly invoked by agents. Provides: gh CLI validation, authentication checking, config file management (.github/project-config.json), context detection for template suggestions, and error handling with logging."
+category:
+  primary: integrations
 ---
 
 # GitHub Project Management - Shared Utilities

--- a/skills/hipp/SKILL.md
+++ b/skills/hipp/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: hipp
 description: Use when designing libraries, modules, or data layers that must be simple, reliable, and self-contained. Use when choosing between embedded vs server-based solutions. Use when reviewing code for unnecessary complexity, dependencies, or configuration. Triggers on requests involving zero-config design, embedded systems, long-term maintainability, or first-principles thinking.
+category:
+  primary: backpressure
 ---
 
 # Hipp's Philosophy of Software Design

--- a/skills/idiomatic-go/SKILL.md
+++ b/skills/idiomatic-go/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: idiomatic-go
 description: Use when writing, reviewing, or refactoring Go code. Triggers on .go files, go.mod presence, or any task involving Go programming. Also use when reviewing Go code for idiomaticity, error handling, concurrency patterns, or interface design.
+category:
+  primary: backpressure
 ---
 
 # Idiomatic Go

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: knowledge-base
 description: Use when building, maintaining, ingesting into, querying, or health-checking a markdown knowledge base or wiki. Use when the user wants to compile sources into structured knowledge, maintain an Obsidian wiki, ingest documents, ask questions against accumulated research, or run health checks on interlinked markdown pages. Triggers on requests involving knowledge bases, wiki maintenance, source ingestion, research compilation, Obsidian wiki workflows, or LLM-maintained documentation.
+category:
+  primary: memory-management
 ---
 
 # Knowledge Base

--- a/skills/linear-method/SKILL.md
+++ b/skills/linear-method/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: linear-method
 description: Use when creating, organizing, or prioritizing issues in Linear. Use when managing backlogs, setting up cycles, scoping projects, writing issue titles/descriptions, or deciding how to structure work in Linear. Also use when asked about Linear best practices.
+category:
+  primary: integrations
 ---
 
 # Linear Method — Best Practices for AI Agents

--- a/skills/mgrep-code-search/SKILL.md
+++ b/skills/mgrep-code-search/SKILL.md
@@ -5,6 +5,8 @@ description: >
   when searching or exploring codebases with more than 30 non-gitignored files and/or nested
   directory structures. It provides natural language semantic search that complements traditional
   grep/ripgrep for finding features, understanding intent, and exploring unfamiliar code.
+category:
+  primary: tooling
 ---
 
 # mgrep Code Search

--- a/skills/norman/SKILL.md
+++ b/skills/norman/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: norman
 description: Use when designing, reviewing, or auditing user interfaces and frontend interactions. Use when evaluating UI usability, accessibility, or interaction patterns. Triggers on requests involving button placement, form design, navigation, error messages, onboarding flows, modal dialogs, or when asked to review a UI for usability.
+category:
+  primary: backpressure
 ---
 
 # Norman's Principles of Interaction Design

--- a/skills/ousterhout/SKILL.md
+++ b/skills/ousterhout/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ousterhout
 description: Use when designing modules, classes, APIs, or system architecture. Use when reviewing or refactoring code for complexity. Use when choosing between implementation approaches. Triggers on requests involving abstraction design, interface simplicity, information hiding, or reducing cognitive load.
+category:
+  primary: backpressure
 ---
 
 # Ousterhout's Philosophy of Software Design

--- a/skills/tigerstyle/SKILL.md
+++ b/skills/tigerstyle/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: tigerstyle
 description: Use when writing safety-critical code, systems programming, infrastructure, or when a project needs rigorous coding discipline. Triggers include requests for defensive coding, assertion-heavy development, performance-conscious design, zero-technical-debt policy, or NASA Power of Ten style rules. Also use when reviewing code for correctness, safety, or performance issues.
+category:
+  primary: backpressure
 ---
 
 # TigerStyle


### PR DESCRIPTION
## Summary

Adds a `category` block to the SKILL.md frontmatter schema (primary + optional secondary[]), updates docs.ts to group the README catalog by primary category, and tags 12 seed skills.

- 8 category enum: economy, workflow, backpressure, tooling, integrations, context-management, memory-management, evolution
- Optional field — existing skills without it work unchanged (warning emitted)
- Validator surfaces a warning when category is missing (soft nudge to tag)
- Retags 12 seed skills (philosophy + tooling + integrations + memory)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — schema and docs tests cover the new field
- [ ] Reviewer to confirm seed mappings match intent
- [ ] Subsequent PR will tag remaining skills