### PR TITLE
feat: apm-builder evolve — Evolution category implementation

### DIFF
--- a/apm-builder/cli.ts
+++ b/apm-builder/cli.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { defineCommand, runMain } from 'citty';
 import pc from 'picocolors';
@@ -10,6 +11,8 @@ import { matchesGlob } from './lib/glob.ts';
 import { updateReadme } from './lib/docs.ts';
 import { TARGETS, type Target } from './lib/types.ts';
 import { listImplementedTargets } from './adapters/index.ts';
+import { runEvolution } from './lib/evolution/orchestrator.ts';
+import { renderReport } from './lib/evolution/render.ts';
 
 const validateCmd = defineCommand({
   meta: { name: 'validate', description: 'Validate all components' },
@@ -172,9 +175,60 @@ Describe what this ${args.type} does and how to use it.
   },
 });
 
+const evolveCmd = defineCommand({
+  meta: { name: 'evolve', description: 'Detect friction patterns in session history; emit a markdown report with proposed diffs' },
+  args: {
+    since: { type: 'string', default: '7d', description: 'Time window (e.g. 7d, 14d, 30d)' },
+    project: { type: 'string', default: 'agent-skills', description: 'Project name (matches ~/.claude/projects/<name>)' },
+    'no-llm': { type: 'boolean', default: false, description: 'Disable Haiku calls; deterministic-only' },
+    'include-arcs': { type: 'boolean', default: false, description: 'Include arc-driven proposals (slower)' },
+    'dry-run': { type: 'boolean', default: false, description: 'Detect but skip writing the report file' },
+    json: { type: 'boolean', default: false, description: 'Print JSON instead of writing markdown' },
+  },
+  async run({ args }) {
+    const sinceMs = parseDuration(args.since);
+    const report = await runEvolution({
+      repoRoot: process.cwd(),
+      project: args.project,
+      sinceMs,
+      noLlm: args['no-llm'],
+      includeArcs: args['include-arcs'],
+      dryRun: args['dry-run'],
+      json: args.json,
+    });
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    const md = renderReport(report);
+    if (args['dry-run']) {
+      console.log(md);
+      return;
+    }
+    const reportDir = path.join(os.homedir(), '.claude', 'evolution-reports', args.project);
+    await fs.mkdir(reportDir, { recursive: true });
+    const date = new Date().toISOString().slice(0, 10);
+    const reportPath = path.join(reportDir, `${date}.md`);
+    await fs.writeFile(reportPath, md);
+    console.log(pc.green(`evolution report written: ${reportPath}`));
+    console.log(pc.cyan(`${report.findings.length} finding(s); cost: $${report.llmCostUsd.toFixed(2)}`));
+  },
+});
+
 const main = defineCommand({
   meta: { name: 'apm-builder', description: 'Multi-harness skills build tool' },
-  subCommands: { validate: validateCmd, build: buildCmd, watch: watchCmd, docs: docsCmd, init: initCmd },
+  subCommands: { validate: validateCmd, build: buildCmd, watch: watchCmd, docs: docsCmd, init: initCmd, evolve: evolveCmd },
 });
 
 runMain(main);
+
+function parseDuration(s: string): number {
+  const m = /^(\d+)([dhm])$/.exec(s);
+  if (!m) throw new Error(`invalid duration: ${s}`);
+  const n = Number(m[1]!);
+  const unit = m[2]!;
+  if (unit === 'd') return n * 86_400_000;
+  if (unit === 'h') return n * 3_600_000;
+  if (unit === 'm') return n * 60_000;
+  throw new Error(`unknown unit: ${unit}`);
+}

--- a/apm-builder/lib/evolution/memory.ts
+++ b/apm-builder/lib/evolution/memory.ts
@@ -1,0 +1,55 @@
+// apm-builder/lib/evolution/memory.ts
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Finding } from './types.ts';
+
+const PATH_REGEX = /`([a-zA-Z0-9_\-./]+\.(?:ts|js|md|json|yml|yaml|sh|go|py))`/g;
+
+export async function detectStaleMemoryRefs(
+  memoryDir: string,
+  repoRoot: string,
+): Promise<Finding[]> {
+  const exists = await fs.stat(memoryDir).then(() => true).catch(() => false);
+  if (!exists) return [];
+
+  const entries = await fs.readdir(memoryDir, { withFileTypes: true });
+  const findings: Finding[] = [];
+  let idx = 1;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const filePath = path.join(memoryDir, entry.name);
+    const content = await fs.readFile(filePath, 'utf8');
+    const matches = [...content.matchAll(PATH_REGEX)];
+    for (const m of matches) {
+      const ref = m[1]!;
+      const absoluteCandidate = path.isAbsolute(ref) ? ref : path.join(repoRoot, ref);
+      const refExists = await fs.stat(absoluteCandidate).then(() => true).catch(() => false);
+      if (refExists) continue;
+      findings.push({
+        id: `F-MEM-${String(idx).padStart(3, '0')}`,
+        patternType: 'memory-stale-ref',
+        severity: 'low',
+        count: 1,
+        evidence: [`> ${entry.name}: dead reference \`${ref}\``],
+        proposedDiff: {
+          targetPath: filePath,
+          diff: buildDeleteRefDiff(filePath, ref),
+          summary: `Remove dead reference \`${ref}\` from ${entry.name}`,
+        },
+      });
+      idx += 1;
+    }
+  }
+  return findings;
+}
+
+function buildDeleteRefDiff(targetPath: string, ref: string): string {
+  return [
+    `--- a/${targetPath}`,
+    `+++ b/${targetPath}`,
+    `@@ stale-ref @@`,
+    `-Reference to \`${ref}\` (file does not exist)`,
+    '',
+  ].join('\n');
+}

--- a/apm-builder/lib/evolution/orchestrator.ts
+++ b/apm-builder/lib/evolution/orchestrator.ts
@@ -1,0 +1,58 @@
+// apm-builder/lib/evolution/orchestrator.ts
+import path from 'node:path';
+import os from 'node:os';
+import { loadSessionsSince } from './sessions.ts';
+import { detectPermissionPrompts } from './permissions.ts';
+import { detectStaleMemoryRefs } from './memory.ts';
+import { redact } from './redact.ts';
+import type { EvolutionReport, EvolveOptions, Finding } from './types.ts';
+
+export interface OrchestratorOptions extends EvolveOptions {
+  /** Override default sessions dir (used by tests). */
+  sessionsDir?: string;
+  /** Override default memory dir (used by tests). */
+  memoryDir?: string;
+}
+
+export async function runEvolution(opts: OrchestratorOptions): Promise<EvolutionReport> {
+  const sessionsDir =
+    opts.sessionsDir ?? path.join(os.homedir(), '.claude', 'projects', opts.project, 'sessions');
+  const memoryDir =
+    opts.memoryDir ?? path.join(os.homedir(), '.claude', 'projects', opts.project, 'memory');
+
+  const since = new Date(Date.now() - opts.sinceMs);
+  const sessions = await loadSessionsSince(sessionsDir, since);
+
+  const findings: Finding[] = [];
+  findings.push(...detectPermissionPrompts(sessions));
+  findings.push(...(await detectStaleMemoryRefs(memoryDir, opts.repoRoot)));
+
+  // Future: meta-scout signals + arcs go here. Skipped in v1 because the
+  // upstream `evolution-engine` library publish is gated on a separate PR.
+
+  // Redact every evidence string and diff.
+  for (const f of findings) {
+    f.evidence = f.evidence.map(redact);
+    if (f.proposedDiff) f.proposedDiff.diff = redact(f.proposedDiff.diff);
+  }
+
+  // Dedupe by (patternType, proposedDiff.targetPath, proposedDiff.summary).
+  const seen = new Set<string>();
+  const deduped: Finding[] = [];
+  for (const f of findings) {
+    const key = `${f.patternType}::${f.proposedDiff?.targetPath ?? ''}::${f.proposedDiff?.summary ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(f);
+  }
+
+  const windowEnd = new Date();
+  return {
+    project: opts.project,
+    windowStart: since,
+    windowEnd,
+    sessionsScanned: sessions.length,
+    llmCostUsd: opts.noLlm ? 0 : 0, // updated when LLM-using detectors land
+    findings: deduped,
+  };
+}

--- a/apm-builder/lib/evolution/permissions.ts
+++ b/apm-builder/lib/evolution/permissions.ts
@@ -1,0 +1,81 @@
+import type { LoadedSession } from './sessions.ts';
+import type { Finding, Severity } from './types.ts';
+
+const APPROVAL_THRESHOLD = 5;
+
+interface PermEvent {
+  tool: string;
+  command: string;
+  decision: 'approve' | 'deny' | string;
+  sessionId: string;
+  timestamp?: string;
+}
+
+function severityOf(count: number): Severity {
+  if (count >= 5) return 'high';
+  if (count >= 3) return 'medium';
+  return 'low';
+}
+
+function canonicalize(tool: string, input: unknown): string {
+  if (tool === 'Bash' && typeof input === 'object' && input !== null && 'command' in input) {
+    return String((input as { command: unknown }).command).trim();
+  }
+  return `${tool}:${JSON.stringify(input)}`;
+}
+
+export function detectPermissionPrompts(sessions: LoadedSession[]): Finding[] {
+  const counts = new Map<string, { approve: number; deny: number; events: PermEvent[] }>();
+
+  for (const session of sessions) {
+    for (const ev of session.events) {
+      if (ev.type !== 'permission-request') continue;
+      const tool = ev.tool ?? '';
+      const key = canonicalize(tool, ev.input);
+      const bucket = counts.get(key) ?? { approve: 0, deny: 0, events: [] };
+      if (ev.decision === 'approve') bucket.approve += 1;
+      else if (ev.decision === 'deny') bucket.deny += 1;
+      bucket.events.push({
+        tool,
+        command: key,
+        decision: ev.decision ?? '',
+        sessionId: session.sessionId,
+        timestamp: ev.timestamp,
+      });
+      counts.set(key, bucket);
+    }
+  }
+
+  const findings: Finding[] = [];
+  let idx = 1;
+  for (const [key, bucket] of counts.entries()) {
+    if (bucket.approve < APPROVAL_THRESHOLD || bucket.deny > 0) continue;
+    const finding: Finding = {
+      id: `F-${String(idx).padStart(3, '0')}`,
+      patternType: 'permission-prompt-recurring',
+      severity: severityOf(bucket.approve),
+      count: bucket.approve,
+      evidence: bucket.events
+        .slice(0, 3)
+        .map((e) => `> ${e.sessionId} @ ${e.timestamp ?? '?'}: \`${key}\` (${e.decision})`),
+      proposedDiff: {
+        targetPath: '.claude/settings.json',
+        diff: buildAllowlistDiff(key),
+        summary: `Add \`${key}\` to permissions.allow[] (approved ${bucket.approve}× with 0 denials)`,
+      },
+    };
+    findings.push(finding);
+    idx += 1;
+  }
+  return findings;
+}
+
+function buildAllowlistDiff(canonicalCommand: string): string {
+  return [
+    '--- a/.claude/settings.json',
+    '+++ b/.claude/settings.json',
+    '@@ permissions.allow @@',
+    `+    "${canonicalCommand}"`,
+    '',
+  ].join('\n');
+}

--- a/apm-builder/lib/evolution/redact.ts
+++ b/apm-builder/lib/evolution/redact.ts
@@ -1,0 +1,17 @@
+// apm-builder/lib/evolution/redact.ts
+const PATTERNS: { re: RegExp; label: string }[] = [
+  { re: /sk-ant-[a-zA-Z0-9_-]{15,}/g, label: 'ANTHROPIC_KEY' },
+  { re: /ghp_[a-zA-Z0-9]{15,}/g, label: 'GITHUB_PAT' },
+  { re: /sk-[a-zA-Z0-9]{20,}/g, label: 'OPENAI_KEY' },
+  { re: /xox[bsap]-[a-zA-Z0-9-]{10,}/g, label: 'SLACK_TOKEN' },
+  { re: /AKIA[0-9A-Z]{16}/g, label: 'AWS_ACCESS_KEY' },
+  { re: /\/Users\/[^/]+\/(?:Downloads|Desktop)\/[^\s)]+/g, label: 'PRIVATE_PATH' },
+];
+
+export function redact(input: string): string {
+  let out = input;
+  for (const { re, label } of PATTERNS) {
+    out = out.replace(re, `<REDACTED:${label}>`);
+  }
+  return out;
+}

--- a/apm-builder/lib/evolution/relevant-skill.ts
+++ b/apm-builder/lib/evolution/relevant-skill.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import Anthropic from '@anthropic-ai/sdk';
+import type { SkillEntry } from './types.ts';
+
+export interface CatalogPaths {
+  repoLocal?: string;
+  home?: string;
+  pluginsCache?: string;
+}
+
+export async function scanSkillCatalog(paths: CatalogPaths): Promise<SkillEntry[]> {
+  const ordered = [paths.repoLocal, paths.home, paths.pluginsCache].filter(Boolean) as string[];
+  const seen = new Map<string, SkillEntry>();
+  for (const root of ordered) {
+    const entries = await scanDir(root);
+    for (const entry of entries) {
+      if (!seen.has(entry.name)) seen.set(entry.name, entry);
+    }
+  }
+  return [...seen.values()];
+}
+
+async function scanDir(root: string): Promise<SkillEntry[]> {
+  const exists = await fs
+    .stat(root)
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) return [];
+  const out: SkillEntry[] = [];
+  const subs = await fs.readdir(root, { withFileTypes: true });
+  for (const sub of subs) {
+    if (!sub.isDirectory()) continue;
+    const skillPath = path.join(root, sub.name, 'SKILL.md');
+    const skillExists = await fs
+      .stat(skillPath)
+      .then(() => true)
+      .catch(() => false);
+    if (!skillExists) continue;
+    const raw = await fs.readFile(skillPath, 'utf8');
+    const parsed = matter(raw);
+    const data = parsed.data as {
+      name?: string;
+      description?: string;
+      category?: { primary?: string };
+    };
+    if (typeof data.name === 'string' && typeof data.description === 'string') {
+      out.push({
+        name: data.name,
+        description: data.description,
+        filePath: skillPath,
+        category: data.category?.primary,
+      });
+    }
+  }
+  return out;
+}
+
+export interface RelevantSkillQuery {
+  /** Cluster evidence — quoted snippets of the friction. */
+  evidence: string[];
+  /** All known skills. */
+  catalog: SkillEntry[];
+}
+
+export interface RelevantSkillResult {
+  /** Name of the matched skill, or null if no good match. */
+  skill: string | null;
+  /** 0-1 confidence. */
+  confidence: number;
+  /** One-sentence rationale. */
+  reasoning: string;
+}
+
+/** Live Anthropic call. Tests stub this via dependency injection or just skip with --no-llm. */
+export async function determineRelevantSkill(
+  query: RelevantSkillQuery,
+  apiKey: string,
+): Promise<RelevantSkillResult> {
+  const client = new Anthropic({ apiKey });
+  const catalogText = query.catalog
+    .map((s) => `- ${s.name}: ${s.description.slice(0, 200)}`)
+    .join('\n');
+  const evidence = query.evidence.join('\n');
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 256,
+    messages: [
+      {
+        role: 'user',
+        content: `Below is friction evidence from agent sessions, followed by the skill catalog.\n\nWhich skill, if any, owns this concern? Return strict JSON: {"skill":"<name|null>","confidence":0.0,"reasoning":"..."}.\n\nEvidence:\n${evidence}\n\nCatalog:\n${catalogText}`,
+      },
+    ],
+  });
+  const text = response.content
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { text: string }).text)
+    .join('');
+  try {
+    const parsed = JSON.parse(text);
+    return {
+      skill: typeof parsed.skill === 'string' ? parsed.skill : null,
+      confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
+      reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : '',
+    };
+  } catch {
+    return { skill: null, confidence: 0, reasoning: 'parse-failure' };
+  }
+}

--- a/apm-builder/lib/evolution/render.ts
+++ b/apm-builder/lib/evolution/render.ts
@@ -1,0 +1,68 @@
+import type { EvolutionReport, Finding, Severity } from './types.ts';
+
+const SEVERITY_RANK: Record<Severity, number> = { high: 0, medium: 1, low: 2 };
+
+export function renderReport(report: EvolutionReport): string {
+  const sorted = [...report.findings].sort(
+    (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity],
+  );
+  const window = `${report.windowStart.toISOString().slice(0, 10)} → ${report.windowEnd
+    .toISOString()
+    .slice(0, 10)}`;
+
+  const lines: string[] = [
+    `# Evolution Report — ${report.project}`,
+    '',
+    `**Window:** ${window} (${report.sessionsScanned} sessions)`,
+    `Cost (USD): $${report.llmCostUsd.toFixed(2)}`,
+    '',
+    '## Summary',
+    '',
+    '| Pattern | Count | Severity | Top fix |',
+    '|---------|-------|----------|---------|',
+  ];
+
+  // Group by patternType for the summary table.
+  const byPattern = new Map<string, Finding[]>();
+  for (const f of sorted) {
+    const list = byPattern.get(f.patternType) ?? [];
+    list.push(f);
+    byPattern.set(f.patternType, list);
+  }
+  for (const [pattern, items] of byPattern.entries()) {
+    const top = items[0]!;
+    const fix = top.proposedDiff?.summary ?? '(surface-only)';
+    lines.push(`| ${pattern} | ${items.length} | ${top.severity} | ${fix} |`);
+  }
+  lines.push('', '## Findings', '');
+
+  for (const f of sorted) {
+    lines.push(`## ${f.id}`);
+    lines.push('');
+    lines.push(`- **Pattern:** ${f.patternType}`);
+    lines.push(`- **Severity:** ${f.severity} (count: ${f.count})`);
+    lines.push('');
+    lines.push('### Evidence');
+    lines.push('');
+    for (const ev of f.evidence) lines.push(ev);
+    lines.push('');
+    if (f.proposedDiff) {
+      lines.push('### Proposed fix');
+      lines.push('');
+      lines.push(`**Target:** \`${f.proposedDiff.targetPath}\``);
+      lines.push('');
+      lines.push(f.proposedDiff.summary);
+      lines.push('');
+      lines.push('```diff');
+      lines.push(f.proposedDiff.diff.trimEnd());
+      lines.push('```');
+      lines.push('');
+    } else {
+      lines.push('### Note');
+      lines.push('');
+      lines.push('Surface-only finding — no proposed diff. Consider manually.');
+      lines.push('');
+    }
+  }
+  return lines.join('\n');
+}

--- a/apm-builder/lib/evolution/sessions.ts
+++ b/apm-builder/lib/evolution/sessions.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { SessionEvent } from './types.ts';
+
+export interface LoadedSession {
+  sessionId: string;
+  filePath: string;
+  events: SessionEvent[];
+  earliestTimestamp: Date;
+  latestTimestamp: Date;
+}
+
+export async function loadSessionsSince(
+  sessionsDir: string,
+  since: Date,
+): Promise<LoadedSession[]> {
+  const exists = await fs.stat(sessionsDir).then(() => true).catch(() => false);
+  if (!exists) return [];
+
+  const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  const jsonlFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.jsonl'))
+    .map((e) => path.join(sessionsDir, e.name));
+
+  const result: LoadedSession[] = [];
+  for (const file of jsonlFiles) {
+    const events = await parseJsonl(file);
+    if (events.length === 0) continue;
+    const timestamps = events
+      .map((ev) => (ev.timestamp ? new Date(ev.timestamp) : null))
+      .filter((t): t is Date => t !== null && !Number.isNaN(t.getTime()));
+    if (timestamps.length === 0) continue;
+    const latest = new Date(Math.max(...timestamps.map((t) => t.getTime())));
+    if (latest < since) continue;
+    const earliest = new Date(Math.min(...timestamps.map((t) => t.getTime())));
+    const sessionId = events[0]?.sessionId ?? path.basename(file, '.jsonl');
+    result.push({
+      sessionId,
+      filePath: file,
+      events,
+      earliestTimestamp: earliest,
+      latestTimestamp: latest,
+    });
+  }
+  return result;
+}
+
+async function parseJsonl(filePath: string): Promise<SessionEvent[]> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  const out: SessionEvent[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      if (obj && typeof obj === 'object') out.push(obj as SessionEvent);
+    } catch {
+      // Skip malformed lines silently for v1 — could surface counts later.
+    }
+  }
+  return out;
+}

--- a/apm-builder/lib/evolution/types.ts
+++ b/apm-builder/lib/evolution/types.ts
@@ -1,0 +1,77 @@
+import type { ComponentSource } from '../types.ts';
+
+/** Event from a JSONL transcript. Subset we care about for v1 detectors. */
+export interface SessionEvent {
+  type?: string;
+  sessionId?: string;
+  timestamp?: string;
+  message?: { content?: unknown };
+  // permission events:
+  tool?: string;
+  input?: unknown;
+  decision?: string;
+}
+
+/** Severity tier — frequency-based per the spec (low <3, medium 3-5, high >5). */
+export type Severity = 'low' | 'medium' | 'high';
+
+/** What pattern type produced this finding. */
+export type PatternType =
+  | 'permission-prompt-recurring'
+  | 'memory-stale-ref'
+  | 'correction-cluster'
+  | 'edit-thrashing'
+  | 'error-loop'
+  | 'arc-cluster';
+
+/** A unified diff against a target file. */
+export interface ProposedDiff {
+  /** Absolute or repo-relative path of the file to patch. */
+  targetPath: string;
+  /** Unified-diff content (--- a/file +++ b/file ... @@ ...). */
+  diff: string;
+  /** One-line human summary of what the diff does. */
+  summary: string;
+}
+
+/** A single detection result. */
+export interface Finding {
+  id: string; // e.g., 'F-001'
+  patternType: PatternType;
+  severity: Severity;
+  /** Frequency or count behind the severity. */
+  count: number;
+  /** Quoted/redacted evidence rendered as markdown blockquote chunks. */
+  evidence: string[];
+  /** Optional proposed fix. Some findings (e.g., high-level signals like restart-cluster) may be surface-only. */
+  proposedDiff?: ProposedDiff;
+}
+
+/** The full report produced by orchestrator. */
+export interface EvolutionReport {
+  project: string;
+  windowStart: Date;
+  windowEnd: Date;
+  sessionsScanned: number;
+  llmCostUsd: number;
+  findings: Finding[];
+}
+
+/** Skill catalog entry used by relevant-skill.ts. */
+export interface SkillEntry {
+  name: string;
+  description: string;
+  filePath: string; // absolute path to the SKILL.md
+  category?: string;
+}
+
+/** Options the CLI passes into the orchestrator. */
+export interface EvolveOptions {
+  repoRoot: string;
+  project: string;
+  sinceMs: number; // Date.now() - sinceMs is the window start
+  noLlm: boolean;
+  includeArcs: boolean;
+  dryRun: boolean;
+  json: boolean;
+}

--- a/apm-builder/tests/evolution/fixtures/memory/MEMORY.md
+++ b/apm-builder/tests/evolution/fixtures/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory Index
+
+- [Old branch reference](feedback_old_branch.md) — references a deleted branch
+- [Existing valid file](feedback_old_branch.md) — second pointer (still valid)

--- a/apm-builder/tests/evolution/fixtures/memory/feedback_old_branch.md
+++ b/apm-builder/tests/evolution/fixtures/memory/feedback_old_branch.md
@@ -1,0 +1,6 @@
+---
+name: Old branch reference
+type: feedback
+---
+
+The fix lives at `apm-builder/lib/missing-file.ts`. See branch `feat/never-existed`.

--- a/apm-builder/tests/evolution/fixtures/sessions/permission-recurring.jsonl
+++ b/apm-builder/tests/evolution/fixtures/sessions/permission-recurring.jsonl
@@ -1,0 +1,7 @@
+{"type":"user","sessionId":"sess-perm","timestamp":"2026-04-25T10:00:00Z","message":{"content":[{"type":"text","text":"deploy please"}]}}
+{"type":"assistant","sessionId":"sess-perm","timestamp":"2026-04-25T10:00:05Z","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"permission-request","sessionId":"sess-perm","timestamp":"2026-04-25T10:00:06Z","tool":"Bash","input":{"command":"npm test"},"decision":"approve"}
+{"type":"permission-request","sessionId":"sess-perm","timestamp":"2026-04-25T10:01:00Z","tool":"Bash","input":{"command":"npm test"},"decision":"approve"}
+{"type":"permission-request","sessionId":"sess-perm","timestamp":"2026-04-25T10:02:00Z","tool":"Bash","input":{"command":"npm test"},"decision":"approve"}
+{"type":"permission-request","sessionId":"sess-perm","timestamp":"2026-04-25T10:03:00Z","tool":"Bash","input":{"command":"npm test"},"decision":"approve"}
+{"type":"permission-request","sessionId":"sess-perm","timestamp":"2026-04-25T10:04:00Z","tool":"Bash","input":{"command":"npm test"},"decision":"approve"}

--- a/apm-builder/tests/evolution/fixtures/sessions/sample-session.jsonl
+++ b/apm-builder/tests/evolution/fixtures/sessions/sample-session.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","sessionId":"sess-1","timestamp":"2026-04-25T10:00:00Z","message":{"content":[{"type":"text","text":"Add a new validation rule"}]}}
+{"type":"assistant","sessionId":"sess-1","timestamp":"2026-04-25T10:00:05Z","message":{"content":[{"type":"text","text":"On it."}]}}
+{"type":"user","sessionId":"sess-1","timestamp":"2026-04-25T10:01:00Z","message":{"content":[{"type":"text","text":"Add another rule"}]}}

--- a/apm-builder/tests/evolution/memory.test.ts
+++ b/apm-builder/tests/evolution/memory.test.ts
@@ -1,0 +1,26 @@
+// apm-builder/tests/evolution/memory.test.ts
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { detectStaleMemoryRefs } from '../../lib/evolution/memory.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MEMORY_DIR = path.join(HERE, 'fixtures/memory');
+const REPO_ROOT = path.resolve(HERE, '../../..'); // agent-skills root
+
+describe('detectStaleMemoryRefs', () => {
+  it('flags a path reference that does not exist', async () => {
+    const findings = await detectStaleMemoryRefs(MEMORY_DIR, REPO_ROOT);
+    const pathFinding = findings.find((f) =>
+      f.evidence.some((e) => e.includes('apm-builder/lib/missing-file.ts')),
+    );
+    expect(pathFinding).toBeDefined();
+    expect(pathFinding?.severity).toBe('low'); // single occurrence
+    expect(pathFinding?.proposedDiff?.targetPath).toMatch(/feedback_old_branch\.md$/);
+  });
+
+  it('does not flag valid existing paths', async () => {
+    const findings = await detectStaleMemoryRefs(MEMORY_DIR, REPO_ROOT);
+    expect(findings.every((f) => !f.evidence.some((e) => e.includes('package.json')))).toBe(true);
+  });
+});

--- a/apm-builder/tests/evolution/orchestrator.test.ts
+++ b/apm-builder/tests/evolution/orchestrator.test.ts
@@ -1,0 +1,27 @@
+// apm-builder/tests/evolution/orchestrator.test.ts
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runEvolution } from '../../lib/evolution/orchestrator.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+
+describe('runEvolution', () => {
+  it('produces a report with permission and memory findings (no LLM)', async () => {
+    const report = await runEvolution({
+      repoRoot: REPO_ROOT,
+      project: 'evolution-test',
+      sinceMs: 365 * 24 * 60 * 60 * 1000, // 1 year window
+      noLlm: true,
+      includeArcs: false,
+      dryRun: true,
+      json: false,
+      sessionsDir: path.join(HERE, 'fixtures/sessions'),
+      memoryDir: path.join(HERE, 'fixtures/memory'),
+    });
+    expect(report.project).toBe('evolution-test');
+    expect(report.findings.length).toBeGreaterThan(0);
+    expect(report.llmCostUsd).toBe(0);
+  });
+});

--- a/apm-builder/tests/evolution/permissions.test.ts
+++ b/apm-builder/tests/evolution/permissions.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadSessionsSince } from '../../lib/evolution/sessions.ts';
+import { detectPermissionPrompts } from '../../lib/evolution/permissions.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(HERE, 'fixtures/sessions');
+
+describe('detectPermissionPrompts', () => {
+  it('flags a Bash command approved 5+ times with no denials', async () => {
+    const sessions = await loadSessionsSince(FIXTURE_DIR, new Date('2026-04-25T00:00:00Z'));
+    const findings = detectPermissionPrompts(sessions);
+    const npmTest = findings.find((f) => f.evidence.some((e) => e.includes('npm test')));
+    expect(npmTest).toBeDefined();
+    expect(npmTest?.severity).toBe('high'); // 5 occurrences = high tier
+    expect(npmTest?.count).toBe(5);
+    expect(npmTest?.proposedDiff?.targetPath).toMatch(/settings\.json$/);
+  });
+
+  it('returns no findings when below threshold', async () => {
+    // Use sample-session.jsonl which has no permission-request events.
+    const sessions = await loadSessionsSince(FIXTURE_DIR, new Date('2026-04-25T00:00:00Z'));
+    const findings = detectPermissionPrompts(
+      sessions.filter((s) => s.sessionId !== 'sess-perm'),
+    );
+    expect(findings).toEqual([]);
+  });
+});

--- a/apm-builder/tests/evolution/redact.test.ts
+++ b/apm-builder/tests/evolution/redact.test.ts
@@ -1,0 +1,27 @@
+// apm-builder/tests/evolution/redact.test.ts
+import { describe, it, expect } from 'vitest';
+import { redact } from '../../lib/evolution/redact.ts';
+
+describe('redact', () => {
+  it('strips Anthropic-style tokens', () => {
+    expect(redact('key=sk-ant-api03-abc123XYZ')).toMatch(/REDACTED/);
+  });
+
+  it('strips GitHub PAT prefixes', () => {
+    expect(redact('token=ghp_abc123XYZ456789')).toMatch(/REDACTED/);
+  });
+
+  it('strips Slack bot tokens', () => {
+    expect(redact('xoxb-1234-5678-token')).toMatch(/REDACTED/);
+  });
+
+  it('strips absolute Downloads/Desktop paths', () => {
+    expect(redact('see /Users/dan/Downloads/secret.txt')).toMatch(/REDACTED/);
+    expect(redact('see /Users/dan/Desktop/notes.md')).toMatch(/REDACTED/);
+  });
+
+  it('preserves non-secret content', () => {
+    const input = 'See `apm-builder/lib/foo.ts` line 42.';
+    expect(redact(input)).toBe(input);
+  });
+});

--- a/apm-builder/tests/evolution/relevant-skill.test.ts
+++ b/apm-builder/tests/evolution/relevant-skill.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scanSkillCatalog } from '../../lib/evolution/relevant-skill.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+
+describe('scanSkillCatalog', () => {
+  it('finds at least the apm-builder skill in the repo-local catalog', async () => {
+    const entries = await scanSkillCatalog({
+      repoLocal: path.join(REPO_ROOT, 'skills'),
+      home: undefined,
+      pluginsCache: undefined,
+    });
+    const apmBuilder = entries.find((e) => e.name === 'apm-builder');
+    expect(apmBuilder).toBeDefined();
+    expect(apmBuilder?.description).toContain('apm-builder');
+  });
+
+  it('dedupes by name with repo-local priority', async () => {
+    const entries = await scanSkillCatalog({
+      repoLocal: path.join(REPO_ROOT, 'skills'),
+      home: path.join(REPO_ROOT, 'skills'), // same dir simulates a duplicate
+      pluginsCache: undefined,
+    });
+    const counts = new Map<string, number>();
+    for (const e of entries) counts.set(e.name, (counts.get(e.name) ?? 0) + 1);
+    expect([...counts.values()].every((c) => c === 1)).toBe(true);
+  });
+});

--- a/apm-builder/tests/evolution/render.test.ts
+++ b/apm-builder/tests/evolution/render.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { renderReport } from '../../lib/evolution/render.ts';
+import type { EvolutionReport } from '../../lib/evolution/types.ts';
+
+const sample: EvolutionReport = {
+  project: 'agent-skills',
+  windowStart: new Date('2026-04-20T00:00:00Z'),
+  windowEnd: new Date('2026-04-27T00:00:00Z'),
+  sessionsScanned: 12,
+  llmCostUsd: 0.04,
+  findings: [
+    {
+      id: 'F-001',
+      patternType: 'permission-prompt-recurring',
+      severity: 'high',
+      count: 7,
+      evidence: ['> sess-1 @ 2026-04-25T10:00:00Z: `npm test` (approve)'],
+      proposedDiff: {
+        targetPath: '.claude/settings.json',
+        diff: '--- a/.claude/settings.json\n+++ b/.claude/settings.json\n@@ permissions.allow @@\n+    "npm test"\n',
+        summary: 'Add `npm test` to permissions.allow[] (approved 7×)',
+      },
+    },
+  ],
+};
+
+describe('renderReport', () => {
+  it('renders header, summary table, and per-finding sections', () => {
+    const out = renderReport(sample);
+    expect(out).toContain('# Evolution Report — agent-skills');
+    expect(out).toContain('| permission-prompt-recurring | 1 | high |');
+    expect(out).toContain('## F-001');
+    expect(out).toContain('```diff\n--- a/.claude/settings.json');
+    expect(out).toContain('Cost (USD): $0.04');
+  });
+
+  it('orders findings high → low severity', () => {
+    const multi: EvolutionReport = {
+      ...sample,
+      findings: [
+        { ...sample.findings[0]!, id: 'F-002', severity: 'low' },
+        { ...sample.findings[0]!, id: 'F-001', severity: 'high' },
+      ],
+    };
+    const out = renderReport(multi);
+    const f1Index = out.indexOf('## F-001');
+    const f2Index = out.indexOf('## F-002');
+    expect(f1Index).toBeLessThan(f2Index);
+  });
+});

--- a/apm-builder/tests/evolution/sessions.test.ts
+++ b/apm-builder/tests/evolution/sessions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadSessionsSince } from '../../lib/evolution/sessions.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(HERE, 'fixtures/sessions');
+
+describe('loadSessionsSince', () => {
+  it('loads JSONL sessions and returns them with parsed events', async () => {
+    const since = new Date('2026-04-25T00:00:00Z');
+    const sessions = await loadSessionsSince(FIXTURE_DIR, since);
+    expect(sessions.length).toBeGreaterThanOrEqual(1);
+    const sample = sessions.find((s) => s.sessionId === 'sess-1');
+    expect(sample).toBeDefined();
+    expect(sample?.events.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('skips sessions where every event predates the window', async () => {
+    const since = new Date('2099-01-01T00:00:00Z');
+    const sessions = await loadSessionsSince(FIXTURE_DIR, since);
+    expect(sessions).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agent-skills",
       "version": "0.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
         "@iarna/toml": "^2.2.5",
         "chokidar": "^4.0.1",
         "citty": "^0.1.6",
@@ -26,6 +27,36 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -856,10 +887,19 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@vitest/expect": {
@@ -975,6 +1015,30 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -992,6 +1056,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1028,6 +1111,18 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -1044,6 +1139,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1054,12 +1158,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1126,6 +1289,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1166,6 +1338,41 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1181,6 +1388,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -1192,6 +1445,18 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gray-matter": {
@@ -1207,6 +1472,54 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/is-extendable": {
@@ -1511,6 +1824,42 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1528,6 +1877,46 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/obug": {
@@ -1771,6 +2160,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1817,7 +2212,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -1986,6 +2380,31 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsx apm-builder/cli.ts build",
     "watch": "tsx apm-builder/cli.ts watch",
     "docs": "tsx apm-builder/cli.ts docs",
+    "evolve": "tsx apm-builder/cli.ts evolve",
     "init": "tsx apm-builder/cli.ts init",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@iarna/toml": "^2.2.5",
+    "chokidar": "^4.0.1",
     "citty": "^0.1.6",
     "gray-matter": "^4.0.3",
-    "yaml": "^2.6.0",
-    "zod": "^3.23.8",
-    "chokidar": "^4.0.1",
+    "p-limit": "^6.1.0",
     "picocolors": "^1.1.1",
-    "p-limit": "^6.1.0"
+    "yaml": "^2.6.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -31,5 +32,6 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "_evolution_todo": "meta-scout import deferred: package is not on npm, lives in github.com/danmestas/meta-scout monorepo at packages/meta-scout/ with no committed dist/. github: install resolves to monorepo root (named claude-doctor, no main entry); gitpkg.now.sh and gitpkg.vercel.app now return 402 Payment Required. Re-evaluate when meta-scout publishes to npm or commits a built dist/."
 }


### PR DESCRIPTION
## Summary

Implements the Evolution skill per spec (`docs/superpowers/specs/2026-04-27-evolution-skill-design.md`). Adds `apm-builder evolve` CLI subcommand that scans recent session transcripts, detects two new friction patterns, and emits a markdown report with unified-diff fixes.

## What's in

- `apm-builder/lib/evolution/` — types, sessions wrapper, 2 NEW detectors (permission prompts, stale memory), redaction, render, orchestrator, skill catalog scanner with Haiku-based relevant-skill determination
- `apm-builder/cli.ts` — `apm-builder evolve` subcommand with `--since/--project/--no-llm/--include-arcs/--dry-run/--json` flags
- `npm run evolve` script
- Synthetic JSONL + memory fixtures (no real session data committed)
- Reports land at `~/.claude/evolution-reports/<project>/<date>.md` (outside the repo tree)

## What's NOT in

- meta-scout-style 12 signals + arc detection — gated on a separate upstream PR that publishes meta-scout to npm (or commits a built dist/). Currently `meta-scout` is a GitHub-only monorepo with no npm publish; the wrapper imports a tiny inline JSONL parser instead. The plan documents this in `_evolution_todo` in package.json. Once the upstream library publishes, a follow-up PR wires those signals in.
- Eval gates / auto-PR (v2 spec, not started)

## Plan defects fixed during implementation

- Sessions test brittleness when sibling fixture files exist
- Severity threshold off-by-one (count=5 → high per test, plan said medium)
- Redact regex thresholds too strict for plausible test inputs
- `import.meta.dirname` replaced with project-standard `fileURLToPath` pattern
- Renderer/test mismatch on bold markdown for the cost line

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 141/141 passing
- [x] Smoke: `npm run evolve -- --since 1d --project nonexistent --dry-run` → empty report on stdout
- [ ] Reviewer: spot-check report directory location (`~/.claude/evolution-reports/`)
- [ ] Reviewer: confirm CLI ergonomics