### PR TITLE
feat: release flow core (Plan 8 Tasks 1-11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 docs/
 node_modules/
 dist/
+release-artifacts/
 *.tsbuildinfo
 .vitest-cache/

--- a/apm-builder/cli.ts
+++ b/apm-builder/cli.ts
@@ -13,6 +13,10 @@ import { TARGETS, type Target } from './lib/types.ts';
 import { listImplementedTargets } from './adapters/index.ts';
 import { runEvolution } from './lib/evolution/orchestrator.ts';
 import { renderReport } from './lib/evolution/render.ts';
+import { runRelease } from './lib/release/release.ts';
+import { computeTag } from './lib/release/git.ts';
+import { renderReleaseNotes } from './lib/release/notes.ts';
+import { loadRepoConfig } from './lib/config.ts';
 
 const validateCmd = defineCommand({
   meta: { name: 'validate', description: 'Validate all components' },
@@ -231,9 +235,110 @@ const evolveCmd = defineCommand({
   },
 });
 
+const releaseCmd = defineCommand({
+  meta: { name: 'release', description: 'Validate, build, tag, and publish a skill release' },
+  args: {
+    skill: {
+      type: 'string',
+      description: 'Skill name (must match SKILL.md frontmatter)',
+      required: true,
+    },
+    version: {
+      type: 'string',
+      description: 'Semver to release (must match manifest version)',
+      required: true,
+    },
+    summary: {
+      type: 'string',
+      description: 'One-line release summary for CHANGELOG and notes',
+      default: 'See CHANGELOG.md for details.',
+    },
+    'git-repo': { type: 'string', default: 'github.com/danmestas/agent-skills' },
+    'no-push': {
+      type: 'boolean',
+      default: false,
+      description: 'Skip git push of the tag (CI use only)',
+    },
+    'dry-run': {
+      type: 'boolean',
+      default: false,
+      description: 'Print the release plan without tagging or publishing',
+    },
+  },
+  async run({ args }) {
+    const repoRoot = process.cwd();
+    const apmToken = process.env.APM_TOKEN;
+    if (args['dry-run']) {
+      // Dry-run never tags, never publishes, never edits files.
+      // Compose what WOULD happen and print it for human review.
+      const components = await discoverComponents(repoRoot);
+      const target = components.find((c) => c.manifest.name === args.skill);
+      if (!target) {
+        console.log(pc.red(`skill "${args.skill}" not found in skills/, plugins/, or rules/`));
+        process.exit(1);
+      }
+      if (target.manifest.version !== args.version) {
+        console.log(
+          pc.red(
+            `manifest version (${target.manifest.version}) does not match --version (${args.version})`,
+          ),
+        );
+        process.exit(1);
+      }
+      const config = await loadRepoConfig(repoRoot);
+      const apmScope = (config['apm']?.['package_scope'] as string | undefined) ?? '';
+      const apmRegistry = (config['apm']?.['registry'] as string | undefined) ?? '';
+      const tag = computeTag(args.skill, args.version);
+      const notes = renderReleaseNotes({
+        component: target,
+        summary: args.summary,
+        apmScope,
+        gitRepo: args['git-repo'],
+      });
+      console.log(pc.cyan('=== release plan (dry-run) ==='));
+      console.log(`  tag:        ${tag}`);
+      console.log(`  targets:    ${target.manifest.targets.join(', ')}`);
+      console.log(`  apm scope:  ${apmScope || '(none)'}`);
+      console.log(
+        `  apm mode:   ${apmRegistry ? `registry (${apmRegistry})` : 'git-url (no registry)'}`,
+      );
+      console.log(`  git push:   ${args['no-push'] ? 'skipped' : 'origin'}`);
+      console.log(pc.cyan('--- release notes ---'));
+      console.log(notes);
+      console.log(pc.cyan('--- end ---'));
+      console.log(pc.yellow('dry-run: no tag created, no artifacts published, no files written'));
+      return;
+    }
+    try {
+      const result = await runRelease({
+        repoRoot,
+        skill: args.skill,
+        version: args.version,
+        summary: args.summary,
+        apmToken,
+        gitRepo: args['git-repo'],
+        pushTag: !args['no-push'],
+      });
+      console.log(pc.green(`released ${result.tag}`));
+      console.log(
+        pc.cyan(`  claude-code: ${result.published.claudeCode ? 'published' : 'skipped'}`),
+      );
+      console.log(pc.cyan(`  apm:         ${result.published.apm}`));
+      console.log(
+        pc.cyan(
+          `  git-url:     ${result.published.gitUrlTargets.length > 0 ? result.published.gitUrlTargets.join(', ') : 'none'}`,
+        ),
+      );
+    } catch (err) {
+      console.log(pc.red(`release failed: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  },
+});
+
 const main = defineCommand({
   meta: { name: 'apm-builder', description: 'Multi-harness skills build tool' },
-  subCommands: { validate: validateCmd, build: buildCmd, watch: watchCmd, docs: docsCmd, init: initCmd, evolve: evolveCmd },
+  subCommands: { validate: validateCmd, build: buildCmd, watch: watchCmd, docs: docsCmd, init: initCmd, evolve: evolveCmd, release: releaseCmd },
 });
 
 runMain(main);

--- a/apm-builder/lib/release/README.md
+++ b/apm-builder/lib/release/README.md
@@ -1,0 +1,1 @@
+Release-flow internals. See `docs/superpowers/plans/2026-04-26-release-cutover.md`.

--- a/apm-builder/lib/release/changelog.ts
+++ b/apm-builder/lib/release/changelog.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs/promises';
+
+export interface ChangelogEntry {
+  skill: string;
+  version: string;
+  date: Date;
+  summary: string;
+}
+
+const HEADER =
+  '# Changelog\n\nAll notable releases of components in this monorepo. Per-component semver.\n';
+
+/**
+ * Append a single release entry to the top-level CHANGELOG.md, grouped under
+ * the entry's ISO date. If a section for that date already exists, the new line
+ * is inserted directly under it (no duplicate heading). Missing files are
+ * created with the standard header.
+ */
+export async function appendChangelogEntry(
+  filePath: string,
+  entry: ChangelogEntry,
+): Promise<void> {
+  const dateKey = entry.date.toISOString().slice(0, 10);
+  const line = `- ${entry.skill}@v${entry.version} — ${entry.summary}`;
+  const existing = await readOrInit(filePath);
+  const updated = insertUnderDate(existing, dateKey, line);
+  await fs.writeFile(filePath, updated, 'utf8');
+}
+
+async function readOrInit(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch {
+    return `${HEADER}\n`;
+  }
+}
+
+function insertUnderDate(content: string, dateKey: string, line: string): string {
+  const heading = `## ${dateKey}`;
+  const lines = content.split('\n');
+  const headingIdx = lines.findIndex((l) => l === heading);
+  if (headingIdx >= 0) {
+    // Insert directly after the blank line(s) that follow the heading.
+    let insertAt = headingIdx + 1;
+    while (insertAt < lines.length && lines[insertAt] === '') insertAt += 1;
+    lines.splice(insertAt, 0, line);
+    return lines.join('\n');
+  }
+  // No section for this date yet — insert a new section above the first existing
+  // date heading, or at the end of the header block if no date headings exist.
+  const firstDateIdx = lines.findIndex((l) => /^## \d{4}-\d{2}-\d{2}$/.test(l));
+  const insertAt = firstDateIdx >= 0 ? firstDateIdx : lines.length;
+  const newSection = ['', heading, '', line, ''];
+  lines.splice(insertAt, 0, ...newSection);
+  // Collapse accidental triple-blank-line runs that the splice may produce.
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+}

--- a/apm-builder/lib/release/git.ts
+++ b/apm-builder/lib/release/git.ts
@@ -1,0 +1,35 @@
+import { simpleGit } from 'simple-git';
+
+export interface TagReleaseOptions {
+  repoRoot: string;
+  skill: string;
+  version: string;
+  /** Set false in tests; defaults true (push to origin). */
+  push?: boolean;
+  /** Optional annotated message; defaults to "Release <tag>". */
+  message?: string;
+}
+
+/** Compute the canonical "<skill>@v<version>" tag name. */
+export function computeTag(skill: string, version: string): string {
+  return `${skill}@v${version}`;
+}
+
+/**
+ * Annotate-tag HEAD with "<skill>@v<version>" and (by default) push the tag to
+ * origin. Refuses to operate if the tag already exists locally.
+ */
+export async function tagRelease(opts: TagReleaseOptions): Promise<string> {
+  const tag = computeTag(opts.skill, opts.version);
+  const g = simpleGit(opts.repoRoot);
+  const existing = await g.tags();
+  if (existing.all.includes(tag)) {
+    throw new Error(`tag "${tag}" already exists; refusing to retag`);
+  }
+  const message = opts.message ?? `Release ${tag}`;
+  await g.addAnnotatedTag(tag, message);
+  if (opts.push !== false) {
+    await g.push('origin', tag);
+  }
+  return tag;
+}

--- a/apm-builder/lib/release/marketplace.ts
+++ b/apm-builder/lib/release/marketplace.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import type { ComponentSource } from '../types.ts';
+
+export interface MarketplaceContext {
+  /** Git host + repo, e.g. "github.com/danmestas/agent-skills". */
+  gitRepo: string;
+}
+
+/**
+ * Render a `claude-plugins-official` listing entry for a plugin component.
+ * The entry shape (name, version, description, publisher, homepage, release,
+ * categories, includes) reflects the field set we expect of the official
+ * schema; if marketplace requires more fields later, this is the single point
+ * of change.
+ */
+export function renderMarketplaceEntry(
+  component: ComponentSource,
+  ctx: MarketplaceContext,
+): string {
+  if (component.manifest.type !== 'plugin') {
+    throw new Error(
+      `renderMarketplaceEntry expects a plugin component, got ${component.manifest.type}`,
+    );
+  }
+  const includes = (component.manifest.includes ?? []).map((p) => path.basename(p));
+  const entry = {
+    name: component.manifest.name,
+    version: component.manifest.version,
+    description: component.manifest.description,
+    publisher: 'danmestas',
+    homepage: `https://${ctx.gitRepo}/tree/main/plugins/${component.manifest.name}`,
+    release: `https://${ctx.gitRepo}/releases/tag/${component.manifest.name}@v${component.manifest.version}`,
+    categories: component.manifest.tags ?? [],
+    includes,
+  };
+  return `${JSON.stringify(entry, null, 2)}\n`;
+}
+
+/** Path under repo root for a per-plugin marketplace listing. */
+export function marketplaceFilePath(skill: string): string {
+  return `marketplace/plugins/${skill}.json`;
+}

--- a/apm-builder/lib/release/notes.ts
+++ b/apm-builder/lib/release/notes.ts
@@ -1,0 +1,70 @@
+import type { ComponentSource, Target } from '../types.ts';
+
+export interface NotesContext {
+  component: ComponentSource;
+  summary: string;
+  /** APM package scope, e.g. "@danmestas". */
+  apmScope: string;
+  /** Git host + repo, e.g. "github.com/danmestas/agent-skills". */
+  gitRepo: string;
+}
+
+const GIT_ONLY_TARGETS: readonly Target[] = ['codex', 'gemini', 'copilot', 'pi'];
+
+/**
+ * Render the markdown body for a GitHub release. Composes a per-target install
+ * matrix from the component's declared `targets:` so each release page tells
+ * the reader exactly how to install for any harness it ships to.
+ */
+export function renderReleaseNotes(ctx: NotesContext): string {
+  const { component, summary, apmScope, gitRepo } = ctx;
+  const { name, version, description, targets } = component.manifest;
+  const sections: string[] = [];
+  sections.push(
+    `# ${name} v${version}`,
+    '',
+    description,
+    '',
+    "## What's in this release",
+    '',
+    summary,
+    '',
+    '## Install',
+  );
+  if (targets.includes('claude-code')) {
+    sections.push(
+      '',
+      '### Claude Code',
+      '',
+      `Download \`${name}-v${version}.zip\` from the assets below, unzip into your \`~/.claude/plugins/\` directory, then \`/plugin install ${name}\`.`,
+    );
+  }
+  if (targets.includes('apm')) {
+    sections.push(
+      '',
+      '### APM',
+      '',
+      '```',
+      `apm install ${apmScope}/${name}@${version}`,
+      '```',
+    );
+  }
+  const gitTargets = targets.filter((t) => GIT_ONLY_TARGETS.includes(t));
+  if (gitTargets.length > 0) {
+    const friendly = gitTargets
+      .map((t) => (t === 'copilot' ? 'Copilot CLI' : t.charAt(0).toUpperCase() + t.slice(1)))
+      .join(' / ');
+    sections.push(
+      '',
+      `### ${friendly}`,
+      '',
+      'Install from the git tag:',
+      '',
+      '```',
+      `<harness-cli> install ${gitRepo}@${name}@v${version}`,
+      '```',
+    );
+  }
+  sections.push('', '## Targets', '', [...targets].join(', '));
+  return sections.join('\n');
+}

--- a/apm-builder/lib/release/publish/apm.ts
+++ b/apm-builder/lib/release/publish/apm.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+export interface APMReleaseOptions {
+  repoRoot: string;
+  skill: string;
+  version: string;
+  /** Empty string means: skip registry push, rely on git-URL install. */
+  registry: string;
+  apmToken: string | undefined;
+  runApm?: (
+    args: string[],
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ stdout: string; exitCode: number }>;
+}
+
+/**
+ * Publish to the APM registry, or fall back to git-URL install if the registry
+ * is unconfigured OR the `apm` binary is not on PATH (ENOENT). The git-URL
+ * fallback is intentional: in environments without the APM CLI installed, we
+ * still want the release flow to succeed — the published git tag IS the
+ * installable artifact for any harness that supports git-URL installs.
+ */
+export async function publishAPM(
+  opts: APMReleaseOptions,
+): Promise<{ mode: 'registry' | 'git-url' }> {
+  const pkgDir = path.join(opts.repoRoot, 'dist/apm', opts.skill);
+  const exists = await fs
+    .stat(pkgDir)
+    .then((s) => s.isDirectory())
+    .catch(() => false);
+  if (!exists) {
+    throw new Error(`expected build output at dist/apm/${opts.skill} but it is missing`);
+  }
+  if (!opts.registry) {
+    // Git-URL fallback: the tag created by tagRelease() is the install artifact.
+    return { mode: 'git-url' };
+  }
+  if (!opts.apmToken) {
+    throw new Error('APM_TOKEN env var is required to push to the APM registry');
+  }
+  const args = ['publish', '--registry', opts.registry];
+  const run = opts.runApm ?? defaultRunApm;
+  const env = { ...process.env, APM_TOKEN: opts.apmToken, PWD: pkgDir };
+  let result: { stdout: string; exitCode: number };
+  try {
+    result = await run(args, env);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') {
+      // APM CLI not installed; degrade gracefully to git-URL mode.
+      console.warn(
+        `[release] apm CLI not found on PATH; falling back to git-URL install for ${opts.skill}@v${opts.version}`,
+      );
+      return { mode: 'git-url' };
+    }
+    throw err;
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(`apm publish failed (exit ${result.exitCode}): ${result.stdout}`);
+  }
+  return { mode: 'registry' };
+}
+
+function defaultRunApm(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ stdout: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('apm', args, {
+      stdio: ['ignore', 'pipe', 'inherit'],
+      env,
+      cwd: env.PWD,
+    });
+    let stdout = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, exitCode: code ?? 1 }));
+  });
+}

--- a/apm-builder/lib/release/publish/claude-code.ts
+++ b/apm-builder/lib/release/publish/claude-code.ts
@@ -10,6 +10,12 @@ export interface ClaudeCodeReleaseOptions {
   version: string;
   releaseNotes: string;
   /**
+   * Subpath under dist/claude-code/ to zip into the release asset. Defaults to
+   * `skills/<skill>` (for skill-type components). Plugin-type releases pass
+   * an alternate path (e.g. `.` to ship the entire plugin output).
+   */
+  distSubpath?: string;
+  /**
    * Override for tests. Defaults to spawning real `gh`. Tests MUST inject a
    * stub — the real binary creates a public GitHub release.
    */
@@ -17,8 +23,13 @@ export interface ClaudeCodeReleaseOptions {
 }
 
 /**
- * Zip dist/claude-code/skills/<name>/ into release-artifacts/<name>-v<version>.zip
- * and call `gh release create <tag> <zip> --title ... --notes-file ...`.
+ * Zip `dist/claude-code/<distSubpath>/` into
+ * `release-artifacts/<skill>-v<version>.zip` and call
+ * `gh release create <tag> <zip> --title ... --notes-file ...`.
+ *
+ * Default subpath is `skills/<skill>`. Plugin releases override this with
+ * `.` (whole dist/claude-code) so the bundle's `.claude-plugin/plugin.json`
+ * + included skills ship together.
  *
  * The `runGh` injection point exists because we can't safely run `gh release
  * create` from tests — it would publish a real release. Production callers
@@ -27,14 +38,15 @@ export interface ClaudeCodeReleaseOptions {
 export async function publishClaudeCode(
   opts: ClaudeCodeReleaseOptions,
 ): Promise<{ zipPath: string }> {
-  const skillDir = path.join(opts.repoRoot, 'dist/claude-code/skills', opts.skill);
+  const subpath = opts.distSubpath ?? path.join('skills', opts.skill);
+  const srcDir = path.join(opts.repoRoot, 'dist/claude-code', subpath);
   const exists = await fs
-    .stat(skillDir)
+    .stat(srcDir)
     .then((s) => s.isDirectory())
     .catch(() => false);
   if (!exists) {
     throw new Error(
-      `expected build output at dist/claude-code/skills/${opts.skill} but it is missing`,
+      `expected build output at dist/claude-code/${subpath} but it is missing`,
     );
   }
   const zipPath = path.join(
@@ -42,7 +54,7 @@ export async function publishClaudeCode(
     'release-artifacts',
     `${opts.skill}-v${opts.version}.zip`,
   );
-  await zipDirectory(skillDir, zipPath);
+  await zipDirectory(srcDir, zipPath);
   const notesPath = path.join(
     opts.repoRoot,
     'release-artifacts',

--- a/apm-builder/lib/release/publish/claude-code.ts
+++ b/apm-builder/lib/release/publish/claude-code.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { zipDirectory } from '../zip.ts';
+
+export interface ClaudeCodeReleaseOptions {
+  repoRoot: string;
+  tag: string;
+  skill: string;
+  version: string;
+  releaseNotes: string;
+  /**
+   * Override for tests. Defaults to spawning real `gh`. Tests MUST inject a
+   * stub — the real binary creates a public GitHub release.
+   */
+  runGh?: (args: string[]) => Promise<{ stdout: string; exitCode: number }>;
+}
+
+/**
+ * Zip dist/claude-code/skills/<name>/ into release-artifacts/<name>-v<version>.zip
+ * and call `gh release create <tag> <zip> --title ... --notes-file ...`.
+ *
+ * The `runGh` injection point exists because we can't safely run `gh release
+ * create` from tests — it would publish a real release. Production callers
+ * leave runGh undefined and get the spawn-based default.
+ */
+export async function publishClaudeCode(
+  opts: ClaudeCodeReleaseOptions,
+): Promise<{ zipPath: string }> {
+  const skillDir = path.join(opts.repoRoot, 'dist/claude-code/skills', opts.skill);
+  const exists = await fs
+    .stat(skillDir)
+    .then((s) => s.isDirectory())
+    .catch(() => false);
+  if (!exists) {
+    throw new Error(
+      `expected build output at dist/claude-code/skills/${opts.skill} but it is missing`,
+    );
+  }
+  const zipPath = path.join(
+    opts.repoRoot,
+    'release-artifacts',
+    `${opts.skill}-v${opts.version}.zip`,
+  );
+  await zipDirectory(skillDir, zipPath);
+  const notesPath = path.join(
+    opts.repoRoot,
+    'release-artifacts',
+    `${opts.skill}-v${opts.version}-notes.md`,
+  );
+  await fs.writeFile(notesPath, opts.releaseNotes, 'utf8');
+  const args = [
+    'release',
+    'create',
+    opts.tag,
+    zipPath,
+    '--title',
+    `${opts.skill} v${opts.version}`,
+    '--notes-file',
+    notesPath,
+  ];
+  const run = opts.runGh ?? defaultRunGh;
+  const result = await run(args);
+  if (result.exitCode !== 0) {
+    throw new Error(`gh release create failed (exit ${result.exitCode})`);
+  }
+  return { zipPath };
+}
+
+function defaultRunGh(args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'inherit'] });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, exitCode: code ?? 1 }));
+  });
+}

--- a/apm-builder/lib/release/publish/git-url.ts
+++ b/apm-builder/lib/release/publish/git-url.ts
@@ -1,0 +1,35 @@
+import { simpleGit } from 'simple-git';
+import type { Target } from '../../types.ts';
+
+export interface GitUrlReleaseOptions {
+  repoRoot: string;
+  tag: string;
+  skill: string;
+  version: string;
+  /** Git host + repo, e.g. "github.com/danmestas/agent-skills". */
+  gitRepo: string;
+  targets: Target[];
+}
+
+/**
+ * "Publish" a git-URL release. The published git tag IS the installable
+ * artifact for these targets — there is no registry to push to. This function
+ * verifies the tag exists at HEAD and emits a target -> install-URL map that
+ * upstream callers (orchestrator + release notes) can surface to humans.
+ */
+export async function publishGitUrl(
+  opts: GitUrlReleaseOptions,
+): Promise<{ installUrls: Partial<Record<Target, string>> }> {
+  const g = simpleGit(opts.repoRoot);
+  const tags = await g.tags();
+  if (!tags.all.includes(opts.tag)) {
+    throw new Error(
+      `tag "${opts.tag}" is not present in this repo; cannot publish git-URL release`,
+    );
+  }
+  const installUrls: Partial<Record<Target, string>> = {};
+  for (const t of opts.targets) {
+    installUrls[t] = `${opts.gitRepo}@${opts.tag}`;
+  }
+  return { installUrls };
+}

--- a/apm-builder/lib/release/release.ts
+++ b/apm-builder/lib/release/release.ts
@@ -11,6 +11,7 @@ import { renderReleaseNotes } from './notes.ts';
 import { publishClaudeCode } from './publish/claude-code.ts';
 import { publishAPM } from './publish/apm.ts';
 import { publishGitUrl } from './publish/git-url.ts';
+import { renderMarketplaceEntry, marketplaceFilePath } from './marketplace.ts';
 import type { Target } from '../types.ts';
 
 export interface ReleaseOptions {
@@ -64,14 +65,27 @@ export async function runRelease(opts: ReleaseOptions): Promise<ReleaseResult> {
     throw new Error(`validation failed: ${fatal.map((e) => e.message).join('; ')}`);
   }
   const config = await loadRepoConfig(opts.repoRoot);
+  // Build the full repo (no filter) so plugin.includes references resolve
+  // through the validator. Passing `filter: opts.skill` would only validate
+  // the released component, breaking includes resolution for plugin types.
   const buildResult = await runBuild({
     repoRoot: opts.repoRoot,
     targets: target.manifest.targets,
     outDir: 'dist',
-    filter: opts.skill,
   });
   if (buildResult.errors.some((e) => e.severity === 'error')) {
     throw new Error(`build failed: ${buildResult.errors.map((e) => e.message).join('; ')}`);
+  }
+  // Generate marketplace listing for plugin components going to Claude Code.
+  // Done before tagging so the listing change is included in the release commit.
+  if (
+    target.manifest.type === 'plugin' &&
+    target.manifest.targets.includes('claude-code')
+  ) {
+    const entry = renderMarketplaceEntry(target, { gitRepo: opts.gitRepo });
+    const dest = path.join(opts.repoRoot, marketplaceFilePath(target.manifest.name));
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await fs.writeFile(dest, entry, 'utf8');
   }
   const tag = await tagRelease({
     repoRoot: opts.repoRoot,
@@ -92,12 +106,16 @@ export async function runRelease(opts: ReleaseOptions): Promise<ReleaseResult> {
     gitUrlTargets: [],
   };
   if (target.manifest.targets.includes('claude-code')) {
+    // Plugin releases ship the whole dist/claude-code/ tree (manifest at root +
+    // included skills); skill releases ship only their per-skill subdir.
+    const distSubpath = target.manifest.type === 'plugin' ? '.' : path.join('skills', opts.skill);
     await publishClaudeCode({
       repoRoot: opts.repoRoot,
       tag,
       skill: opts.skill,
       version: opts.version,
       releaseNotes,
+      distSubpath,
       runGh: opts.runGh,
     });
     published.claudeCode = true;

--- a/apm-builder/lib/release/release.ts
+++ b/apm-builder/lib/release/release.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { discoverComponents } from '../discover.ts';
+import { validateComponents } from '../validate.ts';
+import { runBuild } from '../build.ts';
+import { loadRepoConfig } from '../config.ts';
+import { renderReadme } from '../docs.ts';
+import { tagRelease } from './git.ts';
+import { appendChangelogEntry } from './changelog.ts';
+import { renderReleaseNotes } from './notes.ts';
+import { publishClaudeCode } from './publish/claude-code.ts';
+import { publishAPM } from './publish/apm.ts';
+import { publishGitUrl } from './publish/git-url.ts';
+import type { Target } from '../types.ts';
+
+export interface ReleaseOptions {
+  repoRoot: string;
+  skill: string;
+  version: string;
+  summary: string;
+  apmToken: string | undefined;
+  /** Git host + repo, e.g. "github.com/danmestas/agent-skills". */
+  gitRepo: string;
+  /** Skip git push (used by tests against bare local remotes, and CI when the tag is already pushed). */
+  pushTag?: boolean;
+  runGh?: (args: string[]) => Promise<{ stdout: string; exitCode: number }>;
+  runApm?: (
+    args: string[],
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ stdout: string; exitCode: number }>;
+}
+
+export interface ReleaseResult {
+  tag: string;
+  published: {
+    claudeCode: boolean;
+    apm: 'registry' | 'git-url' | 'skipped';
+    gitUrlTargets: Target[];
+  };
+}
+
+const GIT_URL_TARGETS: readonly Target[] = ['codex', 'gemini', 'copilot', 'pi'];
+
+/**
+ * Wire Tasks 2-8 together: discover -> validate -> build -> tag -> per-target
+ * publishers -> changelog -> README refresh. Aborts before tagging if
+ * validation or build emit any fatal error, so a failed release never leaves a
+ * dangling tag in the repo.
+ */
+export async function runRelease(opts: ReleaseOptions): Promise<ReleaseResult> {
+  const components = await discoverComponents(opts.repoRoot);
+  const target = components.find((c) => c.manifest.name === opts.skill);
+  if (!target) {
+    throw new Error(`skill "${opts.skill}" not found in skills/, plugins/, or rules/`);
+  }
+  if (target.manifest.version !== opts.version) {
+    throw new Error(
+      `manifest version (${target.manifest.version}) does not match --version (${opts.version}); update SKILL.md before releasing`,
+    );
+  }
+  const errors = validateComponents(components);
+  const fatal = errors.filter((e) => e.severity === 'error');
+  if (fatal.length > 0) {
+    throw new Error(`validation failed: ${fatal.map((e) => e.message).join('; ')}`);
+  }
+  const config = await loadRepoConfig(opts.repoRoot);
+  const buildResult = await runBuild({
+    repoRoot: opts.repoRoot,
+    targets: target.manifest.targets,
+    outDir: 'dist',
+    filter: opts.skill,
+  });
+  if (buildResult.errors.some((e) => e.severity === 'error')) {
+    throw new Error(`build failed: ${buildResult.errors.map((e) => e.message).join('; ')}`);
+  }
+  const tag = await tagRelease({
+    repoRoot: opts.repoRoot,
+    skill: opts.skill,
+    version: opts.version,
+    push: opts.pushTag !== false,
+  });
+  const apmScope = (config['apm']?.['package_scope'] as string | undefined) ?? '';
+  const releaseNotes = renderReleaseNotes({
+    component: target,
+    summary: opts.summary,
+    apmScope,
+    gitRepo: opts.gitRepo,
+  });
+  const published: ReleaseResult['published'] = {
+    claudeCode: false,
+    apm: 'skipped',
+    gitUrlTargets: [],
+  };
+  if (target.manifest.targets.includes('claude-code')) {
+    await publishClaudeCode({
+      repoRoot: opts.repoRoot,
+      tag,
+      skill: opts.skill,
+      version: opts.version,
+      releaseNotes,
+      runGh: opts.runGh,
+    });
+    published.claudeCode = true;
+  }
+  if (target.manifest.targets.includes('apm')) {
+    const result = await publishAPM({
+      repoRoot: opts.repoRoot,
+      skill: opts.skill,
+      version: opts.version,
+      registry: (config['apm']?.['registry'] as string | undefined) ?? '',
+      apmToken: opts.apmToken,
+      runApm: opts.runApm,
+    });
+    published.apm = result.mode;
+  }
+  const declaredGitUrl = target.manifest.targets.filter((t) => GIT_URL_TARGETS.includes(t));
+  if (declaredGitUrl.length > 0) {
+    await publishGitUrl({
+      repoRoot: opts.repoRoot,
+      tag,
+      skill: opts.skill,
+      version: opts.version,
+      gitRepo: opts.gitRepo,
+      targets: declaredGitUrl,
+    });
+    published.gitUrlTargets = declaredGitUrl;
+  }
+  await appendChangelogEntry(path.join(opts.repoRoot, 'CHANGELOG.md'), {
+    skill: opts.skill,
+    version: opts.version,
+    date: new Date(),
+    summary: opts.summary,
+  });
+  // Regenerate README to reflect the new version (re-uses Plan 1's renderReadme).
+  const refreshed = await discoverComponents(opts.repoRoot);
+  await fs.writeFile(path.join(opts.repoRoot, 'README.md'), renderReadme(refreshed), 'utf8');
+  return { tag, published };
+}

--- a/apm-builder/lib/release/zip.ts
+++ b/apm-builder/lib/release/zip.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import archiver from 'archiver';
+
+/**
+ * Zip the contents of `srcDir` into `outZipPath`. Paths inside the zip are
+ * relative to `srcDir` (not absolute). Files are added in sorted order with a
+ * fixed epoch mtime so output is deterministic across runs.
+ */
+export async function zipDirectory(srcDir: string, outZipPath: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(outZipPath), { recursive: true });
+  const output = fs.createWriteStream(outZipPath);
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  const closed = new Promise<void>((resolve, reject) => {
+    output.on('close', () => resolve());
+    archive.on('warning', (err) => {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') reject(err);
+    });
+    archive.on('error', reject);
+  });
+  archive.pipe(output);
+  const entries = await collect(srcDir);
+  for (const rel of entries.sort()) {
+    archive.file(path.join(srcDir, rel), { name: rel, date: new Date(0) });
+  }
+  await archive.finalize();
+  await closed;
+}
+
+async function collect(root: string, sub: string = ''): Promise<string[]> {
+  const out: string[] = [];
+  const dirents = await fs.promises.readdir(path.join(root, sub), { withFileTypes: true });
+  for (const d of dirents) {
+    const rel = sub ? path.join(sub, d.name) : d.name;
+    if (d.isDirectory()) out.push(...(await collect(root, rel)));
+    else if (d.isFile()) out.push(rel);
+  }
+  return out;
+}

--- a/apm-builder/tests/release/changelog.test.ts
+++ b/apm-builder/tests/release/changelog.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appendChangelogEntry } from '../../lib/release/changelog.ts';
+
+const FIXTURES = path.resolve(fileURLToPath(import.meta.url), '../fixtures');
+
+describe('appendChangelogEntry', () => {
+  it('prepends a new release line under a new date heading when needed', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'cl-'));
+    const target = path.join(tmp, 'CHANGELOG.md');
+    await fs.copyFile(path.join(FIXTURES, 'sample-changelog-before.md'), target);
+    await appendChangelogEntry(target, {
+      skill: 'pikchr-generator',
+      version: '1.2.0',
+      date: new Date('2026-04-26T00:00:00Z'),
+      summary: 'Add Kroki fallback for offline rendering.',
+    });
+    const after = await fs.readFile(target, 'utf8');
+    const expected = await fs.readFile(path.join(FIXTURES, 'sample-changelog-after.md'), 'utf8');
+    expect(after).toBe(expected);
+  });
+
+  it('creates the file with the standard header when missing', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'cl-'));
+    const target = path.join(tmp, 'CHANGELOG.md');
+    await appendChangelogEntry(target, {
+      skill: 'foo',
+      version: '0.1.0',
+      date: new Date('2026-04-26T00:00:00Z'),
+      summary: 'Initial release.',
+    });
+    const after = await fs.readFile(target, 'utf8');
+    expect(after).toContain('# Changelog');
+    expect(after).toContain('foo@v0.1.0 — Initial release.');
+  });
+
+  it('appends under an existing date heading without duplicating it', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'cl-'));
+    const target = path.join(tmp, 'CHANGELOG.md');
+    await fs.writeFile(
+      target,
+      '# Changelog\n\n## 2026-04-26\n\n- foo@v0.1.0 — first.\n',
+    );
+    await appendChangelogEntry(target, {
+      skill: 'bar',
+      version: '0.2.0',
+      date: new Date('2026-04-26T00:00:00Z'),
+      summary: 'second.',
+    });
+    const after = await fs.readFile(target, 'utf8');
+    const dateHeadings = after.match(/^## 2026-04-26$/gm) ?? [];
+    expect(dateHeadings).toHaveLength(1);
+    expect(after).toContain('- bar@v0.2.0 — second.');
+    expect(after).toContain('- foo@v0.1.0 — first.');
+  });
+});

--- a/apm-builder/tests/release/fixtures/sample-changelog-after.md
+++ b/apm-builder/tests/release/fixtures/sample-changelog-after.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable releases of components in this monorepo. Per-component semver.
+
+## 2026-04-26
+
+- pikchr-generator@v1.2.0 — Add Kroki fallback for offline rendering.
+
+## 2026-04-25
+
+- pikchr-generator@v1.1.0 — themed PlantUML support.

--- a/apm-builder/tests/release/fixtures/sample-changelog-before.md
+++ b/apm-builder/tests/release/fixtures/sample-changelog-before.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable releases of components in this monorepo. Per-component semver.
+
+## 2026-04-25
+
+- pikchr-generator@v1.1.0 — themed PlantUML support.

--- a/apm-builder/tests/release/fixtures/sample-release-notes.md
+++ b/apm-builder/tests/release/fixtures/sample-release-notes.md
@@ -1,0 +1,31 @@
+# pikchr-generator v1.2.0
+
+Themed diagram generation with Kroki fallback
+
+## What's in this release
+
+Add Kroki fallback for offline rendering.
+
+## Install
+
+### Claude Code
+
+Download `pikchr-generator-v1.2.0.zip` from the assets below, unzip into your `~/.claude/plugins/` directory, then `/plugin install pikchr-generator`.
+
+### APM
+
+```
+apm install @danmestas/pikchr-generator@1.2.0
+```
+
+### Codex / Gemini / Copilot CLI / Pi
+
+Install from the git tag:
+
+```
+<harness-cli> install github.com/danmestas/agent-skills@pikchr-generator@v1.2.0
+```
+
+## Targets
+
+claude-code, apm, codex, gemini, copilot, pi

--- a/apm-builder/tests/release/git.test.ts
+++ b/apm-builder/tests/release/git.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { simpleGit } from 'simple-git';
+import { tagRelease, computeTag } from '../../lib/release/git.ts';
+
+describe('git release helpers', () => {
+  it('computes a <skill>@v<version> tag', () => {
+    expect(computeTag('pikchr-generator', '1.2.0')).toBe('pikchr-generator@v1.2.0');
+  });
+
+  it('tags HEAD and pushes the tag', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'git-'));
+    const remote = await fs.mkdtemp(path.join(os.tmpdir(), 'git-remote-'));
+    await simpleGit(remote).init(['--bare']);
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await fs.writeFile(path.join(repo, 'a'), 'a');
+    await g.add('a').commit('init');
+    await g.addRemote('origin', remote);
+    await g.push('origin', 'HEAD:main');
+    await tagRelease({ repoRoot: repo, skill: 'foo', version: '0.1.0' });
+    const tags = await simpleGit(remote).raw(['tag']);
+    expect(tags.trim()).toBe('foo@v0.1.0');
+  });
+
+  it('refuses to retag an existing release', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'git-'));
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await fs.writeFile(path.join(repo, 'a'), 'a');
+    await g.add('a').commit('init');
+    await g.tag(['foo@v0.1.0']);
+    await expect(
+      tagRelease({ repoRoot: repo, skill: 'foo', version: '0.1.0', push: false }),
+    ).rejects.toThrow(/already exists/i);
+  });
+});

--- a/apm-builder/tests/release/marketplace.test.ts
+++ b/apm-builder/tests/release/marketplace.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarketplaceEntry, marketplaceFilePath } from '../../lib/release/marketplace.ts';
+import type { ComponentSource } from '../../lib/types.ts';
+
+describe('renderMarketplaceEntry', () => {
+  it('emits a claude-plugins-official entry for a plugin component', () => {
+    const plugin: ComponentSource = {
+      dir: '/x',
+      relativeDir: 'plugins/superpowers-philosophy',
+      body: 'A plugin description body.',
+      manifest: {
+        name: 'superpowers-philosophy',
+        version: '0.3.0',
+        description: 'Software philosophy bundle',
+        type: 'plugin',
+        targets: ['claude-code', 'apm', 'pi'],
+        includes: ['../../skills/ousterhout', '../../skills/norman'],
+      } as ComponentSource['manifest'],
+    };
+    const entry = JSON.parse(
+      renderMarketplaceEntry(plugin, { gitRepo: 'github.com/danmestas/agent-skills' }),
+    );
+    expect(entry.name).toBe('superpowers-philosophy');
+    expect(entry.version).toBe('0.3.0');
+    expect(entry.description).toBe('Software philosophy bundle');
+    expect(entry.release).toContain('superpowers-philosophy@v0.3.0');
+    expect(entry.includes).toEqual(['ousterhout', 'norman']);
+  });
+
+  it('refuses non-plugin components', () => {
+    const skill: ComponentSource = {
+      dir: '/x',
+      relativeDir: 'skills/foo',
+      body: '',
+      manifest: {
+        name: 'foo',
+        version: '0.1.0',
+        description: 'd',
+        type: 'skill',
+        targets: ['claude-code'],
+      } as ComponentSource['manifest'],
+    };
+    expect(() => renderMarketplaceEntry(skill, { gitRepo: 'github.com/x/y' })).toThrow(
+      /plugin component/i,
+    );
+  });
+
+  it('marketplaceFilePath puts entries under marketplace/plugins/<name>.json', () => {
+    expect(marketplaceFilePath('foo')).toBe('marketplace/plugins/foo.json');
+  });
+});

--- a/apm-builder/tests/release/notes.test.ts
+++ b/apm-builder/tests/release/notes.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { renderReleaseNotes } from '../../lib/release/notes.ts';
+import type { ComponentSource } from '../../lib/types.ts';
+
+const FIXTURES = path.resolve(fileURLToPath(import.meta.url), '../fixtures');
+
+describe('renderReleaseNotes', () => {
+  it('matches the golden release-notes file', async () => {
+    const component: ComponentSource = {
+      dir: '/x',
+      relativeDir: 'skills/pikchr-generator',
+      body: '',
+      manifest: {
+        name: 'pikchr-generator',
+        version: '1.2.0',
+        description: 'Themed diagram generation with Kroki fallback',
+        type: 'skill',
+        targets: ['claude-code', 'apm', 'codex', 'gemini', 'copilot', 'pi'],
+      } as ComponentSource['manifest'],
+    };
+    const md = renderReleaseNotes({
+      component,
+      summary: 'Add Kroki fallback for offline rendering.',
+      apmScope: '@danmestas',
+      gitRepo: 'github.com/danmestas/agent-skills',
+    });
+    const expected = await fs.readFile(path.join(FIXTURES, 'sample-release-notes.md'), 'utf8');
+    expect(md.trim()).toBe(expected.trim());
+  });
+});

--- a/apm-builder/tests/release/publish-apm.test.ts
+++ b/apm-builder/tests/release/publish-apm.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { publishAPM } from '../../lib/release/publish/apm.ts';
+
+describe('publishAPM', () => {
+  it('runs `apm publish` with APM_TOKEN in env', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-'));
+    const pkgDir = path.join(repo, 'dist/apm/foo');
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(path.join(pkgDir, 'apm.yml'), 'name: foo\nversion: 0.1.0\n');
+    const fakeApm = vi.fn(async (args: string[], env: NodeJS.ProcessEnv) => {
+      expect(args).toEqual(['publish', '--registry', 'https://apm.example.com']);
+      expect(env.APM_TOKEN).toBe('secret-token');
+      return { stdout: 'published', exitCode: 0 };
+    });
+    await publishAPM({
+      repoRoot: repo,
+      skill: 'foo',
+      version: '0.1.0',
+      registry: 'https://apm.example.com',
+      apmToken: 'secret-token',
+      runApm: fakeApm,
+    });
+    expect(fakeApm).toHaveBeenCalled();
+  });
+
+  it('throws when APM_TOKEN is missing', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-'));
+    const pkgDir = path.join(repo, 'dist/apm/foo');
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(path.join(pkgDir, 'apm.yml'), 'name: foo\nversion: 0.1.0\n');
+    await expect(
+      publishAPM({
+        repoRoot: repo,
+        skill: 'foo',
+        version: '0.1.0',
+        registry: 'https://apm.example.com',
+        apmToken: undefined,
+        runApm: async () => ({ stdout: '', exitCode: 0 }),
+      }),
+    ).rejects.toThrow(/APM_TOKEN/);
+  });
+
+  it('falls back to git-URL release when registry is empty', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-'));
+    const pkgDir = path.join(repo, 'dist/apm/foo');
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(path.join(pkgDir, 'apm.yml'), 'name: foo\nversion: 0.1.0\n');
+    const fakeApm = vi.fn(
+      async (
+        _args: string[],
+        _env: NodeJS.ProcessEnv,
+      ): Promise<{ stdout: string; exitCode: number }> => ({ stdout: '', exitCode: 0 }),
+    );
+    const result = await publishAPM({
+      repoRoot: repo,
+      skill: 'foo',
+      version: '0.1.0',
+      registry: '',
+      apmToken: undefined,
+      runApm: fakeApm,
+    });
+    expect(fakeApm).not.toHaveBeenCalled();
+    expect(result.mode).toBe('git-url');
+  });
+
+  it('falls back to git-URL when APM CLI is missing (ENOENT)', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'apm-'));
+    const pkgDir = path.join(repo, 'dist/apm/foo');
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(path.join(pkgDir, 'apm.yml'), 'name: foo\nversion: 0.1.0\n');
+    const fakeApm = vi.fn(async () => {
+      const err = new Error('spawn apm ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+    const result = await publishAPM({
+      repoRoot: repo,
+      skill: 'foo',
+      version: '0.1.0',
+      registry: 'https://apm.example.com',
+      apmToken: 'tok',
+      runApm: fakeApm,
+    });
+    expect(result.mode).toBe('git-url');
+  });
+});

--- a/apm-builder/tests/release/publish-claude-code.test.ts
+++ b/apm-builder/tests/release/publish-claude-code.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { publishClaudeCode } from '../../lib/release/publish/claude-code.ts';
+
+describe('publishClaudeCode', () => {
+  it('zips dist/claude-code/skills/<name>/ and calls gh release create', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'pcc-'));
+    const skillDir = path.join(repo, 'dist/claude-code/skills/foo');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'SKILL.md'), '---\nname: foo\n---\n\nbody');
+    const calls: string[][] = [];
+    const fakeGh = vi.fn(async (args: string[]) => {
+      calls.push(args);
+      return { stdout: '', exitCode: 0 };
+    });
+    await publishClaudeCode({
+      repoRoot: repo,
+      tag: 'foo@v0.1.0',
+      skill: 'foo',
+      version: '0.1.0',
+      releaseNotes: '# foo v0.1.0\n\nNotes.',
+      runGh: fakeGh,
+    });
+    expect(calls.length).toBe(1);
+    const args = calls[0]!;
+    expect(args[0]).toBe('release');
+    expect(args[1]).toBe('create');
+    expect(args).toContain('foo@v0.1.0');
+    expect(args.some((a) => a.endsWith('foo-v0.1.0.zip'))).toBe(true);
+    expect(args).toContain('--notes-file');
+    // Verify zip exists at the expected staged location.
+    const zipPath = path.join(repo, 'release-artifacts/foo-v0.1.0.zip');
+    const stat = await fs.stat(zipPath);
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it('throws if dist/claude-code/skills/<name>/ is missing', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'pcc-'));
+    await expect(
+      publishClaudeCode({
+        repoRoot: repo,
+        tag: 'missing@v0.1.0',
+        skill: 'missing',
+        version: '0.1.0',
+        releaseNotes: '',
+        runGh: async () => ({ stdout: '', exitCode: 0 }),
+      }),
+    ).rejects.toThrow(/dist\/claude-code\/skills\/missing/);
+  });
+});

--- a/apm-builder/tests/release/publish-git-url.test.ts
+++ b/apm-builder/tests/release/publish-git-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { simpleGit } from 'simple-git';
+import { publishGitUrl } from '../../lib/release/publish/git-url.ts';
+
+describe('publishGitUrl', () => {
+  it('returns a target -> install-URL map for each git-URL target', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gu-'));
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 't@e.com');
+    await g.addConfig('user.name', 't');
+    await fs.writeFile(path.join(repo, 'a'), 'a');
+    await g.add('a').commit('init');
+    await g.tag(['foo@v0.1.0']);
+    const result = await publishGitUrl({
+      repoRoot: repo,
+      tag: 'foo@v0.1.0',
+      skill: 'foo',
+      version: '0.1.0',
+      gitRepo: 'github.com/danmestas/agent-skills',
+      targets: ['codex', 'gemini', 'copilot', 'pi'],
+    });
+    expect(Object.keys(result.installUrls).sort()).toEqual(['codex', 'copilot', 'gemini', 'pi']);
+    expect(result.installUrls['codex']).toContain('github.com/danmestas/agent-skills');
+    expect(result.installUrls['codex']).toContain('foo@v0.1.0');
+  });
+
+  it('refuses to publish when the tag is not present', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gu-'));
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 't@e.com');
+    await g.addConfig('user.name', 't');
+    await fs.writeFile(path.join(repo, 'a'), 'a');
+    await g.add('a').commit('init');
+    await expect(
+      publishGitUrl({
+        repoRoot: repo,
+        tag: 'nope@v0.1.0',
+        skill: 'nope',
+        version: '0.1.0',
+        gitRepo: 'github.com/x/y',
+        targets: ['codex'],
+      }),
+    ).rejects.toThrow(/tag.*nope/i);
+  });
+});

--- a/apm-builder/tests/release/release.test.ts
+++ b/apm-builder/tests/release/release.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { simpleGit } from 'simple-git';
+import { runRelease } from '../../lib/release/release.ts';
+
+describe('runRelease', () => {
+  it('executes the full validate -> build -> tag -> publish -> changelog flow', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-'));
+    // Bare git so push doesn't error.
+    const remote = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-remote-'));
+    await simpleGit(remote).init(['--bare']);
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 't@e.com');
+    await g.addConfig('user.name', 't');
+    await fs.mkdir(path.join(repo, 'skills/foo'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'skills/foo/SKILL.md'),
+      [
+        '---',
+        'name: foo',
+        'version: 0.1.0',
+        'description: Test skill',
+        'type: skill',
+        'targets:',
+        '  - claude-code',
+        '  - apm',
+        '  - codex',
+        '---',
+        '',
+        'Body.',
+      ].join('\n'),
+    );
+    await fs.writeFile(
+      path.join(repo, 'apm-builder.config.yaml'),
+      'apm:\n  package_scope: "@test"\n  registry: ""\nclaude-code:\n  marketplace: claude-plugins-official\n',
+    );
+    await g.add('.').commit('init');
+    await g.addRemote('origin', remote);
+    await g.push('origin', 'HEAD:main');
+    const ghCalls: string[][] = [];
+    const apmCalls: string[][] = [];
+    const result = await runRelease({
+      repoRoot: repo,
+      skill: 'foo',
+      version: '0.1.0',
+      summary: 'Initial release.',
+      apmToken: 'fake-token',
+      gitRepo: 'github.com/test/repo',
+      runGh: async (args) => {
+        ghCalls.push(args);
+        return { stdout: '', exitCode: 0 };
+      },
+      runApm: async (args) => {
+        apmCalls.push(args);
+        return { stdout: '', exitCode: 0 };
+      },
+    });
+    expect(result.tag).toBe('foo@v0.1.0');
+    expect(result.published.claudeCode).toBe(true);
+    expect(result.published.apm).toBe('git-url'); // registry=""
+    expect(result.published.gitUrlTargets).toContain('codex');
+    expect(ghCalls.some((a) => a[0] === 'release' && a.includes('foo@v0.1.0'))).toBe(true);
+    expect(apmCalls.length).toBe(0); // empty registry skips apm publish
+    const cl = await fs.readFile(path.join(repo, 'CHANGELOG.md'), 'utf8');
+    expect(cl).toContain('foo@v0.1.0 — Initial release.');
+  });
+
+  it('aborts cleanly if validate fails — no tag, no publish', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-'));
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 't@e.com');
+    await g.addConfig('user.name', 't');
+    // Invalid: type "plugin" with target "codex" is rejected by the type x target matrix.
+    await fs.mkdir(path.join(repo, 'plugins/bundle'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'plugins/bundle/SKILL.md'),
+      [
+        '---',
+        'name: bundle',
+        'version: 0.1.0',
+        'description: Bad plugin',
+        'type: plugin',
+        'targets: [codex]',
+        'includes: []',
+        '---',
+        '',
+        'body',
+      ].join('\n'),
+    );
+    await g.add('.').commit('init');
+    await expect(
+      runRelease({
+        repoRoot: repo,
+        skill: 'bundle',
+        version: '0.1.0',
+        summary: 'irrelevant',
+        apmToken: undefined,
+        gitRepo: 'github.com/x/y',
+        pushTag: false,
+        runGh: async () => ({ stdout: '', exitCode: 0 }),
+        runApm: async () => ({ stdout: '', exitCode: 0 }),
+      }),
+    ).rejects.toThrow(/validation/i);
+    const tags = await g.tags();
+    expect(tags.all).toHaveLength(0);
+  });
+});

--- a/apm-builder/tests/release/release.test.ts
+++ b/apm-builder/tests/release/release.test.ts
@@ -108,4 +108,43 @@ describe('runRelease', () => {
     const tags = await g.tags();
     expect(tags.all).toHaveLength(0);
   });
+
+  it('generates a marketplace entry for plugin components', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-mkt-'));
+    const remote = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-mkt-remote-'));
+    await simpleGit(remote).init(['--bare']);
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 't@e.com');
+    await g.addConfig('user.name', 't');
+    await fs.mkdir(path.join(repo, 'skills/foo'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'skills/foo/SKILL.md'),
+      '---\nname: foo\nversion: 0.1.0\ndescription: f\ntype: skill\ntargets: [claude-code]\n---\n\nbody\n',
+    );
+    await fs.mkdir(path.join(repo, 'plugins/bundle'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'plugins/bundle/SKILL.md'),
+      '---\nname: bundle\nversion: 0.2.0\ndescription: b\ntype: plugin\ntargets: [claude-code]\nincludes: [../../skills/foo]\n---\n\nbody\n',
+    );
+    await fs.writeFile(path.join(repo, 'apm-builder.config.yaml'), 'apm: {}\n');
+    await g.add('.').commit('init');
+    await g.addRemote('origin', remote);
+    await g.push('origin', 'HEAD:main');
+    await runRelease({
+      repoRoot: repo,
+      skill: 'bundle',
+      version: '0.2.0',
+      summary: 'plugin first release',
+      apmToken: undefined,
+      gitRepo: 'github.com/test/repo',
+      runGh: async () => ({ stdout: '', exitCode: 0 }),
+      runApm: async () => ({ stdout: '', exitCode: 0 }),
+    });
+    const json = JSON.parse(
+      await fs.readFile(path.join(repo, 'marketplace/plugins/bundle.json'), 'utf8'),
+    );
+    expect(json.name).toBe('bundle');
+    expect(json.version).toBe('0.2.0');
+  });
 });

--- a/apm-builder/tests/release/zip.test.ts
+++ b/apm-builder/tests/release/zip.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createReadStream } from 'node:fs';
+import unzipper from 'unzipper';
+import { zipDirectory } from '../../lib/release/zip.ts';
+
+describe('zipDirectory', () => {
+  it('produces a deterministic zip of a directory', async () => {
+    const src = await fs.mkdtemp(path.join(os.tmpdir(), 'zip-src-'));
+    const out = await fs.mkdtemp(path.join(os.tmpdir(), 'zip-out-'));
+    await fs.mkdir(path.join(src, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(src, 'a.txt'), 'hello');
+    await fs.writeFile(path.join(src, 'sub', 'b.txt'), 'world');
+    const zipPath = path.join(out, 'release.zip');
+    await zipDirectory(src, zipPath);
+    const entries: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      createReadStream(zipPath)
+        .pipe(unzipper.Parse())
+        .on('entry', (entry) => {
+          entries.push(entry.path);
+          entry.autodrain();
+        })
+        .on('close', () => resolve())
+        .on('error', reject);
+    });
+    expect(entries.sort()).toEqual(['a.txt', 'sub/b.txt']);
+  });
+});

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,0 +1,3 @@
+# Marketplace listings
+
+`claude-plugins-official` schema entries for this monorepo. `agent-skills.json` is the umbrella listing that includes everything. Files under `plugins/` are auto-generated from `plugins/*/SKILL.md` by `apm-builder release` and should not be hand-edited. Solo skills do not have marketplace entries — install them via APM (`apm install @danmestas/<skill>`) or the per-skill GitHub release URL.

--- a/marketplace/agent-skills.json
+++ b/marketplace/agent-skills.json
@@ -1,0 +1,10 @@
+{
+  "name": "agent-skills",
+  "version": "0.1.0",
+  "description": "Multi-harness skills monorepo: skills, plugins, rules, hooks, agents, MCP servers built once, published per-harness.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills",
+  "release": "https://github.com/danmestas/agent-skills/releases/latest",
+  "categories": ["productivity", "developer-tools"],
+  "includes": "all"
+}

--- a/marketplace/plugins/knowledge-base.json
+++ b/marketplace/plugins/knowledge-base.json
@@ -1,0 +1,22 @@
+{
+  "name": "knowledge-base",
+  "version": "0.1.0",
+  "description": "Persistent, compounding knowledge base for Claude Code. Drop sources into a vault, let an autoresearch agent synthesize a living wiki, query across sessions, and keep the structure healthy. Use when the user wants persistent notes, a knowledge graph, vault management, or mentions Obsidian, \"second brain\", or \"persistent memory\".\n",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/plugins/knowledge-base",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/knowledge-base@v0.1.0",
+  "categories": [],
+  "includes": [
+    "knowledge-base-overview",
+    "vault-overview",
+    "vault-ingest",
+    "vault-query",
+    "vault-lint",
+    "vault-save",
+    "autoresearch",
+    "defuddle",
+    "obsidian-canvas",
+    "obsidian-bases",
+    "obsidian-markdown"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,23 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@iarna/toml": "^2.2.5",
+        "archiver": "^7.0.1",
         "chokidar": "^4.0.1",
         "citty": "^0.1.6",
         "gray-matter": "^4.0.3",
         "p-limit": "^6.1.0",
         "picocolors": "^1.1.1",
+        "simple-git": "^3.27.0",
         "yaml": "^2.6.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.3",
         "@types/node": "^22.0.0",
+        "@types/unzipper": "^0.10.10",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
+        "unzipper": "^0.12.3",
         "vitest": "^4.1.5"
       },
       "engines": {
@@ -540,11 +545,43 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -574,6 +611,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -840,6 +887,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -856,6 +918,16 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/archiver": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
+      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
       }
     },
     "node_modules/@types/chai": {
@@ -900,6 +972,26 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1039,6 +1131,66 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1058,11 +1210,197 @@
         "node": ">=12"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -1111,6 +1449,24 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1121,6 +1477,22 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/consola": {
@@ -1138,6 +1510,68 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1171,6 +1605,61 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1298,6 +1787,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1320,6 +1827,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1336,6 +1849,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -1371,6 +1900,21 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -1447,6 +1991,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1458,6 +2023,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -1522,6 +2093,32 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -1529,6 +2126,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-yaml": {
@@ -1544,6 +2189,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1551,6 +2209,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1814,6 +2514,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1852,6 +2564,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1919,6 +2655,22 @@
         }
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1943,6 +2695,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -1998,6 +2781,58 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -2057,6 +2892,26 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -2070,12 +2925,62 @@
         "node": ">=4"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2107,6 +3012,122 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
@@ -2114,6 +3135,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tinybench": {
@@ -2212,6 +3263,36 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -2407,6 +3488,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2419,6 +3515,97 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -2449,6 +3636,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -18,18 +18,23 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@iarna/toml": "^2.2.5",
+    "archiver": "^7.0.1",
     "chokidar": "^4.0.1",
     "citty": "^0.1.6",
     "gray-matter": "^4.0.3",
     "p-limit": "^6.1.0",
     "picocolors": "^1.1.1",
+    "simple-git": "^3.27.0",
     "yaml": "^2.6.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.3",
     "@types/node": "^22.0.0",
+    "@types/unzipper": "^0.10.10",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
+    "unzipper": "^0.12.3",
     "vitest": "^4.1.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs": "tsx apm-builder/cli.ts docs",
     "evolve": "tsx apm-builder/cli.ts evolve",
     "init": "tsx apm-builder/cli.ts init",
+    "release": "tsx apm-builder/cli.ts release",
     "test": "vitest run",
     "smoke": "vitest run apm-builder/tests/smoke.test.ts",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

Implements local release flow per Plan 8: changelog/tag/zip/notes building blocks, three per-target publishers (Claude Code, APM, git-URL-only for codex/gemini/copilot/pi), orchestrator, `apm-builder release` CLI subcommand, and marketplace listing files.

**Scope:** Plan 8 Tasks 1-11. Tasks 12-14 (GitHub Actions release workflow, source-repo cutover automation, first real release) deferred to a follow-up PR.

## What's in
- `apm-builder/lib/release/changelog.ts` - golden-fixture-tested CHANGELOG appender
- `apm-builder/lib/release/git.ts` - `<skill>@v<version>` tagger with retag refusal
- `apm-builder/lib/release/zip.ts` - deterministic zip builder (sorted entries, fixed mtime)
- `apm-builder/lib/release/notes.ts` - GitHub release notes from manifest + dist
- `apm-builder/lib/release/publish/claude-code.ts` - zip + `gh release create` (subpath-aware for skills vs plugins)
- `apm-builder/lib/release/publish/apm.ts` - `apm publish` with APM_TOKEN, graceful git-URL fallback when registry empty OR `apm` binary missing (ENOENT)
- `apm-builder/lib/release/publish/git-url.ts` - tag-based install URLs for codex/gemini/copilot/pi
- `apm-builder/lib/release/release.ts` - `runRelease` orchestrator: discover -> validate -> build -> tag -> publish -> changelog -> README refresh
- `apm-builder/lib/release/marketplace.ts` - per-plugin listing renderer
- `apm-builder/cli.ts` - `apm-builder release` subcommand with `--dry-run`
- `npm run release` script
- `marketplace/agent-skills.json` umbrella + `marketplace/plugins/knowledge-base.json`
- All publishers default to `runGh`/`runApm` injection points so tests never invoke real `gh release create` or `apm publish`
- `.gitignore` adds `release-artifacts/`

## Plan defects fixed
1. Plan's `runRelease` passed `filter: opts.skill` to `runBuild`, which broke plugin-includes resolution (validation only saw the released component). Dropped the filter so the build sees the full repo while still emitting only the declared targets.
2. Plan's `publishClaudeCode` hard-coded `dist/claude-code/skills/<name>/`. Plugin releases need the whole `dist/claude-code/` tree (manifest at root + included skills). Added an optional `distSubpath` parameter; the orchestrator picks `.` for plugins and `skills/<name>` for skills.

## What's deferred
- Real GitHub Actions workflow (Task 12)
- Source-repo cutover automation (Task 13)
- First real release of pikchr-generator (Task 14) - manual after this lands

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` passes (170/170)
- [x] `npm run validate` OK (38 components, 6 warnings)
- [x] `npm run build -- --target all` emits 73 files
- [x] `npm run smoke` passes (7/7)
- [x] `npx tsx apm-builder/cli.ts release --help` shows the subcommand
- [x] `npx tsx apm-builder/cli.ts release --skill pikchr-generator --version 0.2.0 --dry-run` produces a release plan output but doesn't actually publish

## Dry-run safety
Every test that touches `gh` or `apm` injects a stub `runGh`/`runApm`. The default-path code that spawns the real binaries is only reached when production callers leave the injection point unset. Verified by inspection - no test ever shells out.