### PR TITLE
feat: finish Plan 8 — release workflow, cutover runbook, per-skill listings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*@v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          SKILL="${TAG%@v*}"
+          VERSION="${TAG##*@v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "skill=$SKILL" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify component exists and version matches
+        run: |
+          SKILL="${{ steps.parse.outputs.skill }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          for dir in skills/$SKILL plugins/$SKILL rules/$SKILL; do
+            if [ -f "$dir/SKILL.md" ]; then
+              FOUND_VERSION=$(grep -E "^version:" "$dir/SKILL.md" | head -1 | sed 's/version: *//;s/[" ]//g')
+              if [ "$FOUND_VERSION" != "$VERSION" ]; then
+                echo "::error::Tag $SKILL@v$VERSION but $dir/SKILL.md declares version=$FOUND_VERSION"
+                exit 1
+              fi
+              echo "ok: $dir/SKILL.md declares version=$VERSION"
+              exit 0
+            fi
+          done
+          echo "::error::No SKILL.md found for $SKILL under skills/, plugins/, or rules/"
+          exit 1
+
+      - name: Validate
+        run: npm run validate
+
+      - name: Run release (live)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APM_TOKEN: ${{ secrets.APM_TOKEN }}
+        run: |
+          npx tsx apm-builder/cli.ts release \
+            --skill "${{ steps.parse.outputs.skill }}" \
+            --version "${{ steps.parse.outputs.version }}" \
+            --no-dry-run

--- a/marketplace/skills/apm-builder.json
+++ b/marketplace/skills/apm-builder.json
@@ -1,0 +1,15 @@
+{
+  "name": "apm-builder",
+  "version": "0.1.0",
+  "description": "Use when building, validating, or scaffolding skills in this monorepo. Triggers: \"validate skills\", \"build apm-builder\", \"scaffold a new skill\", \"init a hook/agent/rules/plugin\", \"run apm-builder\", or any work on the multi-harness skill emission pipeline (Claude Code, APM, Codex, Gemini, Copilot CLI, Pi targets).",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/apm-builder",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/apm-builder@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/apple-contacts.json
+++ b/marketplace/skills/apple-contacts.json
@@ -1,0 +1,15 @@
+{
+  "name": "apple-contacts",
+  "version": "0.1.0",
+  "description": "Search, list, create, update, and delete Apple Contacts via the `contactbook` CLI on macOS. Look up contacts by name, phone, email, or organization. Manage contact groups.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/apple-contacts",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/apple-contacts@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/atlassian-cli-jira.json
+++ b/marketplace/skills/atlassian-cli-jira.json
@@ -1,0 +1,15 @@
+{
+  "name": "atlassian-cli-jira",
+  "version": "0.1.0",
+  "description": "Use when working with Atlassian CLI (acli) to install, authenticate, and manage Jira Cloud work items/issues from the command line: search (JQL), view, create, edit, assign, transition, comment, link, watch, attach, archive/unarchive, bulk operations, and project/board/sprint discovery.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/atlassian-cli-jira",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/atlassian-cli-jira@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/autoresearch.json
+++ b/marketplace/skills/autoresearch.json
@@ -1,0 +1,15 @@
+{
+  "name": "autoresearch",
+  "version": "0.1.0",
+  "description": "Autonomous iterative research loop. Takes a topic, runs web searches, fetches sources, synthesizes findings, and files everything into the wiki as structured pages. Based on Karpathy's autoresearch pattern: program.md configures objectives and constraints, the loop runs until depth is reached, output goes directly into the knowledge base. Triggers on: \"/autoresearch\", \"autoresearch\", \"research [topic]\", \"deep dive into [topic]\", \"investigate [topic]\", \"find everything about [topic]\", \"research and file\", \"go research\", \"build a wiki on\".",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/autoresearch",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/autoresearch@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/cloudflare-email.json
+++ b/marketplace/skills/cloudflare-email.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloudflare-email",
+  "version": "0.1.0",
+  "description": "Use when sending outbound transactional or one-off emails from a Cloudflare-managed domain without running a mail server or paying for a mailbox provider. Triggers on needs to send email programmatically from a custom domain, send-from-my-domain requests, or replacing SMTP relays. Cloudflare Email Service is REST API + Workers only — no SMTP, so it is NOT compatible with Gmail \"Send mail as\", Outlook, or any SMTP client.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/cloudflare-email",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/cloudflare-email@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/datastar-patterns.json
+++ b/marketplace/skills/datastar-patterns.json
@@ -1,0 +1,15 @@
+{
+  "name": "datastar-patterns",
+  "version": "0.1.0",
+  "description": "Use when implementing UI patterns with Datastar — search, inline editing, infinite scroll, file upload, validation, bulk operations, polling, lazy loading, progress indicators, or keyboard shortcuts. Triggers on data-* attributes, @get/@post/@put/@patch helpers, SSE response formatting, or any \"how do I do X in Datastar\" implementation question.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/datastar-patterns",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/datastar-patterns@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/datastar-tao.json
+++ b/marketplace/skills/datastar-tao.json
@@ -1,0 +1,15 @@
+{
+  "name": "datastar-tao",
+  "version": "0.1.0",
+  "description": "Use when building hypermedia-driven web applications, server-rendered UIs, or any frontend where the backend should own state. Use when choosing between SPA and server-driven architecture. Use when reviewing frontend code for unnecessary client-side state, optimistic updates, or client-side routing. Triggers on requests involving SSE, HTML-over-the-wire, DOM morphing, HTMX, Datastar, signals, or backend-first frontend design.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/datastar-tao",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/datastar-tao@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/datastar.json
+++ b/marketplace/skills/datastar.json
@@ -1,0 +1,15 @@
+{
+  "name": "datastar",
+  "version": "0.1.0",
+  "description": "Use when building web applications with Datastar — the hypermedia framework that drives frontend reactivity from the backend using HTML data-* attributes and Server-Sent Events. Triggers on Datastar, data-star, SSE-driven UI, hypermedia framework, backend-driven frontend, data-signals, data-on, PatchElements, or any Go/Python web app using Datastar SDKs.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/datastar",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/datastar@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/defuddle.json
+++ b/marketplace/skills/defuddle.json
@@ -1,0 +1,15 @@
+{
+  "name": "defuddle",
+  "version": "0.1.0",
+  "description": "Strip clutter from web pages before ingesting into the wiki. Removes ads, navigation, headers, footers, and boilerplate: leaving clean readable markdown that saves 40-60% tokens. Triggers on: defuddle, clean this page, strip this url, fetch and clean, clean web content before ingesting, strip ads, remove clutter, clean URL content, readable markdown from URL.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/defuddle",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/defuddle@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/deterministic-simulation-testing.json
+++ b/marketplace/skills/deterministic-simulation-testing.json
@@ -1,0 +1,15 @@
+{
+  "name": "deterministic-simulation-testing",
+  "version": "0.1.0",
+  "description": "Use when building or testing distributed systems, consensus protocols, sync engines, replicated databases, or any system with network/disk/time non-determinism. Also use when tests are flaky due to concurrency, when debugging rare heisenbugs, or when asked about simulation testing, BUGGIFY, VOPR, or fault injection strategies.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/deterministic-simulation-testing",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/deterministic-simulation-testing@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/doppler.json
+++ b/marketplace/skills/doppler.json
@@ -1,0 +1,15 @@
+{
+  "name": "doppler",
+  "version": "0.1.0",
+  "description": "Use when migrating .env files to Doppler secrets management, setting up Doppler for a project, or when asked to secure environment variables. Triggers on .env files containing API keys, tokens, or secrets that should not be in plaintext on disk.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/doppler",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/doppler@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/dx-audit.json
+++ b/marketplace/skills/dx-audit.json
@@ -1,0 +1,15 @@
+{
+  "name": "dx-audit",
+  "version": "0.1.0",
+  "description": "Use when evaluating developer experience or user experience, assessing usability of a CLI/SDK/API/UI, scoring project ergonomics, identifying friction in workflows, or when asked to audit DX or UX. Triggers on \"DX score\", \"UX audit\", \"developer experience\", \"user experience\", \"workflow friction\", \"usability audit\", \"how hard is it to use this\".",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/dx-audit",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/dx-audit@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/evolution-engine.json
+++ b/marketplace/skills/evolution-engine.json
@@ -1,0 +1,15 @@
+{
+  "name": "evolution-engine",
+  "version": "0.1.0",
+  "description": "Use when the user wants to \"analyze sessions\", \"find patterns in my agent history\", \"evolve config\", \"/evolve\", \"what's been frustrating you\", or asks for automated suggestions for improving skills/configs based on session transcripts. Triggers on requests to surface recurring friction, propose allowlist additions, find stale memory, or generate diff-shaped recommendations against existing skills, settings, and memory files.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/evolution-engine",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/evolution-engine@v0.1.0",
+  "categories": [
+    "evolution"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/gh-project-charter.json
+++ b/marketplace/skills/gh-project-charter.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-project-charter",
+  "version": "0.1.0",
+  "description": "Use when creating project charters, documenting project goals/scope, defining success criteria, updating project documentation, or tracking scope changes",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/gh-project-charter",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/gh-project-charter@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/gh-project-operations.json
+++ b/marketplace/skills/gh-project-operations.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-project-operations",
+  "version": "0.1.0",
+  "description": "Use when adding/updating/deleting issues in projects, changing item statuses, bulk operations, archiving items, or managing project boards daily",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/gh-project-operations",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/gh-project-operations@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/gh-project-setup.json
+++ b/marketplace/skills/gh-project-setup.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-project-setup",
+  "version": "0.1.0",
+  "description": "Use when creating new GitHub projects, setting up project boards, configuring kanban/scrum/roadmap boards, or applying project templates. Provides context-aware template suggestions based on repository analysis and conversation. Supports 6 templates: kanban, bug-tracker, feature-development, roadmap, research, release-planning. Handles multi-repo and organization projects.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/gh-project-setup",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/gh-project-setup@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/gh-project-shared.json
+++ b/marketplace/skills/gh-project-shared.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-project-shared",
+  "version": "0.1.0",
+  "description": "Shared utilities for GitHub project management. Not directly invoked by agents. Provides: gh CLI validation, authentication checking, config file management (.github/project-config.json), context detection for template suggestions, and error handling with logging.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/gh-project-shared",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/gh-project-shared@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/hipp.json
+++ b/marketplace/skills/hipp.json
@@ -1,0 +1,20 @@
+{
+  "name": "hipp",
+  "version": "0.1.0",
+  "description": "Use when designing libraries, modules, or data layers that must be simple, reliable, and self-contained. Use when choosing between embedded vs server-based solutions. Use when reviewing code for unnecessary complexity, dependencies, or configuration. Triggers on requests involving zero-config design, embedded systems, long-term maintainability, or first-principles thinking.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/hipp",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/hipp@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm",
+    "codex",
+    "gemini",
+    "copilot",
+    "pi"
+  ]
+}

--- a/marketplace/skills/idiomatic-go.json
+++ b/marketplace/skills/idiomatic-go.json
@@ -1,0 +1,20 @@
+{
+  "name": "idiomatic-go",
+  "version": "0.1.0",
+  "description": "Use when writing, reviewing, or refactoring Go code. Triggers on .go files, go.mod presence, or any task involving Go programming. Also use when reviewing Go code for idiomaticity, error handling, concurrency patterns, or interface design.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/idiomatic-go",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/idiomatic-go@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm",
+    "codex",
+    "gemini",
+    "copilot",
+    "pi"
+  ]
+}

--- a/marketplace/skills/knowledge-base-overview.json
+++ b/marketplace/skills/knowledge-base-overview.json
@@ -1,0 +1,15 @@
+{
+  "name": "knowledge-base-overview",
+  "version": "0.1.0",
+  "description": "Use when building, maintaining, ingesting into, querying, or health-checking a markdown knowledge base or wiki. Use when the user wants to compile sources into structured knowledge, maintain an Obsidian wiki, ingest documents, ask questions against accumulated research, or run health checks on interlinked markdown pages. Triggers on requests involving knowledge bases, wiki maintenance, source ingestion, research compilation, Obsidian wiki workflows, or LLM-maintained documentation.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/knowledge-base-overview",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/knowledge-base-overview@v0.1.0",
+  "categories": [
+    "memory-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/linear-method.json
+++ b/marketplace/skills/linear-method.json
@@ -1,0 +1,15 @@
+{
+  "name": "linear-method",
+  "version": "0.1.0",
+  "description": "Use when creating, organizing, or prioritizing issues in Linear. Use when managing backlogs, setting up cycles, scoping projects, writing issue titles/descriptions, or deciding how to structure work in Linear. Also use when asked about Linear best practices.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/linear-method",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/linear-method@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/mgrep-code-search.json
+++ b/marketplace/skills/mgrep-code-search.json
@@ -1,0 +1,15 @@
+{
+  "name": "mgrep-code-search",
+  "version": "0.1.0",
+  "description": "Semantic code search using mgrep for efficient codebase exploration. This skill should be used when searching or exploring codebases with more than 30 non-gitignored files and/or nested directory structures. It provides natural language semantic search that complements traditional grep/ripgrep for finding features, understanding intent, and exploring unfamiliar code.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/mgrep-code-search",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/mgrep-code-search@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/midscene-testing.json
+++ b/marketplace/skills/midscene-testing.json
@@ -1,0 +1,15 @@
+{
+  "name": "midscene-testing",
+  "version": "0.1.0",
+  "description": "Use when performing ad-hoc browser testing, smoke testing workflows, validating UI after frontend changes, or testing Datastar/HTMX/SSE reactive features that unit tests cannot cover. Also use when consolidating Midscene HTML reports into a single navigable document.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/midscene-testing",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/midscene-testing@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/norman.json
+++ b/marketplace/skills/norman.json
@@ -1,0 +1,20 @@
+{
+  "name": "norman",
+  "version": "0.1.0",
+  "description": "Use when designing, reviewing, or auditing user interfaces and frontend interactions. Use when evaluating UI usability, accessibility, or interaction patterns. Triggers on requests involving button placement, form design, navigation, error messages, onboarding flows, modal dialogs, or when asked to review a UI for usability.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/norman",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/norman@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm",
+    "codex",
+    "gemini",
+    "copilot",
+    "pi"
+  ]
+}

--- a/marketplace/skills/obsidian-bases.json
+++ b/marketplace/skills/obsidian-bases.json
@@ -1,0 +1,15 @@
+{
+  "name": "obsidian-bases",
+  "version": "0.1.0",
+  "description": "Create and edit Obsidian Bases (.base files): Obsidian's native database layer for dynamic tables, card views, list views, filters, formulas, and summaries over vault notes. Triggers on: create a base, add a base file, obsidian bases, base view, filter notes, formula, database view, dynamic table, task tracker base, reading list base.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/obsidian-bases",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/obsidian-bases@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/obsidian-canvas.json
+++ b/marketplace/skills/obsidian-canvas.json
@@ -1,0 +1,15 @@
+{
+  "name": "obsidian-canvas",
+  "version": "0.1.0",
+  "description": "Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to Obsidian canvas files with auto-positioning inside zones. Integrates with /banana for image capture. Triggers on: /canvas, canvas new, canvas add image, canvas add text, canvas add pdf, canvas add note, canvas zone, canvas list, canvas from banana, add to canvas, put this on the canvas, open canvas, create canvas.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/obsidian-canvas",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/obsidian-canvas@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/obsidian-markdown.json
+++ b/marketplace/skills/obsidian-markdown.json
@@ -1,0 +1,15 @@
+{
+  "name": "obsidian-markdown",
+  "version": "0.1.0",
+  "description": "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, highlights, math, and canvas syntax. Reference this when creating or editing any wiki page. Triggers on: write obsidian note, obsidian syntax, wikilink, callout, embed, obsidian markdown, wikilink format, callout syntax, embed syntax, obsidian formatting, how to write obsidian markdown.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/obsidian-markdown",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/obsidian-markdown@v0.1.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/orchestrator-mode.json
+++ b/marketplace/skills/orchestrator-mode.json
@@ -1,0 +1,15 @@
+{
+  "name": "orchestrator-mode",
+  "version": "0.1.0",
+  "description": "Use at session start in the Darkish Factory repo to prime as the pipeline orchestrator (host mode). Loads the §7 loop, the 13-role roster, the escalation classifier, and the rules for converting subagent muscle memory into subharness dispatch. Invoke whenever the operator types a task and you're in this repo.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/orchestrator-mode",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/orchestrator-mode@v0.1.0",
+  "categories": [
+    "workflow"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/ousterhout.json
+++ b/marketplace/skills/ousterhout.json
@@ -1,0 +1,20 @@
+{
+  "name": "ousterhout",
+  "version": "0.1.0",
+  "description": "Use when designing modules, classes, APIs, or system architecture. Use when reviewing or refactoring code for complexity. Use when choosing between implementation approaches. Triggers on requests involving abstraction design, interface simplicity, information hiding, or reducing cognitive load.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/ousterhout",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/ousterhout@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm",
+    "codex",
+    "gemini",
+    "copilot",
+    "pi"
+  ]
+}

--- a/marketplace/skills/pikchr-generator.json
+++ b/marketplace/skills/pikchr-generator.json
@@ -1,0 +1,16 @@
+{
+  "name": "pikchr-generator",
+  "version": "0.2.0",
+  "description": "Generate, theme, and render technical diagrams across four engines (Pikchr,\nGraphViz, D2, Mermaid) with a shared 16-theme palette. Use whenever the user\nasks for a diagram, flowchart, sequence diagram, system architecture,\nstate machine, data pipeline, swim lane, network topology, ER diagram,\nclass diagram, or any boxes-and-arrows technical illustration AND mentions\npikchr, graphviz, dot, d2, or mermaid OR has indicated a preference for\ntext-defined diagrams (over excalidraw/figma). Also use when the user says\n\"draw the architecture\", \"diagram this flow\", \"make a chart of X\", \"show\nthe states\", \"graph this topology\", or asks for any visual these engines\nare suited for. Outputs themed SVG (any of 16 themes via --theme NAME).\nDo NOT use for freeform sketches that need curves and pen strokes (use\nexcalidraw), real Gantt/pie charts (use a chart library), or rich data viz.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/pikchr-generator",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/pikchr-generator@v0.2.0",
+  "categories": [
+    "tooling"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm"
+  ]
+}

--- a/marketplace/skills/signoz-dashboard-builder.json
+++ b/marketplace/skills/signoz-dashboard-builder.json
@@ -1,0 +1,15 @@
+{
+  "name": "signoz-dashboard-builder",
+  "version": "0.1.0",
+  "description": "Use when creating or updating SigNoz dashboards via the MCP API. Triggers on requests to build dashboards, add panels, visualize metrics/logs/traces in SigNoz, or debug dashboard queries that show \"No Data\" or \"Something went wrong\". Also use when working with Claude Code telemetry in SigNoz.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/signoz-dashboard-builder",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/signoz-dashboard-builder@v0.1.0",
+  "categories": [
+    "integrations"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/subagent-to-subharness.json
+++ b/marketplace/skills/subagent-to-subharness.json
@@ -1,0 +1,15 @@
+{
+  "name": "subagent-to-subharness",
+  "version": "0.1.0",
+  "description": "Use when you would normally dispatch a subagent via the Agent tool but you're operating as the Darkish Factory orchestrator. Translates the muscle memory into subharness dispatch. Maps task shapes to the right harness role, frames the task in caveman-standard, reads worker output back, decides next step.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/subagent-to-subharness",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/subagent-to-subharness@v0.1.0",
+  "categories": [
+    "workflow"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/tigerstyle.json
+++ b/marketplace/skills/tigerstyle.json
@@ -1,0 +1,20 @@
+{
+  "name": "tigerstyle",
+  "version": "0.1.0",
+  "description": "Use when writing safety-critical code, systems programming, infrastructure, or when a project needs rigorous coding discipline. Triggers include requests for defensive coding, assertion-heavy development, performance-conscious design, zero-technical-debt policy, or NASA Power of Ten style rules. Also use when reviewing code for correctness, safety, or performance issues.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/tigerstyle",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/tigerstyle@v0.1.0",
+  "categories": [
+    "backpressure"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code",
+    "apm",
+    "codex",
+    "gemini",
+    "copilot",
+    "pi"
+  ]
+}

--- a/marketplace/skills/tts-announcer.json
+++ b/marketplace/skills/tts-announcer.json
@@ -1,0 +1,16 @@
+{
+  "name": "tts-announcer",
+  "version": "0.1.0",
+  "description": "Local, offline voice announcements for Claude Code and Pi via Kokoro-82M TTS. Wires Notification + SubagentStop hooks so the terminal whispers progress instead of going *bing*. Useful when subagents run for minutes and you've wandered off. Use when the user wants TTS announcements, voice notifications, audible subagent feedback, or mentions \"/tts\", \"speak\", \"announce\", or \"Kokoro\". Audio never leaves the machine; no API keys.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/tts-announcer",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/tts-announcer@v0.1.0",
+  "categories": [
+    "workflow"
+  ],
+  "type": "hook",
+  "targets": [
+    "claude-code",
+    "pi"
+  ]
+}

--- a/marketplace/skills/vault-ingest.json
+++ b/marketplace/skills/vault-ingest.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-ingest",
+  "version": "0.1.0",
+  "description": "Ingest sources into the Obsidian wiki vault. Reads a source, extracts entities and concepts, creates or updates wiki pages, cross-references, and logs the operation. Supports files, URLs, and batch mode. Triggers on: ingest, process this source, add this to the wiki, read and file this, batch ingest, ingest all of these, ingest this url.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/vault-ingest",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/vault-ingest@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/vault-lint.json
+++ b/marketplace/skills/vault-lint.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-lint",
+  "version": "0.1.0",
+  "description": "Health check the Obsidian wiki vault. Finds orphan pages, dead wikilinks, stale claims, missing cross-references, frontmatter gaps, and empty sections. Creates or updates Dataview dashboards. Generates canvas maps. Triggers on: \"lint\", \"health check\", \"clean up wiki\", \"check the wiki\", \"wiki maintenance\", \"find orphans\", \"wiki audit\".",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/vault-lint",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/vault-lint@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/vault-overview.json
+++ b/marketplace/skills/vault-overview.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-overview",
+  "version": "0.1.0",
+  "description": "Claude + Obsidian knowledge companion. Sets up a persistent wiki vault, scaffolds structure from a one-sentence description, and routes to specialized sub-skills. Use for setup, scaffolding, cross-project referencing, and hot cache management. Triggers on: \"set up wiki\", \"scaffold vault\", \"create knowledge base\", \"/wiki\", \"wiki setup\", \"obsidian vault\", \"knowledge base\", \"second brain setup\", \"running notetaker\", \"persistent memory\", \"llm wiki\".",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/vault-overview",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/vault-overview@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/vault-query.json
+++ b/marketplace/skills/vault-query.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-query",
+  "version": "0.1.0",
+  "description": "Answer questions using the Obsidian wiki vault. Reads hot cache first, then index, then relevant pages. Synthesizes answers with citations. Files good answers back as wiki pages. Supports quick, standard, and deep modes. Triggers on: what do you know about, query:, what is, explain, summarize, find in wiki, search the wiki, based on the wiki, wiki query quick, wiki query deep.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/vault-query",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/vault-query@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}

--- a/marketplace/skills/vault-save.json
+++ b/marketplace/skills/vault-save.json
@@ -1,0 +1,15 @@
+{
+  "name": "vault-save",
+  "version": "0.1.0",
+  "description": "Save the current conversation, answer, or insight into the Obsidian wiki vault as a structured note. Analyzes the chat, determines the right note type, creates frontmatter, files it in the correct wiki folder, and updates index, log, and hot cache. Triggers on: \"save this\", \"save that answer\", \"/save\", \"file this\", \"save to wiki\", \"save this session\", \"file this conversation\", \"keep this\", \"save this analysis\", \"add this to the wiki\".",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-skills/tree/main/skills/vault-save",
+  "release": "https://github.com/danmestas/agent-skills/releases/tag/vault-save@v0.1.0",
+  "categories": [
+    "context-management"
+  ],
+  "type": "skill",
+  "targets": [
+    "claude-code"
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the remaining Plan 8 items left over from PR #58 (which shipped the local release flow):

1. **`.github/workflows/release.yml`** — tag-driven CI release. Triggers on tags matching `<skill>@v<version>`. Verifies the SKILL.md frontmatter version matches the tag, runs `validate`, then runs `apm-builder release --no-dry-run` with `GITHUB_TOKEN` + `APM_TOKEN` secrets.

2. **`docs/runbooks/source-repo-cutover.md`** — explicitly human-driven runbook (NOT automation) for archiving the 3 absorbed source repos: `karpathy-llm-wiki`, `pikchr-generator`, `claude-tts-hooks`. Per-repo checklist, the README banner template, failure recovery (`gh repo unarchive`), when-to-do-it (after first verified release).

3. **`marketplace/skills/*.json`** — 39 per-skill marketplace listings, one per skill in `skills/`. Each links to homepage, the tagged release URL, and includes the canonical metadata (targets, category, type). The umbrella + plugin listings already shipped in #58.

## What's NOT in this PR

- **First real release of `pikchr-generator`** (Plan 8 Task 14) — intentionally a human-driven step. The release workflow is in place; the trigger is operational. To run:

  \`\`\`bash
  # Configure APM_TOKEN secret in GitHub repo settings first (if publishing to APM registry)
  git tag pikchr-generator@v0.2.0
  git push origin pikchr-generator@v0.2.0
  \`\`\`

  Watch the resulting Action run. Verify the release at `https://github.com/danmestas/agent-skills/releases/tag/pikchr-generator@v0.2.0`.

- **Source repo archives** — runbook ships, but the actual `gh repo archive` calls are operational steps the user runs per repo.

## Verification

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` 170/170 passing
- [x] \`npm run validate\` OK (40 components, 6 expected warnings)
- [x] \`npm run build -- --target all\` 75 files
- [x] \`release.yml\` workflow YAML validates against GitHub Actions schema (no obvious typos)

## Test plan

- [x] Generator produces canonical JSON shape matching the existing umbrella + plugin listings
- [x] All 39 listings generated cleanly from current frontmatter
- [ ] Reviewer to spot-check the release.yml — particularly the tag-parse logic and the version-cross-check step
- [ ] Reviewer to confirm the cutover runbook covers the operational concerns