### PR TITLE
fix(release): tagRelease idempotent when tag already exists at HEAD

### DIFF
--- a/apm-builder/lib/release/git.ts
+++ b/apm-builder/lib/release/git.ts
@@ -17,14 +17,27 @@ export function computeTag(skill: string, version: string): string {
 
 /**
  * Annotate-tag HEAD with "<skill>@v<version>" and (by default) push the tag to
- * origin. Refuses to operate if the tag already exists locally.
+ * origin.
+ *
+ * If the tag already exists, behavior depends on whether it points at HEAD:
+ * - same SHA → no-op (idempotent: e.g., the workflow was triggered BY this tag)
+ * - different SHA → throw (refusing to overwrite a published tag)
  */
 export async function tagRelease(opts: TagReleaseOptions): Promise<string> {
   const tag = computeTag(opts.skill, opts.version);
   const g = simpleGit(opts.repoRoot);
   const existing = await g.tags();
   if (existing.all.includes(tag)) {
-    throw new Error(`tag "${tag}" already exists; refusing to retag`);
+    const tagSha = (await g.revparse([tag])).trim();
+    const headSha = (await g.revparse(['HEAD'])).trim();
+    if (tagSha === headSha) {
+      // Idempotent: the workflow was triggered by this tag, so it already exists
+      // at the right commit. Nothing to do.
+      return tag;
+    }
+    throw new Error(
+      `tag "${tag}" already exists at ${tagSha.slice(0, 7)} but HEAD is ${headSha.slice(0, 7)}; refusing to retag`,
+    );
   }
   const message = opts.message ?? `Release ${tag}`;
   await g.addAnnotatedTag(tag, message);

--- a/apm-builder/tests/release/git.test.ts
+++ b/apm-builder/tests/release/git.test.ts
@@ -27,7 +27,10 @@ describe('git release helpers', () => {
     expect(tags.trim()).toBe('foo@v0.1.0');
   });
 
-  it('refuses to retag an existing release', async () => {
+  it('is idempotent when tag already exists at HEAD (workflow re-runs)', async () => {
+    // The release workflow is triggered by the tag, so by the time it calls
+    // tagRelease the tag already exists pointing at HEAD. That should be a no-op
+    // rather than an error.
     const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'git-'));
     const g = simpleGit(repo);
     await g.init();
@@ -36,8 +39,28 @@ describe('git release helpers', () => {
     await fs.writeFile(path.join(repo, 'a'), 'a');
     await g.add('a').commit('init');
     await g.tag(['foo@v0.1.0']);
+    const result = await tagRelease({
+      repoRoot: repo,
+      skill: 'foo',
+      version: '0.1.0',
+      push: false,
+    });
+    expect(result).toBe('foo@v0.1.0');
+  });
+
+  it('refuses to retag if existing tag points at a different commit', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'git-'));
+    const g = simpleGit(repo);
+    await g.init();
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await fs.writeFile(path.join(repo, 'a'), 'a');
+    await g.add('a').commit('init');
+    await g.tag(['foo@v0.1.0']); // tag at first commit
+    await fs.writeFile(path.join(repo, 'b'), 'b');
+    await g.add('b').commit('second commit'); // HEAD now ahead of tag
     await expect(
       tagRelease({ repoRoot: repo, skill: 'foo', version: '0.1.0', push: false }),
-    ).rejects.toThrow(/already exists/i);
+    ).rejects.toThrow(/refusing to retag/i);
   });
 });


### PR DESCRIPTION
## Summary

The release workflow trigger pattern is:
1. Operator pushes `<skill>@v<version>` tag
2. `.github/workflows/release.yml` fires
3. Workflow runs `apm-builder release --no-dry-run`
4. `runRelease` calls `tagRelease` — which threw `tag already exists; refusing to retag` because the tag was the trigger

This blocked every CI release. Caught by the first real release attempt (pikchr-generator@v0.2.0 — workflow run 25020909196).

## Fix

`tagRelease` is now idempotent when the existing tag points at HEAD:
- Same SHA → no-op (return tag name)
- Different SHA → throw with a clearer error mentioning both SHAs (refusing to overwrite a published tag)

## Test plan

- [x] Updated test: idempotent path verified
- [x] New test: different-SHA path still rejected
- [x] All 4 git.test.ts tests pass

Once this lands and you re-tag (delete the broken tag, re-tag), the workflow should complete cleanly.