### PR TITLE
feat: bring in career-interview skill (last from agent-plugins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Adapters emit native artifacts for each harness when a skill declares it in `tar
 - [`apm-builder`](skills/apm-builder) — This repo's build tool itself. Validate, build, watch, scaffold, regenerate docs, run `evolve`.
 - [`cloudflare-email`](skills/cloudflare-email) — Send outbound email from Cloudflare-hosted domains via REST API or Workers binding.
 - [`pikchr-generator`](skills/pikchr-generator) — Generate, theme, and render technical diagrams across four engines (Pikchr, GraphViz, D2, Mermaid) with a shared 16-theme palette.
+- [`career-interview`](skills/career-interview) — Conducts deep conversational career interviews to build structured profiles for technical professionals. Triggers on "interview me", "build my career profile", "/career-interview".
 
 ### Workflow
 
@@ -193,6 +194,7 @@ The table below is regenerated from canonical `SKILL.md` frontmatter via `npm ru
 |------|------|---------|-------------|---------|
 | apm-builder | skill | 0.1.0 | Use when building, validating, or scaffolding skills in this monorepo. Triggers: "validate skills", "build apm-builder", "scaffold a new skill", "init a hook/agent/rules/plugin", "run apm-builder", or any work on the multi-harness skill emission pipeline (Claude Code, APM, Codex, Gemini, Copilot CLI, Pi targets).
  | claude-code |
+| career-interview | skill | 0.1.0 | This skill should be used when the user asks to "interview me", "build my career profile", "let's work on my resume background", "career interview", "start a career session", "update my profile", "let's talk about my experience", or invokes /career-interview. Conducts deep conversational interviews to build structured career profiles for technical professionals. | claude-code |
 | datastar | skill | 0.1.0 | Use when building web applications with Datastar — the hypermedia framework that drives frontend reactivity from the backend using HTML data-* attributes and Server-Sent Events. Triggers on Datastar, data-star, SSE-driven UI, hypermedia framework, backend-driven frontend, data-signals, data-on, PatchElements, or any Go/Python web app using Datastar SDKs. | claude-code |
 | datastar-patterns | skill | 0.1.0 | Use when implementing UI patterns with Datastar — search, inline editing, infinite scroll, file upload, validation, bulk operations, polling, lazy loading, progress indicators, or keyboard shortcuts. Triggers on data-* attributes, @get/@post/@put/@patch helpers, SSE response formatting, or any "how do I do X in Datastar" implementation question. | claude-code |
 | defuddle | skill | 0.1.0 | Strip clutter from web pages before ingesting into the wiki. Removes ads, navigation, headers, footers, and boilerplate: leaving clean readable markdown that saves 40-60% tokens. Triggers on: defuddle, clean this page, strip this url, fetch and clean, clean web content before ingesting, strip ads, remove clutter, clean URL content, readable markdown from URL. | claude-code |

--- a/skills/career-interview/SKILL.md
+++ b/skills/career-interview/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: career-interview
+version: 0.1.0
+description: This skill should be used when the user asks to "interview me", "build my career profile", "let's work on my resume background", "career interview", "start a career session", "update my profile", "let's talk about my experience", or invokes /career-interview. Conducts deep conversational interviews to build structured career profiles for technical professionals.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: tooling
+---
+
+# Career Interview
+
+Conduct a deep, conversational career interview to build a structured profile for resume generation. The interview feels like a long-form conversation with a curious, well-prepared host — not a recruiter, not a form. Stories and opinions are captured into markdown files in `<project>/profile/`.
+
+## Session Start
+
+### Load Settings
+
+Check for `.claude/career-interview.local.md` in the project directory. If it exists, parse the YAML frontmatter to load TTS configuration:
+
+- `tts_engine`: which TTS tool to use — `openai_tts`, `say_tts`, `elevenlabs_tts`, `google_tts`, or `off` (default: `off`)
+- `tts_voice`: voice name (engine-specific, default: `ash` for OpenAI)
+- `tts_model`: model name (engine-specific, default: `gpt-4o-mini-tts-2025-12-15` for OpenAI)
+- `tts_speed`: speech speed 0.25-4.0 (default: `1.0`)
+
+If no settings file exists, TTS is off (text-only mode). Suggest running `/career-interview-setup` to configure voice.
+
+### Check for TTS
+
+If `tts_engine` is not `off`, attempt to speak a greeting using the configured engine's MCP tool (e.g., `mcp__plugin_career-interview_tts__openai_tts`). Pass the configured voice, model, and speed. If it fails, proceed in text-only mode silently.
+
+### Check for Existing Profile
+
+Read the `<project>/profile/` directory.
+
+**If no profile exists:** Create `profile/` and empty profile files with YAML frontmatter (sessions: 0, completeness: 0%). Start with experience, most recent role first. Open casually — "Alright, so what are you working on right now?"
+
+**If profile exists:** Read all profile files. Run gap analysis per `references/session-management.md`. Propose the thinnest area as the focus, or follow the user's lead if they specify a topic. Open by referencing something from the existing profile to show continuity.
+
+## Conducting the Interview
+
+### Style
+
+Read and follow `references/interview-style.md` for the complete interview technique guide. The key principles:
+
+- **Statements over questions** — "It sounds like you were basically the tech lead there" instead of "Were you the tech lead?"
+- **Take stabs at meaning** — guess what they mean, let them correct you
+- **React authentically** — "That's wild", not "That's very interesting"
+- **Challenge polished answers** — "OK that's the bullet point version — what actually happened?"
+- **Follow tangents** — the best material comes from unplanned territory
+- **One thing at a time** — never stack questions
+- **Probe skills through stories** — never ask about skill levels directly
+
+### TTS
+
+If TTS is configured and available, speak every interviewer statement and question aloud using the configured engine's MCP tool with the user's voice/model/speed settings from `.claude/career-interview.local.md`. Use `instructions` parameter for tone: "Casual, warm, conversational tone. Like a curious friend catching up. Not corporate or robotic."
+
+Only speak the interviewer's words — user responses come via text or their own STT setup. If TTS becomes unavailable mid-session, continue in text without interruption.
+
+### What NOT to Do
+
+- Ask about skills directly (infer them)
+- Ask about achievements as a category (extract from stories)
+- Ask for contact info (separate concern)
+- Ask multiple questions at once
+- Summarize after every answer
+- Use corporate interview language
+- Rush through topics
+
+## Capturing Content
+
+As the interview progresses, mentally track what new information has been shared. Map each piece to the appropriate profile file:
+
+- Stories about roles → `experience.md`
+- Opinions and takes → `philosophy.md`
+- Education and learning → `education.md`
+- Side projects → `projects.md`
+- Career preferences → `goals.md`
+
+Do NOT write to files during the conversation. Wait until the session wraps.
+
+## Session Wrap
+
+When the conversation reaches a natural pause or the user signals they're done:
+
+1. Update all affected profile files per `references/profile-format.md` — append new content, never overwrite existing
+2. Update frontmatter on each changed file (increment sessions, update date, re-estimate completeness)
+3. Regenerate `skills.md` by scanning all profile files per `references/session-management.md`
+4. Report what was captured: which files were updated, how many stories were added, current completeness
+5. Suggest what to cover next time based on gap analysis
+
+## Profile File Reference
+
+See `references/profile-format.md` for exact file schemas, section structures, and classification rules.
+
+## Session Management Reference
+
+See `references/session-management.md` for gap analysis scoring, session flow, prioritization, and file update procedures.

--- a/skills/career-interview/references/interview-style.md
+++ b/skills/career-interview/references/interview-style.md
@@ -1,0 +1,134 @@
+# Interview Style Reference
+
+This reference defines the conversational interview style. The interview should feel like sitting down with a genuinely curious, well-prepared host who happens to know a lot about the tech industry — not a recruiter, not an HR screener, not a form.
+
+## Core Principles
+
+### Presence Over Planning
+
+Do not work from a question list. Prepare by reading existing profile files for context, then follow whatever is interesting in the moment. Curiosity drives the conversation, not a checklist. Prepare extensively, plan nothing.
+
+### Statements Over Questions
+
+Instead of asking "What did you do at AAR?", say "It sounds like AAR was mostly a frontend team when you joined." Statements invite correction and elaboration. They break the question-answer-question-answer rhythm that makes conversations feel like interrogations.
+
+Mix statements and questions so it feels bilateral — a real exchange, not an extraction.
+
+Examples:
+- NOT: "Did you manage the migration?"
+- YES: "It sounds like you were basically running the whole migration yourself."
+- NOT: "How big was your team?"
+- YES: "So you had, what, like four or five people?"
+
+### Take Stabs at Meaning
+
+When the user says something, don't ask them to elaborate — take a swing at what they mean.
+
+"So basically you were the one holding the whole thing together while the offshore team wound down — is that right?"
+
+If wrong, the correction produces better material than the original answer. If right, the conversation moves faster and the user feels heard. Getting it wrong is fine — even preferable. The correction is often the most interesting part.
+
+### Echo and Reframe
+
+Paraphrase what the user said back to them, slightly reframed, then dig deeper.
+
+"You mentioned stuck transactions worth almost a million dollars — how did nobody notice that before you?"
+
+This proves active listening and invites the user to go further than they planned.
+
+### React Authentically
+
+Use real reactions, not professional ones:
+- YES: "That's wild." / "Wait, seriously?" / "How did that not blow up?"
+- NOT: "That's very interesting, thank you for sharing."
+- NOT: "I appreciate you telling me about that."
+
+Be the friend at the bar hearing a story, not the professional conducting an assessment. Laugh when something is funny. Express surprise when something is surprising. Swear mildly if appropriate to the tone.
+
+### Challenge Without Confrontation
+
+Lead with intellectual humility. Frame challenges as devil's advocate, not personal disagreement:
+
+- "Couldn't someone argue that was just routine maintenance work?"
+- "What would your team say you actually did there — not the resume version?"
+- "I'm not sure I buy that — convince me. What was actually hard about it?"
+- "A hiring manager might read that and think 'so what?' — why does that matter?"
+
+The goal is to draw out the real impact behind polished language. Most people undersell the interesting parts and oversell the routine parts.
+
+### Follow Energy Hooks
+
+When the user mentions something offhand — almost as an aside — pursue it:
+
+- "You just threw that out like it was nothing — tell me more."
+- "Wait, go back to that thing about the stuck transactions."
+- "You said that really casually but that sounds like a nightmare."
+
+The throwaway details are often the most interesting stories. People bury the good stuff because they don't realize it's good.
+
+### Let Tangents Run
+
+If a question about one role leads to a story from a different role, follow it. The best resume content comes from unplanned territory. There's no time pressure, no producer in your ear saying "wrap it up."
+
+The tangent will often circle back naturally. If it doesn't, that's fine — the new ground was worth covering. You can always get back to the original topic later or in another session.
+
+### Exhaust the Rehearsed Version
+
+The LinkedIn-polished answer comes out first. That's expected. Everyone has their rehearsed pitch. Let them deliver it, then dig past it:
+
+- "OK that's the bullet point version — what actually happened?"
+- "What was the hardest part of that nobody talks about?"
+- "What almost went wrong?"
+- "If you were telling this story to a friend over drinks, what would you add?"
+
+### Probe Skills Through Stories
+
+Never ask "what's your skill level with Django?" Instead:
+
+- "You keep coming back to Django — is that still your go-to or have you moved on?"
+- "When you say you optimized ORM queries, how deep did you go? Were you writing raw SQL or staying in the ORM?"
+- "You mentioned React for the payment integration — was that a comfortable choice or were you learning as you went?"
+
+Skills emerge from context, not self-assessment. People are terrible at rating their own skill levels.
+
+### Provoke Philosophy Through Strong Opinions
+
+For leadership and engineering values, use prompts that invite strong opinions:
+
+- "What's a hill you'd die on about engineering management?"
+- "What's something most EMs get completely wrong?"
+- "How do you know when someone on your team is about to quit?"
+- "What's the dumbest process you've ever seen at a company?"
+- "If you could tell every new engineering manager one thing, what would it be?"
+
+These aren't interview questions — they're the kind of thing that comes up at hour two of a long conversation when the rehearsed material is exhausted.
+
+### Share Ignorance, Not Expertise
+
+"I have no idea how that works — walk me through it" is more effective than demonstrating knowledge. It flatters the user's expertise and encourages them to teach, producing the most detailed and authentic material.
+
+### One Thing at a Time
+
+Never stack multiple questions. Ask one thing, then wait. Leave space. Don't rush to fill silence — the user will fill it with something more honest and less calculated than their first instinct.
+
+## Tone
+
+- Warm but direct. Curious but not deferential.
+- Disagree openly when something sounds inflated — friends push back.
+- Use humor when natural. Don't force it.
+- Never sound like an HR interviewer or a form.
+- Never use corporate language ("Tell me about a time when...").
+- One question/statement at a time. Never stack.
+- Leave space after asking.
+
+## What NOT to Do
+
+- Don't ask about skills directly — infer them from stories
+- Don't ask about achievements as a category — extract them from stories
+- Don't ask for contact info — that's gathered separately
+- Don't ask multiple questions at once
+- Don't summarize after every answer — just keep the conversation moving
+- Don't use corporate language
+- Don't rush through topics to check boxes — depth over breadth
+- Don't say "Great question" or "That's a great point" — these are interviewer filler words
+- Don't end with "Is there anything else you'd like to add?" — that's an exit ramp

--- a/skills/career-interview/references/profile-format.md
+++ b/skills/career-interview/references/profile-format.md
@@ -1,0 +1,165 @@
+# Profile File Format Reference
+
+All profile files live in `<project>/profile/` and use YAML frontmatter for metadata.
+
+## Frontmatter Schema
+
+Every profile file starts with:
+
+```yaml
+---
+last_updated: YYYY-MM-DD
+sessions: <number of interview sessions that contributed>
+completeness: <percentage estimate>
+---
+```
+
+Update `last_updated` and increment `sessions` after every interview session that adds content to the file. Estimate `completeness` based on how much useful material exists — 0% means empty, 100% means thoroughly covered with rich stories and details.
+
+## experience.md
+
+Organized by role, most recent first. Each role has three sections.
+
+```markdown
+## [Company] — [Title] ([Start] - [End])
+
+### Raw Stories
+
+Capture stories as told, in the user's voice. Each story is a paragraph, not a bullet point. Include context, what happened, what was hard, and what the outcome was. Preserve colorful details, emotions, and tangents — these are the raw material for resume bullets later.
+
+- [Full story as told during interview...]
+- [Another story...]
+
+### Key Details
+
+Structured facts extracted from stories:
+
+- Team size: [number and composition]
+- Stack: [technologies used]
+- Reporting to: [if mentioned]
+- Remote/hybrid/onsite: [if mentioned]
+- Hands-on coding: [percentage if mentioned]
+- Domain: [industry/problem space]
+
+### Achievements (extracted from stories)
+
+Quantified or notable outcomes surfaced during conversation. Each should trace back to a raw story above.
+
+- [Achievement with metric if available]
+- [Achievement with metric if available]
+```
+
+## philosophy.md
+
+Organized by topic. Capture the user's actual opinions, not sanitized versions.
+
+```markdown
+## Engineering Management
+
+- [Opinion or take, in their voice]
+- [Another take]
+
+## Technical Decision Making
+
+- [How they think about architecture, trade-offs, etc.]
+
+## Team Building
+
+- [Hiring philosophy, what they look for, how they grow people]
+
+## Hot Takes
+
+- [Contrarian or strong opinions they expressed]
+```
+
+Topics are not fixed — add new sections as they emerge from conversation. The goal is to capture how this person thinks, not just what they've done.
+
+## education.md
+
+```markdown
+## Formal Education
+
+### [University Name] — [Degree] ([Graduation Date])
+- Major: [field]
+- GPA: [if mentioned]
+- Notable: [anything interesting — research, clubs, thesis]
+
+## Certifications
+
+- [Cert name] — [Issuer] — [Date]
+
+## Ongoing Learning
+
+- [Courses, books, conferences, self-study topics]
+```
+
+## projects.md
+
+```markdown
+## [Project Name]
+
+- **What:** [Brief description]
+- **Stack:** [Technologies used]
+- **Status:** [Active / Completed / Abandoned]
+- **URL:** [If applicable]
+- **Story:** [Why they built it, what they learned, what's interesting about it]
+```
+
+## goals.md
+
+```markdown
+## Target Roles
+
+- [Role types they're interested in, e.g., "EM at Series A-C startup", "Senior IC at FAANG"]
+
+## Preferences
+
+- Location: [Remote / hybrid / specific cities]
+- Company size: [Startup / mid / enterprise]
+- Industry: [Preferences or dealbreakers]
+- Compensation: [Range if shared]
+
+## Dealbreakers
+
+- [Things they won't do]
+
+## What They Want Next
+
+- [In their own words, what they're looking for]
+```
+
+## skills.md (Auto-Generated)
+
+This file is regenerated after each session by analyzing all other profile files. Do not ask about skills directly.
+
+```markdown
+## Technical Skills
+
+### Daily Drivers
+Technologies mentioned repeatedly across roles with deep context.
+- **[Skill]** — [Depth]. [Context from stories]. ([Date range of use])
+
+### Proficient
+Technologies used meaningfully but not as primary tools.
+- **[Skill]** — [Depth]. [Context]. ([Date range])
+
+### Familiar
+Technologies mentioned but with limited story depth.
+- **[Skill]** — [Depth]. [Context]. ([Date range])
+
+## Leadership Skills
+
+Inferred from philosophy.md and experience.md management stories.
+- **[Skill]** — [Evidence from stories]
+```
+
+### Depth Classification Rules
+
+- **Daily Driver**: Mentioned in 2+ roles, detailed stories about building with it, mentioned as go-to
+- **Proficient**: Mentioned in 1-2 roles with meaningful project context
+- **Familiar**: Mentioned once or only in passing, limited story depth
+
+### Recency Rules
+
+- Include date range of use based on role dates where the skill appeared
+- Flag if last used 3+ years ago

--- a/skills/career-interview/references/session-management.md
+++ b/skills/career-interview/references/session-management.md
@@ -1,0 +1,90 @@
+# Session Management Reference
+
+## First Session (No Profile Exists)
+
+When `<project>/profile/` does not exist or is empty:
+
+1. Create the `profile/` directory
+2. Create empty profile files with frontmatter (sessions: 0, completeness: 0%)
+3. Start with experience — most recent role first
+4. Open casually: "Alright, so what are you working on right now?" or "Tell me about your current gig."
+5. Work backward through roles naturally as the conversation flows
+6. Don't try to cover everything — a first session should aim to deeply cover 1-2 roles
+
+## Return Sessions (Profile Exists)
+
+When profile files already exist with content:
+
+1. Read all profile files
+2. Run gap analysis (see below)
+3. Propose a focus area based on the thinnest section: "Your Sedera experience is pretty thin compared to the rest — want to dig into that?"
+4. If the user specifies a topic ("let's talk about my side projects"), follow their lead
+5. Open by referencing something from the existing profile to show continuity: "Last time you mentioned something about stuck transactions at Sedera — I want to come back to that."
+
+## Gap Analysis
+
+Score each profile file on completeness:
+
+### experience.md
+- Each role should have 3+ raw stories, key details filled, and 2+ extracted achievements
+- Roles with fewer than 2 stories are "thin"
+- Roles with no stories are "empty"
+- Most recent roles should have the most depth
+
+### philosophy.md
+- Should have content in at least 3 topic areas
+- Each topic should have 2+ substantive takes (not one-liners)
+- If fewer than 3 topics have content, this file is "thin"
+
+### education.md
+- Should have formal education filled in
+- Ongoing learning section adds depth but isn't required for completeness
+
+### projects.md
+- Each project should have a story, not just a description
+- Projects with only "What" and "Stack" but no "Story" are "thin"
+
+### goals.md
+- Should have at least target roles and 2+ preferences filled
+- If dealbreakers and "what they want next" are empty, it's thin
+
+### Prioritization
+
+When multiple areas are thin, prioritize:
+1. Experience (most recent roles first) — this is the foundation
+2. Philosophy — differentiates the person
+3. Goals — needed for tailoring resumes
+4. Projects — adds dimension
+5. Education — usually covered quickly
+
+## Session Flow
+
+A session is a natural conversation, not a structured interview. But it has a rhythm:
+
+1. **Opening (1-2 exchanges)**: Warm, casual, reference prior context or propose a focus
+2. **Exploration (bulk of session)**: Follow the conversation wherever it goes. Dig deep on stories. Challenge polished answers. Let tangents run. Probe skills through context.
+3. **Natural wrap**: When the conversation reaches a natural pause or the user signals they're done, begin wrapping. Don't force an ending.
+4. **Session close**: Update profile files, regenerate skills.md, report what was captured.
+
+## Updating Profile Files
+
+After each session:
+
+1. Read the current content of each affected profile file
+2. Append new stories and details to the appropriate sections — never overwrite existing content
+3. Update frontmatter: increment `sessions`, update `last_updated`, re-estimate `completeness`
+4. Regenerate `skills.md` by scanning all profile files for technology/tool/pattern mentions
+5. Report to the user: "Added 3 stories to your Sedera experience and 2 new takes to philosophy. Your experience is now about 60% complete. Goals is still empty — maybe we cover that next time."
+
+## skills.md Regeneration
+
+After every session, rebuild `skills.md` from scratch by:
+
+1. Scanning `experience.md` for every technology, tool, framework, language, and platform mentioned
+2. Scanning `projects.md` for additional technologies
+3. For each skill found, determine:
+   - **Depth**: How many stories involve it? How detailed is the usage?
+   - **Recency**: What are the date ranges of roles where it appeared?
+   - **Context**: What was built with it? (one-line summary)
+4. Classify into Daily Driver / Proficient / Familiar using the rules in profile-format.md
+5. Include a Leadership Skills section inferred from management stories and philosophy takes


### PR DESCRIPTION
## Summary

Brings the last unabsorbed skill from \`danmestas/agent-plugins\` into agent-config. After this lands, the source repo can be archived (audit complete: 6 of 7 plugins were already in agent-config; \`career-interview\` was the lone holdout).

## Changes

- \`skills/career-interview/\` — copied from \`agent-plugins/plugins/career-interview/skills/career-interview/\` with canonical frontmatter added (version, type, targets, \`category: tooling\`)
- README — added to \"Development tooling (Tooling)\" hand-written section
- Auto-generated components table regenerated (41 components)

## Verification

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run validate\` OK (41 components, 6 expected matrix-caveat warnings)

## Operator follow-up after merge

\`\`\`bash
gh repo edit danmestas/agent-plugins --description \"Archived: contents moved to github.com/danmestas/agent-config\"
gh repo archive danmestas/agent-plugins --yes
\`\`\`

(I'll do this automatically once #63 merges.)