### PR TITLE
feat: 7 new Evolution skills (skill-gap-detector, reflect, memorize, skill-eval-runner, description-linter, stuck-detector, evolution-changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Multi-harness AI agent configuration monorepo. Authors write skills, plugins, ho
 The repo's directory structure mirrors the component-type schema:
 
 ```
-skills/      — type: skill   (39 components — typed agent capabilities triggered by description)
+skills/      — type: skill   (46 components — typed agent capabilities triggered by description)
 plugins/     — type: plugin  (1 component — multi-skill bundles)
 hooks/       — type: hook    (1 component — event-driven scripts)
 agents/      — type: agent   (planned)
@@ -110,6 +110,13 @@ Bundled as the [`knowledge-base`](plugins/knowledge-base) plugin (install once f
 ### Evolution
 
 - [`evolution-engine`](skills/evolution-engine) — Read recent session transcripts, detect recurring friction patterns, emit unified-diff fixes against existing skills/configs/memory. CLI: `npm run evolve`.
+- [`skill-gap-detector`](skills/skill-gap-detector) — Find *missing* skills (not edits) by scanning sessions for "I had to explain X 3+ times" clusters. Drafts proposed SKILL.md files under `~/.claude/evolution-reports/<project>/proposed-skills/` for human review.
+- [`reflect`](skills/reflect) — Structured post-task critique. Five sections (summary / went well / didn't / proposals / open questions) → markdown report. No auto-apply.
+- [`memorize`](skills/memorize) — Pairs with `/reflect`. Converts an agreed proposal or insight into a project ADR (`docs/adr/`) or personal memory (`~/.claude/projects/<project>/memory/`). Always confirms content first.
+- [`skill-eval-runner`](skills/skill-eval-runner) — Binary pass/fail evals (no scoring, per MindStudio research) for skill descriptions. Reads `skills/<name>/tests/evals.json`. Auto-fires after SKILL.md edits.
+- [`description-linter`](skills/description-linter) — Static analyzer for SKILL.md frontmatter: trigger-phrase heuristics, length cap, kebab-case names, cross-skill conflict detection. Reports only — no auto-fix.
+- [`stuck-detector`](skills/stuck-detector) — Off-ramp when the agent (or user) hits a doom-loop. Stops retrying, writes a structured handoff, asks whether to escalate / pause / continue with reduced scope.
+- [`evolution-changelog`](skills/evolution-changelog) — Maintains `EVOLUTION.md` at repo root: append-only log of applied evolution-driven changes, one bullet per change with signal, file, and one-line rationale.
 
 ### Frontend frameworks (Tooling)
 
@@ -164,7 +171,21 @@ The table below is regenerated from canonical `SKILL.md` frontmatter via `npm ru
 
 | Name | Type | Version | Description | Targets |
 |------|------|---------|-------------|---------|
+| description-linter | skill | 0.1.0 | Use when the user types "lint my skills", "check skill descriptions", "/lint-skills", "validate skill triggers", "audit skill descriptions", or asks whether two skills conflict on the same prompt. Also fires PostToolUse on edits to any skills/*/SKILL.md. Static-analyzes SKILL.md frontmatter for trigger quality, length, naming, and cross-skill conflicts. Does NOT auto-fix — only reports.
+ | claude-code |
+| evolution-changelog | skill | 0.1.0 | Use when the user types "/changelog evolution", "log this evolution", "track applied evolutions", "update EVOLUTION.md", or asks to record what evolution-driven changes have been applied to the repo. Also fires PostToolUse on `git apply` operations against files matching the evolution-report path pattern. Maintains the EVOLUTION.md changelog at the repo root, one date-section per day, one bullet per applied change.
+ | claude-code |
 | evolution-engine | skill | 0.1.0 | Use when the user wants to "analyze sessions", "find patterns in my agent history", "evolve config", "/evolve", "what's been frustrating you", or asks for automated suggestions for improving skills/configs based on session transcripts. Triggers on requests to surface recurring friction, propose allowlist additions, find stale memory, or generate diff-shaped recommendations against existing skills, settings, and memory files.
+ | claude-code |
+| memorize | skill | 0.1.0 | Use when the user types "/memorize", "save this learning", "make this an ADR", "capture this for future sessions", "remember this", "write this down for next time", or "save that proposal". Also auto-fires after /reflect when the user expresses agreement with a proposal. Converts a recent insight or reflection into either a project ADR or a personal memory entry. Always confirms content with the user before writing.
+ | claude-code |
+| reflect | skill | 0.1.0 | Use when the user types "/reflect", "review what we just did", "critique the last task", "what could go better", "post-task review", "retro this", or after a meaningful task ships and the agent judges a structured critique would help. Produces a markdown reflection report at ~/.claude/evolution-reports/<project>/reflections/. Does NOT auto-apply changes — output is for human review.
+ | claude-code |
+| skill-eval-runner | skill | 0.1.0 | Use when the user types "/eval skill X", "test skill X", "run evals on", "regression test skill", "eval skill", or asks whether a skill's description still triggers correctly. Also fires PostToolUse on edits to any skills/*/SKILL.md so a freshly-edited skill's triggers are immediately checked. Runs binary pass/fail evals (no scoring) per MindStudio's research.
+ | claude-code |
+| skill-gap-detector | skill | 0.1.0 | Use when the user wants to "find missing skills", "what skills should I have", "what am I explaining over and over", "/skill-gap", "audit my repeated instructions", or asks which skills they're missing based on session history. Also weekly cron-friendly. Scans recent session transcripts for "I had to explain X 3+ times" patterns and drafts proposed new SKILL.md files for human review. Does NOT auto-install.
+ | claude-code |
+| stuck-detector | skill | 0.1.0 | Use when the user says "stuck", "I'm stuck", "this isn't working", "tool keeps failing", "give up on this", "we're going in circles", "/stuck", or when the agent itself notices it has hit N consecutive tool errors in a session window. Generates a handoff summary so progress can resume in a fresh session, escalate to a stronger model, or pause for user input. Stops the doom-loop of blind retries.
  | claude-code |
 
 ### integrations

--- a/skills/description-linter/SKILL.md
+++ b/skills/description-linter/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: description-linter
+version: 0.1.0
+description: >
+  Use when the user types "lint my skills", "check skill descriptions", "/lint-skills",
+  "validate skill triggers", "audit skill descriptions", or asks whether two skills
+  conflict on the same prompt. Also fires PostToolUse on edits to any skills/*/SKILL.md.
+  Static-analyzes SKILL.md frontmatter for trigger quality, length, naming, and
+  cross-skill conflicts. Does NOT auto-fix — only reports.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# description-linter
+
+A static analyzer for `description` fields in `skills/*/SKILL.md`. Reports issues; does not fix.
+
+## When to invoke
+
+- User explicit: `/lint-skills`, "lint descriptions", "audit my skills".
+- Auto-firing: PostToolUse on any edit to `skills/*/SKILL.md`.
+
+## Lint rules
+
+For each skill:
+
+### 1. Trigger phrases present
+
+The description must contain at least:
+- One **verb** indicating an action ("create", "build", "review", "find", "lint", "test", "manage").
+- Two **concrete user phrases** in quotes or otherwise clearly demarcated, e.g., `"/lint-skills"`, `"check my skills"`. Quoted phrases survive the harness's matching better than abstract descriptions.
+
+If the description is purely abstract ("skill for design philosophy") with no quoted/concrete phrases → **flag**.
+
+### 2. Length cap
+
+- **Hard cap: 800 chars.** Anything longer almost certainly hurts trigger reliability — the harness's relevance scoring is dominated by the first sentence in long descriptions, and the rest is noise.
+- **Soft cap: 500 chars.** Above 500 → warn ("trim or split"). The strongest descriptions in this repo are 200-450 chars.
+
+### 3. Name shape
+
+- Must be `kebab-case` (already enforced by Zod schema in `apm-builder/lib/schema.ts`, but call it out so the user sees the rule.)
+- Must be ≤4 words / ≤30 chars. Long names are a smell — usually mean the skill does too much.
+
+### 4. Conflict check (the load-bearing rule)
+
+For every pair of skills (A, B):
+- Extract the trigger phrases from each (the substrings inside `"..."`, the verbs, and the slash-commands).
+- If 2+ trigger phrases match between A and B → **flag conflict.**
+
+The fast check is a one-liner; the agent can run:
+
+```bash
+grep -E '"[^"]{3,40}"' skills/*/SKILL.md | sort | uniq -c | sort -rn | head -30
+```
+
+The phrases that show up in 2+ skills are conflict candidates. Manually verify each before flagging — generic words like "skill" or "use" are noise.
+
+## Output format
+
+Print one block per affected skill:
+
+```
+description-linter: skills/<name>/SKILL.md
+  WARN  length          612 chars (soft cap 500)
+  FAIL  no-trigger      no quoted concrete phrase found
+  WARN  conflict        shares trigger "review code" with skills/<other>
+        Resolution: tighten one description to disambiguate (e.g., "review Go code" vs. "review TS code").
+```
+
+Roll-up at the bottom:
+
+```
+----
+27 skills checked. 2 FAIL, 4 WARN, 21 OK.
+```
+
+## Anti-patterns
+
+- **Do NOT auto-fix descriptions.** This skill is for *humans to read*. Auto-rewriting trigger phrases is destructive — the human knows their own use case better than a generic rule.
+- **Do NOT block commits.** Even on auto-fire (PostToolUse), output is informational. Hooks should not refuse the edit.
+- **Do NOT lint plugins or hooks the same way as skills.** Plugins are bundles (description matters less) and hooks are event-driven (no description-matching at all). Restrict the trigger-phrase rules to `type: skill`.
+- **Don't be cute about ambiguity.** If two skills genuinely overlap but the user wants both (e.g., `vault-overview` and `knowledge-base-overview` reference each other), flag once and let the human dismiss.
+
+## See also
+
+- `apm-builder/lib/schema.ts` — kebab-case enforcement (already-running ground truth).
+- `skills/skill-eval-runner/SKILL.md` — the dynamic complement (does the description actually trigger?).
+- `skills/evolution-engine/SKILL.md` — sibling that proposes diffs against descriptions when triggers are observed-failing.

--- a/skills/evolution-changelog/SKILL.md
+++ b/skills/evolution-changelog/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: evolution-changelog
+version: 0.1.0
+description: >
+  Use when the user types "/changelog evolution", "log this evolution", "track applied
+  evolutions", "update EVOLUTION.md", or asks to record what evolution-driven changes
+  have been applied to the repo. Also fires PostToolUse on `git apply` operations
+  against files matching the evolution-report path pattern. Maintains the EVOLUTION.md
+  changelog at the repo root, one date-section per day, one bullet per applied change.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# evolution-changelog
+
+Maintains `EVOLUTION.md` at the repo root: a human-readable log of which evolution-driven changes have been applied, when, and why. Closes the loop between `evolution-engine` proposals and the actual repo history.
+
+## When to invoke
+
+- User explicit: "log this evolution", "/changelog evolution", "update the EVOLUTION log".
+- Auto-firing: PostToolUse hook on Bash invocations matching `git apply` against any path under `~/.claude/evolution-reports/` or any patch produced by `evolution-engine`.
+
+## File location
+
+```
+<repo-root>/EVOLUTION.md
+```
+
+If it doesn't exist, create it with the header from the format example below.
+
+## Format
+
+```markdown
+# Evolution Changelog
+
+A log of applied evolution-driven changes to this repo. Each entry: date, signal that
+fired, file changed, one-line description.
+
+## 2026-04-27
+
+- **stale-memory** | `~/.claude/projects/agent-config/memory/feedback_old.md` deleted | dead branch reference cleaned
+- **permission-recurring** | `.claude/settings.json` allowlist | added `npm test` (approved 7×)
+- **trigger-mismatch** | `skills/reflect/SKILL.md` description | added `"retro this"` after eval failure
+
+## 2026-04-20
+
+- **edit-thrashing** | `skills/orchestrator-mode/SKILL.md` body | clarified §7 loop after 4 reverts
+```
+
+The format is deliberately simple: `**<signal>** | <file> | <one-line description>`. No prose; no nesting; one bullet per applied change.
+
+## Workflow
+
+### 1. Locate the source report
+
+Most commonly, the latest evolution-engine output:
+
+```
+~/.claude/evolution-reports/<project>/<YYYY-MM-DD>.md
+```
+
+Read its findings. Each finding has a signal name (e.g., `permission-recurring`, `stale-memory`, `edit-thrashing`) and a target file.
+
+### 2. Determine which were *actually applied*
+
+Cross-check against `git log` since the report's date. For each finding, check whether the proposed file change shows up in commit history. Only applied changes get logged.
+
+(If invoked auto-firing on `git apply`, the patch path identifies the finding directly — no cross-check needed.)
+
+### 3. Append to EVOLUTION.md
+
+- If today's `## YYYY-MM-DD` section exists, add bullets to it.
+- If not, create a new section *above* the previous one (most recent on top).
+- Keep entries chronologically descending: today first, then earlier dates.
+
+### 4. Format each bullet
+
+```
+- **<signal-name>** | <path-relative-to-repo-root-or-~/.claude> | <one-line-description-of-change>
+```
+
+Rules:
+- `<signal-name>` is the exact signal from the evolution report (kebab-case).
+- `<path>` is a single file or settings key, not a directory.
+- `<description>` is one sentence, ≤80 chars. Imperative or past tense, consistent within a section.
+
+### 5. Commit (if asked)
+
+This skill writes the file. It does NOT auto-commit. The user runs `git add EVOLUTION.md && git commit` themselves, or asks the agent to.
+
+## Anti-patterns
+
+- **Do NOT log proposals that weren't applied.** EVOLUTION.md is the *applied* log, not the *proposed* log. The proposed log is each day's evolution-report.
+- **Do NOT prose it up.** This is a changelog. One line per change. If a change needs more explanation, link to the source report or commit, don't expand inline.
+- **Do NOT auto-commit.** Writing the file is one operation; committing is a different decision.
+- **Do NOT delete or rewrite history.** Append-only. If a previous entry was wrong, add a correction bullet under today's date — don't edit history.
+
+## See also
+
+- `skills/evolution-engine/SKILL.md` — the upstream that produces the per-day reports.
+- `skills/reflect/SKILL.md` + `skills/memorize/SKILL.md` — those produce ADRs/memory; EVOLUTION.md is the third artifact and tracks file-level changes.
+- `EVOLUTION.md` (this repo's root) — the file maintained by this skill.

--- a/skills/memorize/SKILL.md
+++ b/skills/memorize/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: memorize
+version: 0.1.0
+description: >
+  Use when the user types "/memorize", "save this learning", "make this an ADR",
+  "capture this for future sessions", "remember this", "write this down for next time",
+  or "save that proposal". Also auto-fires after /reflect when the user expresses
+  agreement with a proposal. Converts a recent insight or reflection into either
+  a project ADR or a personal memory entry. Always confirms content with the user
+  before writing.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# memorize
+
+Persists a learning. Pairs with `reflect`: reflection produces proposals, memorize converts agreed proposals into durable artifacts.
+
+## When to invoke
+
+- User explicit: `/memorize`, "save that", "make it an ADR", "remember this for next time".
+- Auto-firing: immediately after `/reflect` if the user replies with agreement (e.g., "yes do that", "ship it", "good, save it"). The agent picks up the most-recently-agreed proposal.
+
+## Two output forms
+
+The skill writes ONE of two file shapes, chosen by scope:
+
+### Form A: Project ADR (project-scoped lessons)
+
+For learnings that belong with the codebase — "this repo's commit hooks expect signed commits", "this codebase's tests need DB seeded first", etc.
+
+- Path: `<repo-root>/docs/adr/<YYYY-MM-DD>-<topic-slug>.md`
+- ONLY write here if `<repo-root>/docs/adr/` already exists.
+- If it doesn't exist, **propose** creating it: tell the user "this lesson is project-scoped but `docs/adr/` doesn't exist; want me to create it?" Wait for explicit yes before mkdir.
+
+ADR format:
+
+```markdown
+# <YYYY-MM-DD>: <Topic>
+
+## Context
+
+One paragraph: what situation surfaced this lesson.
+
+## Decision
+
+What we decided / what the rule is going forward.
+
+## Consequences
+
+What this implies for future contributors.
+
+## Provenance
+
+- Source: `/reflect` on <date> | inline insight from session <id>
+- Related files: <list>
+```
+
+### Form B: Personal memory (cross-project lessons)
+
+For learnings about *the user* — preferences, recurring frustrations, principles — that should travel with the user across all projects.
+
+- Path: `~/.claude/projects/<project>/memory/feedback_<topic>.md`
+- This is compatible with the existing auto-memory system; the runtime indexes these and surfaces them in MEMORY.md.
+
+Memory format:
+
+```markdown
+# <Title — short, declarative>
+
+<2-4 sentence body explaining the lesson, in the user's voice as much as possible.
+Include the trigger phrase that caused the lesson if there is one.>
+
+## When this applies
+
+- <bullet: trigger condition 1>
+- <bullet: trigger condition 2>
+
+## Source
+
+- Session: <id or date>
+- Related: <reflection path if applicable>
+```
+
+## Workflow
+
+1. Identify what to memorize:
+   - From `/reflect` proposals: the user agreed to a specific proposal. Pull its text verbatim.
+   - From inline insight: read recent conversation and synthesize one paragraph.
+
+2. Decide scope (Form A vs Form B):
+   - Mentions a specific file/path/command in the current repo → Form A.
+   - About preferences, principles, recurring user friction → Form B.
+   - Ambiguous → ask the user.
+
+3. **Show the file content to the user before writing.** Render the proposed content in the chat. Get explicit confirmation. Edit if requested.
+
+4. Write the file. Print the path.
+
+## Anti-patterns
+
+- **Don't write without showing first.** Always preview, get confirmation, then write.
+- **Don't make it both forms.** One memorize call = one file. If something is both project-scoped AND personal, propose two memorize calls explicitly.
+- **Don't memorize trivia.** "We used grep today" is not a lesson. Lessons must include a *generalizable* rule.
+- **Don't expand beyond one topic per file.** Multiple lessons get multiple files.
+
+## See also
+
+- `skills/reflect/SKILL.md` — the upstream that surfaces what to memorize.
+- `skills/evolution-engine/SKILL.md` — finds *recurring* friction; memorize captures *one* lesson at a time.
+- `~/.claude/projects/<project>/memory/MEMORY.md` — the auto-memory index where Form B entries appear.

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: reflect
+version: 0.1.0
+description: >
+  Use when the user types "/reflect", "review what we just did", "critique the last task",
+  "what could go better", "post-task review", "retro this", or after a meaningful task
+  ships and the agent judges a structured critique would help. Produces a markdown
+  reflection report at ~/.claude/evolution-reports/<project>/reflections/. Does NOT
+  auto-apply changes — output is for human review.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# reflect
+
+A structured post-task critique. Inspired by the Reflexion pattern: the agent reasons over its own recent transcript and emits a written self-assessment with specific, actionable proposals. The output is reviewable; nothing auto-applies.
+
+## When to invoke
+
+- User explicit: `/reflect`, "let's retro this", "what went wrong", "critique that".
+- Auto-firing: after a "meaningful task" ships. The agent decides what "meaningful" means — typical heuristics:
+  - A PR was opened or merged.
+  - A multi-step plan executed to completion.
+  - A reported bug was fixed and verified.
+  - A new skill, hook, or component landed.
+- Skip for trivial single-tool tasks (one read, one edit, one shell command). Reflection on noise is noise.
+
+## The structured critique
+
+Produce a markdown report with exactly these five sections, in order:
+
+### 1. Summary
+
+One sentence describing what was attempted.
+
+> Built 7 Evolution-category skills under `skills/<name>/SKILL.md` and opened PR #N.
+
+### 2. What went well
+
+A bullet list of 2-5 items. Be specific — "tests passed" is too generic; "validate caught a bad category enum on the second skill before commit" is useful.
+
+### 3. What didn't
+
+A bullet list of 2-5 items. Cite the moment things went off-track:
+
+- Quote the exact tool error or user correction.
+- Identify the upstream cause (wrong assumption, missing context, skipped check).
+- Note whether you noticed it yourself or the user pointed it out (the latter is worse).
+
+### 4. Specific actionable proposals
+
+For each "didn't go well" item, propose ONE concrete change. Each proposal must name:
+
+- **The artifact** to change: a file path, a memory entry, a skill description, a settings.json key.
+- **The diff shape**: what to add, remove, or replace. Quote enough surrounding context to be unambiguous.
+- **The trigger condition**: when next time this proposal would have helped.
+
+Example:
+
+> **Proposal:** add `npm run validate` to the pre-commit allowlist in `.claude/settings.json` so future commits in this repo don't trigger a permission prompt for it.
+>
+> Trigger condition: any commit in `agent-config`. Saw this 3× this session.
+
+### 5. Open questions
+
+Things the agent isn't sure about. Phrase as questions for the human, not as more proposals. ("Should reflection auto-fire on PR-merged events, or wait for explicit `/reflect`?")
+
+## Output
+
+```
+~/.claude/evolution-reports/<project>/reflections/<YYYY-MM-DD>-<topic-slug>.md
+```
+
+`<topic-slug>` is a short kebab-case description of the task, ≤4 words, derived from the conversation. E.g., `2026-04-27-evolution-skills.md`.
+
+After writing, print the path to the user. Do not pre-apply any of the proposals.
+
+## Pairing with `/memorize`
+
+If the user agrees with proposals from this reflection, the `memorize` skill (auto-fired on agreement, or invoked by the user) converts the relevant proposals into durable ADRs or memory entries.
+
+## Anti-patterns
+
+- **No bland self-praise.** "We did a good job" with no specifics is wasted output.
+- **No rumination.** Cap each section at 5 bullets. Long reflections don't get read.
+- **No auto-apply.** Even obvious-looking proposals stay as proposals. The human reviews and triggers `/memorize` for the ones worth keeping.
+- **No vague proposals.** "Improve error handling" fails the spec. "Wrap the Bash call at <file:line> in a try/catch and log to <path>" passes.
+
+## See also
+
+- `skills/memorize/SKILL.md` — converts agreed proposals into durable ADRs/memory.
+- `skills/evolution-engine/SKILL.md` — does pattern-detection across sessions; reflection is per-task.
+- `skills/skill-gap-detector/SKILL.md` — finds missing skills; reflection finds tactical fixes.

--- a/skills/skill-eval-runner/SKILL.md
+++ b/skills/skill-eval-runner/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: skill-eval-runner
+version: 0.1.0
+description: >
+  Use when the user types "/eval skill X", "test skill X", "run evals on", "regression
+  test skill", "eval skill", or asks whether a skill's description still triggers correctly.
+  Also fires PostToolUse on edits to any skills/*/SKILL.md so a freshly-edited skill's
+  triggers are immediately checked. Runs binary pass/fail evals (no scoring) per
+  MindStudio's research.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# skill-eval-runner
+
+Binary pass/fail evals for skill descriptions. Each test case is a prompt + the skill that *should* be invoked. The agent reads the description, judges (using its own description-matching, no external LLM call), and reports pass/fail per prompt.
+
+## Why binary, not scored
+
+MindStudio's research on agent evals: scoring (1-10) introduces noise from the judge model and gives false precision. A skill either triggers correctly on a prompt or it doesn't. Roll-up: a skill passes its eval if every prompt passes; otherwise it fails and the user sees which prompts regressed.
+
+## When to invoke
+
+- User explicit: `/eval skill <name>`, "test the X skill", "run evals", "regression check".
+- Auto-firing: PostToolUse on edits to any `skills/*/SKILL.md`. If the description was edited, re-run that skill's evals immediately.
+
+## Eval file location
+
+For a skill at `skills/<name>/`, evals live at:
+
+```
+skills/<name>/tests/evals.json
+```
+
+Format:
+
+```json
+{
+  "name": "<name>-eval",
+  "prompts": [
+    {
+      "id": "trigger-on-design-question",
+      "prompt": "How should I design a deep module?",
+      "must_invoke_skill": "ousterhout"
+    },
+    {
+      "id": "negative-case-pure-go-syntax",
+      "prompt": "What's the syntax for a Go map literal?",
+      "must_NOT_invoke_skill": "ousterhout"
+    }
+  ]
+}
+```
+
+Each entry is one of two shapes:
+
+- `must_invoke_skill: "<name>"` — the prompt should trigger this skill.
+- `must_NOT_invoke_skill: "<name>"` — the prompt should NOT trigger this skill (false-positive guard).
+
+## Running an eval
+
+The agent reading this skill IS the LLM judge. No external API call required for v1.
+
+For each prompt:
+
+1. Read `skills/<name>/SKILL.md` frontmatter `description` field.
+2. Without prior context bias, judge: *would Claude Code's skill-routing logic trigger this skill on this prompt?* Use the same heuristic the harness uses (description keyword/intent matching).
+3. Compare to the expected outcome (`must_invoke_skill` or `must_NOT_invoke_skill`).
+4. Mark each prompt **pass** or **fail**.
+
+Roll-up: skill **passes** iff all prompts pass. Otherwise **fails** with the per-prompt failure reasons.
+
+## Output
+
+Print to the user:
+
+```
+skill-eval: ousterhout
+  PASS  trigger-on-design-question      "How should I design a deep module?"
+  PASS  negative-case-pure-go-syntax    "What's the syntax for a Go map literal?"
+  FAIL  trigger-on-refactor-prompt      "Help me refactor this function"
+        Expected: must_invoke_skill=ousterhout
+        Reason: description doesn't include "refactor" trigger; consider adding.
+  ----
+  Result: 2/3 PASS — skill REGRESSED.
+```
+
+## When `evals.json` doesn't exist
+
+If a skill has no `tests/evals.json`:
+
+1. Scaffold an empty one with the schema:
+
+   ```json
+   {
+     "name": "<name>-eval",
+     "prompts": []
+   }
+   ```
+
+2. Tell the user: "no evals defined yet for `<name>`. Wrote a stub at `skills/<name>/tests/evals.json`. Add 3-5 trigger prompts and 1-2 negative cases, then re-run `/eval skill <name>`."
+
+3. Do NOT invent prompts inline. The user authors their own ground-truth.
+
+## Anti-patterns
+
+- **Do NOT score 1-10.** Pass/fail only.
+- **Do NOT call an external LLM as judge.** The agent reading this skill is the judge — that's the trick.
+- **Do NOT auto-fix descriptions.** Failing evals signal a problem; the human edits the description and re-runs.
+- **Do NOT skip negative cases.** Triggers on the wrong prompt is just as bad as missing the right one.
+
+## See also
+
+- `skills/description-linter/SKILL.md` — static analysis on descriptions; this skill is dynamic.
+- `skills/reflect/SKILL.md` — eval failures are a natural reflection trigger.
+- MindStudio's eval architecture writeup (binary, programmatic, no scoring).

--- a/skills/skill-gap-detector/SKILL.md
+++ b/skills/skill-gap-detector/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: skill-gap-detector
+version: 0.1.0
+description: >
+  Use when the user wants to "find missing skills", "what skills should I have",
+  "what am I explaining over and over", "/skill-gap", "audit my repeated instructions",
+  or asks which skills they're missing based on session history. Also weekly cron-friendly.
+  Scans recent session transcripts for "I had to explain X 3+ times" patterns and
+  drafts proposed new SKILL.md files for human review. Does NOT auto-install.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# skill-gap-detector
+
+Surfaces *missing* skills, not edits to existing ones. Pairs with `evolution-engine`: where evolution-engine proposes diffs against existing files, this proposes brand-new skills the user keeps reinventing inline.
+
+## When to invoke
+
+- User says "what skills am I missing", "I keep explaining X", "/skill-gap", "find gaps".
+- Weekly maintenance loop (e.g., a `/loop 7d /skill-gap` cron).
+- After `evolution-engine` runs and finds repeated-instruction clusters with no matching existing skill.
+
+## How it works
+
+1. Run the existing detector pipeline:
+
+   ```bash
+   npm run evolve -- --since 14d --json
+   ```
+
+   The `--json` output (PR #51) contains structured `repeated-instructions` clusters: each cluster is a phrase the user has typed 3+ times across sessions, with timestamps and excerpts.
+
+2. For each cluster:
+   - Cross-check the existing skill catalog (`skills/*/SKILL.md` frontmatter `description` fields). If any existing skill's description already contains 2+ of the cluster's trigger phrases, skip — it's a *triggering* problem (route to `description-linter`), not a gap.
+   - Otherwise, draft a new skill scaffold.
+
+3. For each gap, propose a name (kebab-case, ≤4 words, derived from the cluster's most-common noun phrase) and write:
+
+   ```
+   ~/.claude/evolution-reports/<project>/proposed-skills/<proposed-name>/SKILL.md
+   ```
+
+4. Print a summary to the user listing each draft path and a one-line rationale.
+
+## Draft SKILL.md template
+
+```yaml
+---
+name: <proposed-kebab-case>
+version: 0.1.0
+description: >
+  Use when [extracted trigger phrase 1], [trigger phrase 2], or [trigger phrase 3].
+  [One-line summary of what the skill should do, derived from the most recent
+  cluster excerpt.]
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution   # human reviewer changes to actual category
+---
+
+# <proposed-name>
+
+> PROPOSED — drafted by `skill-gap-detector` on <date>.
+> Source: <N> repeated-instruction occurrences across <M> sessions.
+
+## Cluster evidence
+
+<bullet list of 3-5 verbatim user excerpts that triggered this cluster>
+
+## Suggested body
+
+[A short stub describing what the skill should do. Based on the agent's reading
+of *what the user wanted* in the cluster excerpts, not on speculation.]
+
+## Open questions for the human reviewer
+
+- Is the proposed name accurate?
+- Is `category.primary` correct? (Evolution drafts default to `evolution`; reviewer
+  re-categorizes.)
+- Should this skill replace, supplement, or hand off to <existing-skill-X>?
+```
+
+## Anti-patterns
+
+- **Do NOT auto-install.** Drafts go under `~/.claude/evolution-reports/<project>/proposed-skills/`, not under `skills/`. The human reviews, edits, and runs `npm run init -- <name>` to formalize.
+- **Do NOT mass-produce.** Cap at 5 drafts per run. If the pipeline finds more, rank by occurrence count and surface the rest as a "next 10 candidates" appendix in the summary.
+- **Do NOT write the body in detail.** A stub + cluster evidence is enough. The reviewer fills in the real body.
+
+## Output
+
+- Per-gap directory: `~/.claude/evolution-reports/<project>/proposed-skills/<name>/SKILL.md`
+- Summary printed to user: counts, paths, top 3 cluster excerpts per draft.
+
+## See also
+
+- `skills/evolution-engine/SKILL.md` — sibling that proposes edits to *existing* files.
+- `skills/description-linter/SKILL.md` — handles the "trigger doesn't match" case.
+- `skills/reflect/SKILL.md` — post-task critique that may also surface gaps.

--- a/skills/stuck-detector/SKILL.md
+++ b/skills/stuck-detector/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: stuck-detector
+version: 0.1.0
+description: >
+  Use when the user says "stuck", "I'm stuck", "this isn't working", "tool keeps failing",
+  "give up on this", "we're going in circles", "/stuck", or when the agent itself
+  notices it has hit N consecutive tool errors in a session window. Generates a handoff
+  summary so progress can resume in a fresh session, escalate to a stronger model,
+  or pause for user input. Stops the doom-loop of blind retries.
+type: skill
+targets:
+  - claude-code
+category:
+  primary: evolution
+---
+
+# stuck-detector
+
+The off-ramp. When the agent (or the user) realizes the current path isn't working, this skill stops the retry loop and produces a structured handoff so progress can resume elsewhere.
+
+## When to invoke
+
+- User explicit: "stuck", "we're going in circles", "this isn't working", "give up on this", "/stuck".
+- Self-firing: the agent notices its own pattern. Heuristics that suggest stuckness:
+  - Same tool errored 3+ times with the same error class within the last ~20 turns.
+  - The same file has been edited and re-edited without the user expressing satisfaction.
+  - The user has corrected the agent's interpretation of the task 2+ times.
+  - The agent is about to retry an action it already tried and failed.
+
+The skill is invoked when the agent *judges* it's stuck. Don't build complex auto-detection — the prompt itself is the detector.
+
+## Workflow
+
+### 1. Acknowledge directly
+
+Stop work. Tell the user, in one sentence: "I'm stuck on <X>. Generating a handoff summary." Do NOT keep retrying while this skill runs.
+
+### 2. Generate the handoff
+
+Write to:
+
+```
+~/.claude/evolution-reports/<project>/stuck/<YYYY-MM-DD>-<topic-slug>.md
+```
+
+The handoff has four sections:
+
+#### a. Original ask
+
+What did the user ask for? Quote them as exactly as you can. If multiple asks layered, list them in order.
+
+#### b. What was tried and failed
+
+Bullet list. For each attempt:
+- One-line summary of the approach.
+- Specific failure: tool error message, test output, user correction.
+- Why the agent thought it would work.
+
+#### c. What information would unblock progress
+
+This is the **load-bearing section**. Be specific:
+
+- "The contents of `<file>` — I've been guessing at its shape."
+- "Whether the user wants behavior A or behavior B — they said both at different points."
+- "Which version of `<library>` is installed — error suggests version mismatch."
+- "Access to `<command>` — kept hitting permission prompts."
+
+If the answer is "I genuinely don't know what would unblock me", say that. It's a valid handoff.
+
+#### d. Recommended next action
+
+Pick ONE:
+
+- **Escalate to Opus** — if the issue feels like it needs deeper reasoning, not more context.
+- **Fresh session paste** — if the issue is context pollution / long-conversation drift. Provide a clean version of the task that can be pasted into a new session.
+- **Ask user for input** — if the unblocking info is something only the user has.
+- **Pause** — if the right move is for the user to come back later with a different framing.
+
+### 3. Print the path and ask
+
+After writing, print the file path. Then ask the user one question — exactly:
+
+> Continue with reduced scope, escalate, or pause?
+
+Wait for their answer. Do NOT pick for them.
+
+## Anti-patterns
+
+- **Do NOT keep retrying while writing the handoff.** The whole point is to stop the loop.
+- **Do NOT build heavy stuck-detection logic.** The skill is invoked when the agent thinks it's stuck. Don't try to build a deterministic stuck-detector — that's a different problem.
+- **Do NOT auto-escalate.** The user picks the next move. Even if Opus seems right, ask first.
+- **Do NOT make the handoff long.** Cap each section at 5 bullets. A long handoff that nobody reads is worse than a short one that gets actioned.
+
+## See also
+
+- `skills/reflect/SKILL.md` — for *post-task* critique. This skill is for *mid-task* unsticking.
+- `skills/evolution-engine/SKILL.md` — running this skill regularly seeds evolution-engine with "tool kept failing" signal.
+- The Voyager paper (curriculum self-correction): the "skill library refresh" idea, reduced to one simple action — write down what's broken, ask the human.


### PR DESCRIPTION
## Summary

Adds 7 skills to the **Evolution** category to complement the existing `evolution-engine`. Together they cover the meta-skill space: detect missing skills, reflect on tasks, memorize learnings, eval skill triggers, lint descriptions, escape stuck-loops, and log applied evolutions.

Component count: **41 → 48**. All 171 tests pass; `npx tsc --noEmit` clean; `npm run validate` green; sample build emits cleanly.

## The 7 skills

| Skill | Trigger pattern | Anti-pattern explicitly rejected |
|---|---|---|
| `skill-gap-detector` | "find missing skills", "what skills should I have", "/skill-gap", "what am I explaining over and over" | Auto-installing proposed skills (drafts go to `~/.claude/evolution-reports/<project>/proposed-skills/` for human review) |
| `reflect` | "/reflect", "review what we just did", "critique the last task", "post-task review", auto-fires on meaningful task completion | Auto-applying proposals (reflection is for review only) |
| `memorize` | "/memorize", "save this learning", "make this an ADR", "remember this", auto-fires on agreement after `/reflect` | Writing without showing content first; combining project ADR + personal memory in one file |
| `skill-eval-runner` | "/eval skill X", "test skill X", "regression test skill", auto-fires PostToolUse on `skills/*/SKILL.md` edits | Scored 1-10 evals (binary pass/fail per MindStudio research); external LLM judge (the reading agent IS the judge) |
| `description-linter` | "lint my skills", "/lint-skills", "validate skill triggers", auto-fires PostToolUse on SKILL.md edits | Auto-fixing descriptions; blocking commits |
| `stuck-detector` | "stuck", "this isn't working", "tool keeps failing", "/stuck", auto-fires on N consecutive tool errors | Heavy auto-detection logic; auto-escalating without user input; long handoff documents |
| `evolution-changelog` | "/changelog evolution", "log this evolution", auto-fires PostToolUse on `git apply` against evolution-report patches | Logging proposals (EVOLUTION.md is the *applied* log); rewriting history; auto-committing |

## Research informing the design

- **OpenSpace / NeoLab context-engineering-kit** — proposed-skill drafts as separate artifacts under a review path, not direct edits to existing files.
- **claude-mem** — the `/memorize` + ADR/personal-memory split.
- **ACE paper** — append-only evolution log (this is what `evolution-changelog` implements).
- **Reflexion** — structured post-task critique with specific actionable proposals (the `reflect` body).
- **Voyager** — the curriculum self-correction insight, reduced to `stuck-detector`'s "write down what's broken, ask the human" off-ramp.
- **MindStudio's eval architecture writeup** — binary pass/fail, no scoring (powers `skill-eval-runner`).

## Validation

```text
$ npm run validate
OK (48 components, 6 warnings).

$ npm test
Test Files  38 passed (38)
     Tests  171 passed (171)

$ npx tsc --noEmit
(clean)

$ npm run build -- --target claude-code --filter reflect
built 1 file(s) across 1 target(s).
```

## Test plan

- [x] `npm run validate` reports 48 components clean
- [x] `npm test` — all 171 tests pass
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run build -- --target claude-code --filter <new-skill>` emits cleanly
- [x] `npm run docs` regenerates the components table with all 7 new skills under the `evolution` category
- [x] README Evolution section updated with one-line per new skill