### PR TITLE
feat: 6 claude-mem-inspired patterns (trace, recall, fail-safe, flat-line, shouldTrackProject, adapters+modes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.agent-config/
 .agents/
 .codex/
 .worktrees/

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,102 @@
+# Conventions
+
+Cross-cutting rules that apply to every component in this repo. Skills, hooks, and
+adapters all live by them. New components must follow the conventions in this file
+unless they document a deliberate, narrow exception.
+
+## Fail-safe hook scripts
+
+Every hook script in this repo MUST be fail-safe. Hooks run inside the user's
+session lifecycle (PreToolUse, PostToolUse, SessionStart, Stop, etc.); a hook
+that errors out, hangs, or writes to stderr in panic mode will block the user.
+That is unacceptable, regardless of how legitimate the failure is.
+
+The rule:
+
+- Do NOT use `set -e`. A hook that exits non-zero on the first command failure
+  blocks the host session and surfaces noisy errors.
+- DO wrap the body so any failure is swallowed: `||  true` on individual
+  commands that may fail, and `exit 0` at the very end no matter what.
+- DO log unrecoverable errors to stderr (or a quiet log file) — never fail loudly.
+- When the hook protocol allows it, output a JSON envelope `{"continue": true,
+  "suppressOutput": true}` on errors so the host harness keeps moving.
+
+Reference implementation: [`hooks/_lib/fail-safe.sh`](hooks/_lib/fail-safe.sh).
+Hook scripts can `source` it to import the wrapper helpers.
+
+Skeleton:
+
+```bash
+#!/usr/bin/env bash
+# shellcheck shell=bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../_lib/fail-safe.sh" 2>/dev/null || true
+
+failsafe::trap_errors
+
+# ... your hook body here. Failures here are caught, logged, and ignored. ...
+
+exit 0
+```
+
+If `_lib/fail-safe.sh` is unavailable (e.g., the hook ships standalone in a
+plugin bundle), inline the critical bits:
+
+```bash
+#!/usr/bin/env bash
+set +e
+trap 'echo "hook error at line $LINENO" >&2; exit 0' ERR
+# ... body ...
+exit 0
+```
+
+## Markdown flat-line format
+
+Append-only changelogs and ledger files (`EVOLUTION.md`, future audit logs,
+session digests) use a flat-line format optimized for scanning and grep — not
+GitHub-rendered tables.
+
+Shape:
+
+```markdown
+## 2026-04-27
+**F-001** 09:23 [stale-memory] | `feedback_old.md` deleted | dead branch ref
+**F-002** 14:55 [permission] | `settings.json` | added `npm test` (×7)
+
+## 2026-04-26
+**F-003** 11:02 [trigger-mismatch] | `skills/reflect/SKILL.md` | added "retro this"
+```
+
+The fields, in order:
+
+1. Bold finding ID (`**F-NNN**`) — sortable, greppable, one per row.
+2. Time (`HH:MM`) — local time, optional.
+3. Signal type — bracketed identifier (`[stale-memory]`, `[permission]`, etc.).
+   Optional: prefix with one icon (`🔧`, `🔒`, `🎯`) for at-a-glance scanning. The
+   icon variant is allowed but not required; the bracketed text is the source
+   of truth.
+4. The artifact path or short subject — a single backtick-wrapped path.
+5. A one-line description.
+
+Why flat-line vs Markdown tables:
+
+- `grep` works against the raw line; tables fragment information across columns.
+- New columns can be added without rewriting history.
+- Diff-friendly: each finding is exactly one line.
+- LLM-friendly: each line is a complete record without table-header context.
+
+## Per-project state directory
+
+Hooks, skills, and adapters that need scratch space write to `.agent-config/`
+at the repo root. Examples: `.agent-config/trace/<session-id>.jsonl`,
+`.agent-config/recall.disabled`, `.agent-config/exclude.json`. The directory
+is gitignored; nothing in it should be committed.
+
+## Cross-harness contract
+
+Every hook ships through an adapter (see `apm-builder/lib/harness-adapters/`).
+A hook script reads its input from stdin, writes JSON output to stdout, and
+exits 0. The adapter library normalizes the per-harness envelope so the same
+hook body works under Claude Code, Codex, Gemini, Copilot, and Pi when those
+adapters mature.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ The repo's directory structure mirrors the component-type schema:
 ```
 skills/      — type: skill   (46 components — typed agent capabilities triggered by description)
 plugins/     — type: plugin  (1 component — multi-skill bundles)
-hooks/       — type: hook    (1 component — event-driven scripts)
+hooks/       — type: hook    (3 components — tts-announcer, trace, recall — event-driven scripts)
 agents/      — type: agent   (planned)
 rules/       — type: rules   (planned)
 mcp/         — type: mcp     (planned)
 ```
 
 `apm-builder/lib/discover.ts` walks all six top-level dirs.
+
+## Conventions
+
+Cross-cutting rules every component follows live in [`CONVENTIONS.md`](CONVENTIONS.md):
+
+- **Fail-safe hook scripts** — hooks never block the host session.
+- **Markdown flat-line format** — append-only changelogs use one entry per line for grep + diff friendliness.
+- **Per-project state directory** — `.agent-config/` for trace logs, recall toggles, and per-project excludes (gitignored).
+- **Cross-harness contract** — hooks read JSON from stdin and write JSON to stdout; the harness adapter library handles per-host envelope differences.
 
 ## Taxonomy
 
@@ -117,6 +126,8 @@ Bundled as the [`knowledge-base`](plugins/knowledge-base) plugin (install once f
 - [`description-linter`](skills/description-linter) — Static analyzer for SKILL.md frontmatter: trigger-phrase heuristics, length cap, kebab-case names, cross-skill conflict detection. Reports only — no auto-fix.
 - [`stuck-detector`](skills/stuck-detector) — Off-ramp when the agent (or user) hits a doom-loop. Stops retrying, writes a structured handoff, asks whether to escalate / pause / continue with reduced scope.
 - [`evolution-changelog`](skills/evolution-changelog) — Maintains `EVOLUTION.md` at repo root: append-only log of applied evolution-driven changes, one bullet per change with signal, file, and one-line rationale.
+- [`trace`](hooks/trace) — Hook that appends one JSONL record per tool call to `.agent-config/trace/<session-id>.jsonl`. Zero LLM cost; structured evidence for `reflect` and `stuck-detector` to read later.
+- [`recall`](hooks/recall) — `SessionStart` hook that injects recent feedback memories and ADRs into the session as additional context. Default ON; opt out with `.agent-config/recall.disabled`.
 
 ### Frontend frameworks (Tooling)
 
@@ -187,6 +198,8 @@ The table below is regenerated from canonical `SKILL.md` frontmatter via `npm ru
  | claude-code |
 | stuck-detector | skill | 0.1.0 | Use when the user says "stuck", "I'm stuck", "this isn't working", "tool keeps failing", "give up on this", "we're going in circles", "/stuck", or when the agent itself notices it has hit N consecutive tool errors in a session window. Generates a handoff summary so progress can resume in a fresh session, escalate to a stronger model, or pause for user input. Stops the doom-loop of blind retries.
  | claude-code |
+| trace | hook | 0.1.0 | Append-only JSONL trace of every tool call in the session. Records `{ts, tool, args, status, duration_ms}` per `PostToolUse` event so later skills can audit what happened without an LLM. Use when the user types "/trace", "track tool calls", "trace this session", "audit tool history", or asks why the agent did something. The hook fires automatically on every tool call; the trigger phrases are mostly for the agent to surface the file path on demand.
+ | claude-code |
 
 ### integrations
 
@@ -208,6 +221,8 @@ The table below is regenerated from canonical `SKILL.md` frontmatter via `npm ru
 | Name | Type | Version | Description | Targets |
 |------|------|---------|-------------|---------|
 | knowledge-base-overview | skill | 0.1.0 | Use when building, maintaining, ingesting into, querying, or health-checking a markdown knowledge base or wiki. Use when the user wants to compile sources into structured knowledge, maintain an Obsidian wiki, ingest documents, ask questions against accumulated research, or run health checks on interlinked markdown pages. Triggers on requests involving knowledge bases, wiki maintenance, source ingestion, research compilation, Obsidian wiki workflows, or LLM-maintained documentation. | claude-code |
+| recall | hook | 0.1.0 | Auto-injects recent feedback memories and ADRs at session start so the agent has context from past learnings. Walks `~/.claude/projects/<project>/memory/` and `<repo>/docs/adr/` for the latest entries (default 5) and emits them as SessionStart additionalContext. Use when the user types "/recall", "what should I remember", "recent decisions", "load my memories", or asks about prior conclusions. Default ON; opt out by creating `.agent-config/recall.disabled` in the repo.
+ | claude-code |
 
 ### tooling
 

--- a/apm-builder/lib/harness-adapters/claude-code.ts
+++ b/apm-builder/lib/harness-adapters/claude-code.ts
@@ -1,0 +1,56 @@
+// Claude Code harness adapter. Parses the hook envelope Claude Code sends on
+// stdin and produces the `{hookSpecificOutput: {...}}` shape it expects on
+// stdout. The shape comes straight from the Claude Code hook protocol; see
+// docs/anthropic for the source of truth.
+
+import type {
+  HarnessAdapter,
+  NormalizedHookInput,
+  NormalizedHookOutput,
+} from './types.ts';
+
+interface ClaudeCodeRawInput {
+  hook_event_name?: string;
+  session_id?: string;
+  cwd?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_response?: unknown;
+  transcript_path?: string;
+}
+
+export const claudeCodeHarnessAdapter: HarnessAdapter = {
+  name: 'claude-code',
+
+  normalizeInput(raw: string): NormalizedHookInput {
+    let parsed: ClaudeCodeRawInput;
+    try {
+      parsed = JSON.parse(raw) as ClaudeCodeRawInput;
+    } catch {
+      parsed = {};
+    }
+    return {
+      event: parsed.hook_event_name ?? 'unknown',
+      sessionId: parsed.session_id ?? 'unknown',
+      cwd: parsed.cwd ?? process.cwd(),
+      tool: parsed.tool_name,
+      toolInput: parsed.tool_input,
+      toolResponse: parsed.tool_response,
+      extras: parsed.transcript_path ? { transcriptPath: parsed.transcript_path } : undefined,
+    };
+  },
+
+  formatOutput(out: NormalizedHookOutput): string {
+    const envelope: Record<string, unknown> = {};
+    if (out.continue !== undefined) envelope['continue'] = out.continue;
+    if (out.suppressOutput !== undefined) envelope['suppressOutput'] = out.suppressOutput;
+    if (out.additionalContext) {
+      envelope['hookSpecificOutput'] = {
+        hookEventName: 'SessionStart',
+        additionalContext: out.additionalContext,
+      };
+    }
+    if (out.payload) Object.assign(envelope, out.payload);
+    return JSON.stringify(envelope);
+  },
+};

--- a/apm-builder/lib/harness-adapters/codex.ts
+++ b/apm-builder/lib/harness-adapters/codex.ts
@@ -1,0 +1,15 @@
+// Codex harness adapter — STUB. Real implementation lands when a hook needs
+// to ship to Codex; until then we throw on use so callers fail loudly rather
+// than silently.
+
+import type { HarnessAdapter } from './types.ts';
+
+export const codexHarnessAdapter: HarnessAdapter = {
+  name: 'codex',
+  normalizeInput() {
+    throw new Error('codex harness adapter: not yet implemented');
+  },
+  formatOutput() {
+    throw new Error('codex harness adapter: not yet implemented');
+  },
+};

--- a/apm-builder/lib/harness-adapters/copilot.ts
+++ b/apm-builder/lib/harness-adapters/copilot.ts
@@ -1,0 +1,14 @@
+// Copilot CLI harness adapter — STUB. Real implementation lands when a hook
+// needs to ship to Copilot CLI.
+
+import type { HarnessAdapter } from './types.ts';
+
+export const copilotHarnessAdapter: HarnessAdapter = {
+  name: 'copilot',
+  normalizeInput() {
+    throw new Error('copilot harness adapter: not yet implemented');
+  },
+  formatOutput() {
+    throw new Error('copilot harness adapter: not yet implemented');
+  },
+};

--- a/apm-builder/lib/harness-adapters/gemini.ts
+++ b/apm-builder/lib/harness-adapters/gemini.ts
@@ -1,0 +1,14 @@
+// Gemini CLI harness adapter — STUB. Real implementation lands when a hook
+// needs to ship to Gemini CLI.
+
+import type { HarnessAdapter } from './types.ts';
+
+export const geminiHarnessAdapter: HarnessAdapter = {
+  name: 'gemini',
+  normalizeInput() {
+    throw new Error('gemini harness adapter: not yet implemented');
+  },
+  formatOutput() {
+    throw new Error('gemini harness adapter: not yet implemented');
+  },
+};

--- a/apm-builder/lib/harness-adapters/index.ts
+++ b/apm-builder/lib/harness-adapters/index.ts
@@ -1,0 +1,52 @@
+// Harness-adapter picker. Detects the host harness from environment cues and
+// returns the matching adapter. Falls back to claude-code when no signal is
+// present — that's the primary harness this repo targets.
+
+import type { HarnessAdapter } from './types.ts';
+import { claudeCodeHarnessAdapter } from './claude-code.ts';
+import { codexHarnessAdapter } from './codex.ts';
+import { geminiHarnessAdapter } from './gemini.ts';
+import { copilotHarnessAdapter } from './copilot.ts';
+import { piHarnessAdapter } from './pi.ts';
+
+export type {
+  HarnessAdapter,
+  NormalizedHookInput,
+  NormalizedHookOutput,
+} from './types.ts';
+
+export const HARNESS_ADAPTERS: Record<string, HarnessAdapter> = {
+  'claude-code': claudeCodeHarnessAdapter,
+  codex: codexHarnessAdapter,
+  gemini: geminiHarnessAdapter,
+  copilot: copilotHarnessAdapter,
+  pi: piHarnessAdapter,
+};
+
+/**
+ * Detect which harness is hosting the current process.
+ *
+ * Detection rules (first match wins):
+ *  - `CLAUDE_PROJECT_DIR` set → `claude-code`
+ *  - `CODEX_HOME` set → `codex`
+ *  - `GEMINI_CLI` set → `gemini`
+ *  - `GH_COPILOT_CLI` set → `copilot`
+ *  - `PI_HOME` set → `pi`
+ *  - default → `claude-code`
+ */
+export function detectHarness(env: NodeJS.ProcessEnv = process.env): string {
+  if (env['CLAUDE_PROJECT_DIR']) return 'claude-code';
+  if (env['CODEX_HOME']) return 'codex';
+  if (env['GEMINI_CLI']) return 'gemini';
+  if (env['GH_COPILOT_CLI']) return 'copilot';
+  if (env['PI_HOME']) return 'pi';
+  return 'claude-code';
+}
+
+/** Pick the adapter matching the host harness, or claude-code as a fallback. */
+export function getHarnessAdapter(env: NodeJS.ProcessEnv = process.env): HarnessAdapter {
+  const adapter = HARNESS_ADAPTERS[detectHarness(env)];
+  // detectHarness always returns a key that exists; the fallback exists to
+  // satisfy noUncheckedIndexedAccess.
+  return adapter ?? claudeCodeHarnessAdapter;
+}

--- a/apm-builder/lib/harness-adapters/pi.ts
+++ b/apm-builder/lib/harness-adapters/pi.ts
@@ -1,0 +1,14 @@
+// Pi harness adapter — STUB. Real implementation lands when a hook needs to
+// ship to Pi.
+
+import type { HarnessAdapter } from './types.ts';
+
+export const piHarnessAdapter: HarnessAdapter = {
+  name: 'pi',
+  normalizeInput() {
+    throw new Error('pi harness adapter: not yet implemented');
+  },
+  formatOutput() {
+    throw new Error('pi harness adapter: not yet implemented');
+  },
+};

--- a/apm-builder/lib/harness-adapters/types.ts
+++ b/apm-builder/lib/harness-adapters/types.ts
@@ -1,0 +1,43 @@
+// Shared types for the cross-harness adapter library. Each harness (Claude
+// Code, Codex, Gemini, Copilot, Pi) wraps hook input + output in a different
+// JSON envelope; an adapter `normalizeInput` produces the canonical shape we
+// work with, and `formatOutput` re-wraps it for the harness.
+//
+// This is intentionally a thin contract. Adapters live in their own files.
+
+export interface NormalizedHookInput {
+  /** Lifecycle event name, e.g. `PreToolUse`, `PostToolUse`, `SessionStart`. */
+  event: string;
+  /** Stable session identifier. */
+  sessionId: string;
+  /** Working directory of the host session. */
+  cwd: string;
+  /** Tool name when the event is tool-scoped. */
+  tool?: string;
+  /** Raw tool input as the harness reported it. */
+  toolInput?: unknown;
+  /** Raw tool response when present (PostToolUse only). */
+  toolResponse?: unknown;
+  /** Free-form bag for harness-specific extras the adapter wants to surface. */
+  extras?: Record<string, unknown>;
+}
+
+export interface NormalizedHookOutput {
+  /** When false, signal to the host that the session should stop. Defaults true. */
+  continue?: boolean;
+  /** Suppress the host's own output for this hook. */
+  suppressOutput?: boolean;
+  /** Free-form additional context for SessionStart-style hooks. */
+  additionalContext?: string;
+  /** Optional JSON payload some harnesses include verbatim. */
+  payload?: Record<string, unknown>;
+}
+
+export interface HarnessAdapter {
+  /** Identifier for this harness (`claude-code`, `codex`, etc.). */
+  name: string;
+  /** Parse the host harness's stdin envelope into the canonical shape. */
+  normalizeInput(raw: string): NormalizedHookInput;
+  /** Render a canonical output back into the host harness's expected JSON. */
+  formatOutput(out: NormalizedHookOutput): string;
+}

--- a/apm-builder/lib/should-track.ts
+++ b/apm-builder/lib/should-track.ts
@@ -1,0 +1,73 @@
+// Per-project tracking gate. Skills and hooks that record per-session data
+// (trace logs, evolution sessions, recall context) consult this gate before
+// writing anything. Lets a user opt out of tracking for sensitive directories
+// (~/.config, ~/Downloads, system tmp, etc.) without disabling tracking globally.
+//
+// Resolution order:
+//   1. Per-project: <cwd>/.agent-config/exclude.json
+//   2. Global:      ~/.config/agent-config/exclude.json
+//   3. Hardcoded defaults (system + sensitive dirs).
+//
+// The exclude file shape is:
+//   { "exclude": ["/absolute/path/prefix", "~/relative/prefix"] }
+// Any cwd that starts with one of the listed prefixes is excluded.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export interface ExcludeConfig {
+  exclude: string[];
+}
+
+const DEFAULT_EXCLUDES: string[] = [
+  '/tmp',
+  '/var',
+  '/private/tmp',
+  '/private/var',
+  path.join(os.homedir(), '.config'),
+  path.join(os.homedir(), 'Downloads'),
+  path.join(os.homedir(), 'Desktop'),
+  path.join(os.homedir(), 'Library', 'Caches'),
+];
+
+function expandTilde(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+function readExclude(file: string): string[] {
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<ExcludeConfig>;
+    if (!parsed || !Array.isArray(parsed.exclude)) return [];
+    return parsed.exclude.map(expandTilde);
+  } catch {
+    return [];
+  }
+}
+
+function projectExclude(cwd: string): string[] {
+  return readExclude(path.join(cwd, '.agent-config', 'exclude.json'));
+}
+
+function globalExclude(): string[] {
+  return readExclude(path.join(os.homedir(), '.config', 'agent-config', 'exclude.json'));
+}
+
+/**
+ * Decide whether to track a session in `cwd`. Returns true unless `cwd` lives
+ * under any excluded prefix (built-in defaults, the global exclude file, or
+ * the per-project exclude file).
+ */
+export function shouldTrackProject(cwd: string): boolean {
+  const normalized = path.resolve(cwd);
+  const excludes = [...DEFAULT_EXCLUDES, ...globalExclude(), ...projectExclude(cwd)];
+  for (const prefix of excludes) {
+    const resolvedPrefix = path.resolve(prefix);
+    if (normalized === resolvedPrefix) return false;
+    if (normalized.startsWith(resolvedPrefix + path.sep)) return false;
+  }
+  return true;
+}

--- a/apm-builder/modes/README.md
+++ b/apm-builder/modes/README.md
@@ -1,0 +1,50 @@
+# Modes
+
+Per-domain prompt scaffolding. A mode is a small JSON file that names a task
+domain (`code`, `design`, `ops`, …) and lists the observation types, priority
+skills, and memory topics relevant to that domain.
+
+Modes are referenced by `--mode <name>` on selected skill commands and by
+`mode:` in skill frontmatter on tasks. The mode value is a *hint* to the agent,
+not a routing rule: skills like `skill-gap-detector` and `reflect` use it to
+narrow their pattern detection and bias their proposals toward the domain in
+play.
+
+## Schema
+
+```json
+{
+  "name": "code",
+  "description": "Software development tasks…",
+  "observation_types": ["bug", "fix", "refactor", "feature", "test"],
+  "skills_priority": ["ousterhout", "tigerstyle", "idiomatic-go"],
+  "memory_topics": ["architecture", "performance", "patterns"]
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable identifier used in `--mode` flags and `mode:` frontmatter. |
+| `description` | Plain-language summary of the domain. |
+| `observation_types` | Categories an evolution detector or `reflect` skill should look for in trace + memory. |
+| `skills_priority` | Skill names to bias toward when proposing changes or composing prompts. |
+| `memory_topics` | Topic tags `memorize` should attach to feedback memories created in this mode. |
+
+## Adding a mode
+
+1. Drop `<name>.json` into `apm-builder/modes/`.
+2. Reference it from any skill that accepts a `--mode` flag.
+3. Optionally update `skills/skill-gap-detector/SKILL.md` and `skills/reflect/SKILL.md` if the mode introduces new conventions worth documenting.
+
+## Built-in modes
+
+- [`code.json`](code.json) — software development.
+- [`design.json`](design.json) — UI, UX, interaction.
+- [`ops.json`](ops.json) — operations, infrastructure, on-call.
+
+## Wiring status
+
+The mode files exist and are referenced from skill docs. Full runtime wiring
+(dispatching prompts and detectors based on mode) lands when a skill needs it;
+until then, `--mode` is documented as a hint for the agent to interpret
+in-prompt.

--- a/apm-builder/modes/code.json
+++ b/apm-builder/modes/code.json
@@ -1,0 +1,7 @@
+{
+  "name": "code",
+  "description": "Software development tasks: writing, reviewing, refactoring, debugging code.",
+  "observation_types": ["bug", "fix", "refactor", "feature", "test", "perf", "review"],
+  "skills_priority": ["ousterhout", "tigerstyle", "idiomatic-go", "hipp", "dx-audit"],
+  "memory_topics": ["architecture", "performance", "patterns", "build-tooling"]
+}

--- a/apm-builder/modes/design.json
+++ b/apm-builder/modes/design.json
@@ -1,0 +1,7 @@
+{
+  "name": "design",
+  "description": "UI, UX, interaction, and visual design tasks.",
+  "observation_types": ["affordance", "feedback", "mapping", "error-prevention", "accessibility", "density"],
+  "skills_priority": ["norman", "dx-audit", "frontend-design"],
+  "memory_topics": ["interaction-patterns", "density", "accessibility", "visual-language"]
+}

--- a/apm-builder/modes/ops.json
+++ b/apm-builder/modes/ops.json
@@ -1,0 +1,7 @@
+{
+  "name": "ops",
+  "description": "Operations, infrastructure, deployment, observability, and on-call work.",
+  "observation_types": ["incident", "deploy", "rollback", "alert", "permission", "config-drift"],
+  "skills_priority": ["tigerstyle", "signoz-dashboard-builder", "hipp"],
+  "memory_topics": ["runbooks", "alerting", "permissions", "infrastructure", "incident-history"]
+}

--- a/apm-builder/tests/harness-adapters/claude-code.test.ts
+++ b/apm-builder/tests/harness-adapters/claude-code.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { claudeCodeHarnessAdapter } from '../../lib/harness-adapters/claude-code.ts';
+import { detectHarness, getHarnessAdapter } from '../../lib/harness-adapters/index.ts';
+
+describe('claudeCodeHarnessAdapter', () => {
+  it('normalizes a PostToolUse envelope', () => {
+    const raw = JSON.stringify({
+      hook_event_name: 'PostToolUse',
+      session_id: 'abc-123',
+      cwd: '/tmp/repo',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      tool_response: { is_error: false },
+      transcript_path: '/tmp/transcript.jsonl',
+    });
+    const normalized = claudeCodeHarnessAdapter.normalizeInput(raw);
+    expect(normalized.event).toBe('PostToolUse');
+    expect(normalized.sessionId).toBe('abc-123');
+    expect(normalized.cwd).toBe('/tmp/repo');
+    expect(normalized.tool).toBe('Bash');
+    expect(normalized.toolInput).toEqual({ command: 'npm test' });
+    expect(normalized.toolResponse).toEqual({ is_error: false });
+    expect(normalized.extras?.['transcriptPath']).toBe('/tmp/transcript.jsonl');
+  });
+
+  it('produces sensible defaults on malformed input', () => {
+    const normalized = claudeCodeHarnessAdapter.normalizeInput('not-json');
+    expect(normalized.event).toBe('unknown');
+    expect(normalized.sessionId).toBe('unknown');
+    expect(typeof normalized.cwd).toBe('string');
+  });
+
+  it('formats SessionStart additionalContext into hookSpecificOutput', () => {
+    const out = claudeCodeHarnessAdapter.formatOutput({
+      additionalContext: '## Recent\n**M-001** foo',
+      continue: true,
+    });
+    const parsed = JSON.parse(out) as Record<string, unknown>;
+    expect(parsed['continue']).toBe(true);
+    expect(parsed['hookSpecificOutput']).toEqual({
+      hookEventName: 'SessionStart',
+      additionalContext: '## Recent\n**M-001** foo',
+    });
+  });
+
+  it('round-trips a minimal envelope', () => {
+    const raw = JSON.stringify({
+      hook_event_name: 'SessionStart',
+      session_id: 's1',
+      cwd: '/tmp/x',
+    });
+    const normalized = claudeCodeHarnessAdapter.normalizeInput(raw);
+    const formatted = claudeCodeHarnessAdapter.formatOutput({
+      continue: true,
+      suppressOutput: true,
+    });
+    const parsed = JSON.parse(formatted) as Record<string, unknown>;
+    expect(normalized.event).toBe('SessionStart');
+    expect(parsed['continue']).toBe(true);
+    expect(parsed['suppressOutput']).toBe(true);
+  });
+});
+
+describe('detectHarness', () => {
+  it('returns claude-code when CLAUDE_PROJECT_DIR is set', () => {
+    expect(detectHarness({ CLAUDE_PROJECT_DIR: '/tmp/repo' })).toBe('claude-code');
+  });
+
+  it('returns codex when CODEX_HOME is set and Claude is not', () => {
+    expect(detectHarness({ CODEX_HOME: '/tmp/codex' })).toBe('codex');
+  });
+
+  it('falls back to claude-code when no env signal is present', () => {
+    expect(detectHarness({})).toBe('claude-code');
+  });
+
+  it('getHarnessAdapter returns the matching adapter', () => {
+    const a = getHarnessAdapter({ CLAUDE_PROJECT_DIR: '/x' });
+    expect(a.name).toBe('claude-code');
+  });
+});

--- a/apm-builder/tests/should-track.test.ts
+++ b/apm-builder/tests/should-track.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { shouldTrackProject } from '../lib/should-track.ts';
+
+describe('shouldTrackProject', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    // Use a path outside the default exclude list (~/.config, /tmp, /var,
+    // ~/Downloads, ~/Desktop). The system tmpdir resolves to /var/folders
+    // on macOS, which is under /var, so we put fixtures under HOME instead.
+    tmpRoot = fs.mkdtempSync(path.join(os.homedir(), '.should-track-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('tracks a normal project directory by default', () => {
+    const project = path.join(tmpRoot, 'my-project');
+    fs.mkdirSync(project);
+    expect(shouldTrackProject(project)).toBe(true);
+  });
+
+  it('excludes ~/.config and its descendants', () => {
+    const configDir = path.join(os.homedir(), '.config');
+    expect(shouldTrackProject(configDir)).toBe(false);
+    expect(shouldTrackProject(path.join(configDir, 'foo', 'bar'))).toBe(false);
+  });
+
+  it('excludes /tmp and friends', () => {
+    expect(shouldTrackProject('/tmp')).toBe(false);
+    expect(shouldTrackProject('/tmp/whatever')).toBe(false);
+  });
+
+  it('honors a per-project exclude.json', () => {
+    const project = path.join(tmpRoot, 'project-with-exclude');
+    fs.mkdirSync(project);
+    const cfgDir = path.join(project, '.agent-config');
+    fs.mkdirSync(cfgDir);
+    // Exclude the project itself.
+    fs.writeFileSync(
+      path.join(cfgDir, 'exclude.json'),
+      JSON.stringify({ exclude: [project] }),
+    );
+    expect(shouldTrackProject(project)).toBe(false);
+  });
+
+  it('returns true when the per-project config is missing or malformed', () => {
+    const project = path.join(tmpRoot, 'project-no-cfg');
+    fs.mkdirSync(project);
+    expect(shouldTrackProject(project)).toBe(true);
+
+    const cfgDir = path.join(project, '.agent-config');
+    fs.mkdirSync(cfgDir);
+    fs.writeFileSync(path.join(cfgDir, 'exclude.json'), '{ this is not json');
+    expect(shouldTrackProject(project)).toBe(true);
+  });
+});

--- a/hooks/_lib/fail-safe.sh
+++ b/hooks/_lib/fail-safe.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared fail-safe helpers for hook scripts in agent-config.
+#
+# A hook MUST never block the user's session. This library installs a trap
+# that catches unhandled errors, logs them quietly to stderr, and exits 0.
+# Source it at the top of every hook body, then call failsafe::trap_errors.
+#
+# See CONVENTIONS.md for the full rule.
+
+# shellcheck shell=bash
+
+failsafe::trap_errors() {
+  set +e
+  trap 'failsafe::on_error $? "$BASH_COMMAND" $LINENO' ERR
+}
+
+failsafe::on_error() {
+  local code="$1"
+  local cmd="$2"
+  local line="$3"
+  printf '[hook fail-safe] exit=%s line=%s cmd=%s\n' "${code}" "${line}" "${cmd}" >&2
+  # Surface a JSON envelope when the host harness expects one. Hooks that don't
+  # use stdout for protocol can ignore it; Claude Code's hook protocol treats
+  # the envelope as a no-op continue signal.
+  printf '{"continue": true, "suppressOutput": true}\n' 2>/dev/null || true
+  exit 0
+}
+
+# Convenience: run a command, swallow any non-zero exit code, return 0.
+failsafe::try() {
+  "$@" 2>/dev/null || true
+}

--- a/hooks/_lib/should-track.sh
+++ b/hooks/_lib/should-track.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Bash port of apm-builder/lib/should-track.ts. Hooks call this at the top
+# and bail early when tracking is disabled for the current cwd.
+#
+# Usage:
+#   if ! should_track_project "$PWD"; then exit 0; fi
+
+# shellcheck shell=bash
+
+should_track_project() {
+  local cwd="${1:-$PWD}"
+  cwd="$(cd "${cwd}" 2>/dev/null && pwd -P || echo "${cwd}")"
+
+  # Built-in default excludes.
+  local defaults=(
+    "/tmp"
+    "/var"
+    "/private/tmp"
+    "/private/var"
+    "${HOME}/.config"
+    "${HOME}/Downloads"
+    "${HOME}/Desktop"
+    "${HOME}/Library/Caches"
+  )
+
+  local prefix
+  for prefix in "${defaults[@]}"; do
+    if [[ "${cwd}" == "${prefix}" || "${cwd}" == "${prefix}"/* ]]; then
+      return 1
+    fi
+  done
+
+  # Per-project + global JSON. We don't depend on jq; we look for any line in
+  # `exclude.json` matching `"<prefix>"`. This is intentionally lenient — hooks
+  # are fail-safe so a malformed file just means default behavior.
+  local files=(
+    "${cwd}/.agent-config/exclude.json"
+    "${HOME}/.config/agent-config/exclude.json"
+  )
+
+  local file
+  for file in "${files[@]}"; do
+    [[ -f "${file}" ]] || continue
+    while IFS= read -r line; do
+      # Strip surrounding whitespace and JSON noise.
+      local entry="${line//[\"\\,\[\]]/}"
+      entry="${entry//[[:space:]]/}"
+      [[ -z "${entry}" || "${entry}" == "exclude:" || "${entry}" == "{" || "${entry}" == "}" ]] && continue
+      # Expand leading tilde.
+      [[ "${entry}" == "~/"* ]] && entry="${HOME}/${entry#~/}"
+      [[ "${entry}" == "~" ]] && entry="${HOME}"
+      if [[ "${cwd}" == "${entry}" || "${cwd}" == "${entry}"/* ]]; then
+        return 1
+      fi
+    done < "${file}"
+  done
+
+  return 0
+}

--- a/hooks/recall/SKILL.md
+++ b/hooks/recall/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: recall
+version: 0.1.0
+description: >
+  Auto-injects recent feedback memories and ADRs at session start so the agent
+  has context from past learnings. Walks `~/.claude/projects/<project>/memory/`
+  and `<repo>/docs/adr/` for the latest entries (default 5) and emits them as
+  SessionStart additionalContext. Use when the user types "/recall", "what
+  should I remember", "recent decisions", "load my memories", or asks about
+  prior conclusions. Default ON; opt out by creating
+  `.agent-config/recall.disabled` in the repo.
+type: hook
+targets:
+  - claude-code
+category:
+  primary: memory-management
+  secondary:
+    - context-management
+hooks:
+  SessionStart:
+    command: hooks/recall.sh
+---
+
+# recall
+
+The complement to [`hooks/trace`](../trace/SKILL.md). Trace writes; recall reads.
+At session start, the script walks two directories and injects up to N recent
+markdown entries into the session's additional context window:
+
+1. `~/.claude/projects/<project>/memory/feedback_*.md` — the auto-saved feedback memories.
+2. `<repo-root>/docs/adr/*.md` — Architectural Decision Records, when the repo uses them.
+
+Latest 5 entries (combined, sorted by mtime) are injected by default. The
+result is rendered with the flat-line format described in [`CONVENTIONS.md`](../../CONVENTIONS.md).
+
+## Output shape
+
+The hook prints a single JSON object on stdout, conforming to the Claude Code
+SessionStart hook protocol:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Recent feedback\n\n**M-001** 2026-04-25 [feedback] | `feedback_specs_local_only.md` | …\n…"
+  }
+}
+```
+
+If there is nothing to inject (no memory files, no ADRs, recall disabled),
+the hook exits 0 with no JSON — Claude Code treats that as "no additional
+context" and continues normally.
+
+## Default ON, opt out manually
+
+Recall is on by default for any tracked project. To disable for the current
+project, create an empty file:
+
+```bash
+touch .agent-config/recall.disabled
+```
+
+Recall checks for that file on every SessionStart event and bails immediately
+when it exists. The hook does NOT auto-create the disable marker — opting out
+is intentional.
+
+It also checks the per-project / global exclusion list (see
+[`hooks/_lib/should-track.sh`](../_lib/should-track.sh)). Excluded directories
+get no memory injection regardless of the disable flag.
+
+## Token cost
+
+Estimated 100-500 tokens per session, depending on memory volume. The hook
+truncates each memory to its first 30 lines and caps the combined output at
+roughly 4 KB. Increase `RECALL_LIMIT` (default 5) or `RECALL_LINES` (default 30)
+in the environment to grow the budget; lower them to shrink it.
+
+## Why a hook, not a daemon
+
+Same reasoning as `trace`: a one-shot bash script that fires on a single
+lifecycle event is enough. claude-mem performs vector search over an embedding
+index for "relevant past memories"; we use mtime-sorted recency, which is good
+enough for the prior-art-from-yesterday case that drives 80% of the value.
+
+## See also
+
+- [`hooks/trace/SKILL.md`](../trace/SKILL.md) — the writer counterpart.
+- [`skills/memorize/SKILL.md`](../../skills/memorize/SKILL.md) — how memories get written.
+- [`CONVENTIONS.md`](../../CONVENTIONS.md) — flat-line format + fail-safe rule.

--- a/hooks/recall/hooks/recall.sh
+++ b/hooks/recall/hooks/recall.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SessionStart hook for agent-config. Walks memory + ADR dirs for recent
+# entries, formats them as flat-line markdown, and injects them as
+# `additionalContext` on the SessionStart hook envelope.
+#
+# Reads JSON from stdin (per Claude Code's hook protocol), writes JSON to
+# stdout (also per protocol). On any error, exits 0 with no output.
+
+# shellcheck shell=bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  set +e
+  trap 'exit 0' ERR
+}
+# shellcheck source=../_lib/should-track.sh
+source "${SCRIPT_DIR}/../../_lib/should-track.sh" 2>/dev/null || true
+
+failsafe::trap_errors 2>/dev/null || true
+
+RECALL_LIMIT="${RECALL_LIMIT:-5}"
+RECALL_LINES="${RECALL_LINES:-30}"
+
+input="$(cat 2>/dev/null || true)"
+
+extract_field() {
+  local field="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "${input}" | jq -r --arg f "${field}" '.[$f] // empty' 2>/dev/null
+  else
+    printf '%s' "${input}" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*: *"\(.*\)"/\1/'
+  fi
+}
+
+cwd="$(extract_field cwd)"
+[[ -z "${cwd}" ]] && cwd="${PWD}"
+
+# Per-project exclusion gate.
+if command -v should_track_project >/dev/null 2>&1; then
+  should_track_project "${cwd}" || exit 0
+fi
+
+# Opt-out: presence of the disable marker.
+if [[ -f "${cwd}/.agent-config/recall.disabled" ]]; then
+  exit 0
+fi
+
+# Project name = last path segment of cwd. The Claude Code memory directory
+# layout is ~/.claude/projects/<project>/memory/.
+project_name="$(basename "${cwd}")"
+memory_dir="${HOME}/.claude/projects/${project_name}/memory"
+adr_dir="${cwd}/docs/adr"
+
+candidates=()
+if [[ -d "${memory_dir}" ]]; then
+  while IFS= read -r f; do
+    candidates+=("${f}")
+  done < <(find "${memory_dir}" -maxdepth 1 -name 'feedback_*.md' -type f 2>/dev/null)
+fi
+if [[ -d "${adr_dir}" ]]; then
+  while IFS= read -r f; do
+    candidates+=("${f}")
+  done < <(find "${adr_dir}" -maxdepth 2 -name '*.md' -type f 2>/dev/null)
+fi
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Sort by mtime descending. `stat -f %m` (BSD/macOS) and `stat -c %Y` (GNU).
+mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
+sorted=()
+while IFS= read -r line; do
+  sorted+=("$(printf '%s' "${line}" | cut -d' ' -f2-)")
+done < <(
+  for f in "${candidates[@]}"; do
+    printf '%s %s\n' "$(mtime "${f}")" "${f}"
+  done | sort -rn
+)
+
+count=0
+buffer=""
+buffer="${buffer}## Recent memory + decisions\n\n"
+
+idx=1
+for f in "${sorted[@]}"; do
+  [[ ${count} -ge ${RECALL_LIMIT} ]] && break
+  fname="$(basename "${f}")"
+  date_str="$(date -r "$(mtime "${f}")" +%Y-%m-%d 2>/dev/null || echo "")"
+  signal="memory"
+  [[ "${f}" == *"/docs/adr/"* ]] && signal="adr"
+  excerpt="$(head -n "${RECALL_LINES}" "${f}" 2>/dev/null | tr '\n' ' ' | tr -s ' ' | cut -c1-180)"
+  printf -v line '**M-%03d** %s [%s] | `%s` | %s' "${idx}" "${date_str}" "${signal}" "${fname}" "${excerpt}"
+  buffer="${buffer}${line}\n"
+  count=$((count + 1))
+  idx=$((idx + 1))
+done
+
+if [[ ${count} -eq 0 ]]; then
+  exit 0
+fi
+
+# Emit JSON.
+if command -v jq >/dev/null 2>&1; then
+  printf '%b' "${buffer}" | jq -Rs '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: .}}' 2>/dev/null
+else
+  # Fallback: rough JSON build. Escape backslashes and quotes.
+  ctx="${buffer//\\/\\\\}"
+  ctx="${ctx//\"/\\\"}"
+  ctx="${ctx//$'\n'/\\n}"
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "${ctx}"
+fi
+
+exit 0

--- a/hooks/trace/SKILL.md
+++ b/hooks/trace/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: trace
+version: 0.1.0
+description: >
+  Append-only JSONL trace of every tool call in the session. Records `{ts, tool,
+  args, status, duration_ms}` per `PostToolUse` event so later skills can audit
+  what happened without an LLM. Use when the user types "/trace", "track tool
+  calls", "trace this session", "audit tool history", or asks why the agent did
+  something. The hook fires automatically on every tool call; the trigger
+  phrases are mostly for the agent to surface the file path on demand.
+type: hook
+targets:
+  - claude-code
+category:
+  primary: evolution
+  secondary:
+    - context-management
+hooks:
+  PostToolUse:
+    command: hooks/trace.sh
+---
+
+# trace
+
+Each Claude Code session writes one JSONL file under
+`.agent-config/trace/<session-id>.jsonl`. Every line is a single tool-call
+record:
+
+```json
+{"ts":"2026-04-27T18:33:11Z","tool":"Bash","args":{"command":"npm test"},"status":"ok","duration_ms":1247}
+```
+
+Compared to the per-tool LLM critique pattern claude-mem uses for memory
+extraction, the trace hook costs nothing at runtime (no model call, no DB
+write — just a JSONL append). The cost is paid later: skills like `reflect`,
+`stuck-detector`, and the evolution detectors read the trace file to spot
+patterns (edit thrashing, repeated permission prompts, tool-call loops) that
+would be invisible from message-history alone.
+
+## Schema
+
+| Field | Type | Notes |
+|---|---|---|
+| `ts` | ISO-8601 string | UTC, second-precision is fine |
+| `tool` | string | The Claude Code tool name (`Bash`, `Read`, `Edit`, `Grep`, etc.) |
+| `args` | object | Tool input. Truncated at ~2KB per record. |
+| `status` | `"ok"`, `"error"`, `"blocked"` | `blocked` when a permission denial occurred |
+| `duration_ms` | number | From PreToolUse to PostToolUse, when both fire |
+
+The schema is intentionally small. Skills that need richer context resolve it
+on demand from the transcript (see `skills/reflect/SKILL.md`).
+
+## File location
+
+`<repo-root>/.agent-config/trace/<session-id>.jsonl`
+
+The directory is created on the first PostToolUse event and is gitignored
+(see `.gitignore`).
+
+## Disable
+
+Tracking is disabled automatically for excluded directories
+(`~/.config`, `~/Downloads`, `~/Desktop`, `/tmp`, `/var`, plus any path listed
+in `.agent-config/exclude.json` or `~/.config/agent-config/exclude.json`).
+See [`apm-builder/lib/should-track.ts`](../../apm-builder/lib/should-track.ts).
+
+To disable for a specific project that would otherwise be tracked, add the
+path to a project-local exclude file:
+
+```json
+{ "exclude": ["/absolute/path/to/project"] }
+```
+
+## Cost
+
+The hook does about 1ms of work per tool call. No LLM, no network, no DB.
+Storage grows roughly linearly with session length — a 4-hour session writes
+on the order of 50-200 KB of JSONL.
+
+## Why a hook, not a daemon
+
+claude-mem runs a stateful background process that observes events and pushes
+them through an LLM extraction pipeline into SQLite + a vector index. We
+deliberately reject that architecture for this repo: a single fail-safe shell
+script is enough for the patterns we care about, and consumers
+(`reflect`, `stuck-detector`) can read the JSONL on demand without any
+running process.
+
+## See also
+
+- [`hooks/recall/SKILL.md`](../recall/SKILL.md) — the SessionStart counterpart that injects past context.
+- [`skills/reflect/SKILL.md`](../../skills/reflect/SKILL.md) — post-task critique that consumes the trace.
+- [`skills/stuck-detector/SKILL.md`](../../skills/stuck-detector/SKILL.md) — mid-task detector that reads the trace for thrashing patterns.
+- [`CONVENTIONS.md`](../../CONVENTIONS.md) — fail-safe hook convention this script follows.

--- a/hooks/trace/hooks/trace.sh
+++ b/hooks/trace/hooks/trace.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# PostToolUse hook for agent-config. Appends one JSONL record per tool call to
+# `.agent-config/trace/<session-id>.jsonl`. Intentionally minimal: no LLM, no
+# DB, no daemon. Skills like `reflect` and `stuck-detector` read the file later.
+#
+# Reads the Claude Code hook envelope from stdin:
+#   { "session_id": "...", "tool_name": "...", "tool_input": {...},
+#     "tool_response": {...}, "cwd": "...", ... }
+#
+# Writes a single JSONL line:
+#   {"ts":"<ISO>","tool":"<name>","args":<tool_input>,"status":"<ok|error|blocked>",
+#    "duration_ms":<int|null>}
+#
+# Per CONVENTIONS.md: never blocks, always exits 0.
+
+# shellcheck shell=bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  set +e
+  trap 'exit 0' ERR
+}
+# shellcheck source=../_lib/should-track.sh
+source "${SCRIPT_DIR}/../../_lib/should-track.sh" 2>/dev/null || true
+
+failsafe::trap_errors 2>/dev/null || true
+
+# Read entire JSON envelope.
+input="$(cat)"
+
+# Extract a couple of well-known fields without depending on jq.
+extract_field() {
+  local field="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "${input}" | jq -r --arg f "${field}" '.[$f] // empty' 2>/dev/null
+  else
+    # Fallback: naive grep for top-level "<field>": "<value>".
+    printf '%s' "${input}" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*: *"\(.*\)"/\1/'
+  fi
+}
+
+cwd="$(extract_field cwd)"
+[[ -z "${cwd}" ]] && cwd="${PWD}"
+
+# Per-project exclusion gate.
+if command -v should_track_project >/dev/null 2>&1; then
+  should_track_project "${cwd}" || exit 0
+fi
+
+session_id="$(extract_field session_id)"
+[[ -z "${session_id}" ]] && session_id="unknown-$(date +%s)"
+
+tool_name="$(extract_field tool_name)"
+[[ -z "${tool_name}" ]] && tool_name="?"
+
+# Status: blocked > error > ok.
+status="ok"
+if printf '%s' "${input}" | grep -q '"hookEventName"[[:space:]]*:[[:space:]]*"PreToolUse"'; then
+  # Pre-call envelope; we treat it as ok for now.
+  status="ok"
+fi
+if printf '%s' "${input}" | grep -qi '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; then
+  status="blocked"
+elif printf '%s' "${input}" | grep -qi '"is_error"[[:space:]]*:[[:space:]]*true'; then
+  status="error"
+fi
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+trace_dir="${cwd}/.agent-config/trace"
+mkdir -p "${trace_dir}" 2>/dev/null || true
+trace_file="${trace_dir}/${session_id}.jsonl"
+
+# Build the JSONL record. Prefer jq for correctness; fall back to printf.
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "${input}" | jq -c --arg ts "${ts}" --arg tool "${tool_name}" --arg status "${status}" \
+    '{ts: $ts, tool: $tool, args: (.tool_input // {}), status: $status, duration_ms: (.duration_ms // null)}' \
+    >> "${trace_file}" 2>/dev/null || true
+else
+  # Best-effort fallback. Truncate args to keep the line bounded.
+  args_blob="$(printf '%s' "${input}" | tr -d '\n' | cut -c1-2000)"
+  printf '{"ts":"%s","tool":"%s","args":%s,"status":"%s","duration_ms":null}\n' \
+    "${ts}" "${tool_name}" "{}" "${status}" >> "${trace_file}" 2>/dev/null || true
+  # We don't try to escape the raw envelope; jq is the supported path. Suppress lint.
+  : "${args_blob}"
+fi
+
+exit 0

--- a/hooks/tts-announcer/hooks/notify-tts.sh
+++ b/hooks/tts-announcer/hooks/notify-tts.sh
@@ -5,6 +5,8 @@
 # per-project (first time → random pick, then stable) so voice + project name
 # reinforce each other.
 set -u
+# Fail-safe per CONVENTIONS.md: trap unhandled errors and exit 0 always.
+trap 'echo "[tts notify-tts] hook error at line $LINENO" >&2; exit 0' ERR
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 payload="$(cat)"

--- a/hooks/tts-announcer/hooks/subagent-stop-tts.sh
+++ b/hooks/tts-announcer/hooks/subagent-stop-tts.sh
@@ -5,6 +5,8 @@
 # reads `cwd` from the parent for the project name, and uses a per-project
 # voice (first time → random pick, then stable).
 set -u
+# Fail-safe per CONVENTIONS.md: trap unhandled errors and exit 0 always.
+trap 'echo "[tts subagent-stop] hook error at line $LINENO" >&2; exit 0' ERR
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 payload="$(cat)"

--- a/skills/evolution-changelog/SKILL.md
+++ b/skills/evolution-changelog/SKILL.md
@@ -33,24 +33,36 @@ If it doesn't exist, create it with the header from the format example below.
 
 ## Format
 
+EVOLUTION.md uses the **markdown flat-line format** documented in
+[`CONVENTIONS.md`](../../CONVENTIONS.md). One entry per line; sortable IDs;
+date-sectioned; greppable.
+
 ```markdown
 # Evolution Changelog
 
-A log of applied evolution-driven changes to this repo. Each entry: date, signal that
-fired, file changed, one-line description.
+A log of applied evolution-driven changes to this repo. Each entry: finding ID,
+time, signal, file changed, one-line description.
 
 ## 2026-04-27
-
-- **stale-memory** | `~/.claude/projects/agent-config/memory/feedback_old.md` deleted | dead branch reference cleaned
-- **permission-recurring** | `.claude/settings.json` allowlist | added `npm test` (approved 7×)
-- **trigger-mismatch** | `skills/reflect/SKILL.md` description | added `"retro this"` after eval failure
+**F-001** 09:23 [stale-memory] | `feedback_old.md` deleted | dead branch reference cleaned
+**F-002** 14:55 [permission] | `settings.json` | added `npm test` (×7)
+**F-003** 17:02 [trigger-mismatch] | `skills/reflect/SKILL.md` | added "retro this" after eval failure
 
 ## 2026-04-20
-
-- **edit-thrashing** | `skills/orchestrator-mode/SKILL.md` body | clarified §7 loop after 4 reverts
+**F-004** 11:18 [edit-thrashing] | `skills/orchestrator-mode/SKILL.md` | clarified §7 loop after 4 reverts
 ```
 
-The format is deliberately simple: `**<signal>** | <file> | <one-line description>`. No prose; no nesting; one bullet per applied change.
+The fields per line:
+1. `**F-NNN**` — bold finding ID (3-digit, monotonically increasing across the file).
+2. `HH:MM` — local time (optional but recommended).
+3. `[signal]` — bracketed signal type. The icon-prefixed variant
+   (`🔧 [stale-memory]`, etc.) is allowed but not required.
+4. `` `<artifact>` `` — single backtick-wrapped path or settings key.
+5. One-line description, ≤80 chars.
+
+Why flat-line vs the older table form: each entry is a single line, so `grep`,
+`tail -n 20`, and `head` all work cleanly; new fields can be appended without
+rewriting history; LLMs read each line as a complete record.
 
 ## Workflow
 
@@ -76,16 +88,18 @@ Cross-check against `git log` since the report's date. For each finding, check w
 - If not, create a new section *above* the previous one (most recent on top).
 - Keep entries chronologically descending: today first, then earlier dates.
 
-### 4. Format each bullet
+### 4. Format each line
 
 ```
-- **<signal-name>** | <path-relative-to-repo-root-or-~/.claude> | <one-line-description-of-change>
+**F-NNN** HH:MM [signal] | `path` | description
 ```
 
 Rules:
-- `<signal-name>` is the exact signal from the evolution report (kebab-case).
+- `F-NNN` is the next monotonically increasing ID across the whole file (find the highest existing ID, add 1, zero-pad to 3 digits).
+- `[signal]` is the exact signal from the evolution report, in brackets.
 - `<path>` is a single file or settings key, not a directory.
 - `<description>` is one sentence, ≤80 chars. Imperative or past tense, consistent within a section.
+- The icon variant (`🔧 [signal]`, `🔒 [permission]`) is allowed but optional. The bracketed text is the source of truth.
 
 ### 5. Commit (if asked)
 

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -28,6 +28,19 @@ A structured post-task critique. Inspired by the Reflexion pattern: the agent re
   - A new skill, hook, or component landed.
 - Skip for trivial single-tool tasks (one read, one edit, one shell command). Reflection on noise is noise.
 
+## Mode hint
+
+Accepts `--mode <name>` (or `mode:` in the task frontmatter) to bias the
+critique toward a specific domain. The mode value is a *hint* for the agent:
+look up `apm-builder/modes/<name>.json` and weight the critique sections
+toward that domain's `observation_types` and `memory_topics`. Examples:
+
+- `--mode code` — emphasize architecture, performance, refactor opportunities, test patterns.
+- `--mode design` — emphasize affordances, feedback, mapping, accessibility.
+- `--mode ops` — emphasize incident retrospection, alerting, runbook gaps, permission hygiene.
+
+When no mode is set, run a balanced critique across all categories.
+
 ## The structured critique
 
 Produce a markdown report with exactly these five sections, in order:

--- a/skills/skill-gap-detector/SKILL.md
+++ b/skills/skill-gap-detector/SKILL.md
@@ -24,6 +24,19 @@ Surfaces *missing* skills, not edits to existing ones. Pairs with `evolution-eng
 - Weekly maintenance loop (e.g., a `/loop 7d /skill-gap` cron).
 - After `evolution-engine` runs and finds repeated-instruction clusters with no matching existing skill.
 
+## Mode hint
+
+Pass `--mode <name>` (or set `mode:` in task frontmatter) to bias the
+detector toward a specific domain. The mode value is a *hint*: when set, the
+agent should narrow its pattern matching to the domain's `observation_types`
+(see `apm-builder/modes/<name>.json`) and prefer drafting skills aligned with
+the mode's `skills_priority` and `memory_topics`.
+
+Example: `--mode code` favors development-leaning gap proposals (test patterns,
+build-tooling, refactor workflows); `--mode design` favors UX-leaning ones
+(interaction patterns, accessibility checks). When no mode is set, run on the
+full pattern surface.
+
 ## How it works
 
 1. Run the existing detector pipeline:


### PR DESCRIPTION
## Summary

Adopts six patterns surfaced from the claude-mem deep-dive without copying its heavy architecture. The whole change set is markdown-content authoring + thin shell scripts + minimal TypeScript scaffolding (~1.1K LOC total).

## The six patterns

| # | Pattern | Trigger / shape | Value |
|---|---|---|---|
| 1 | `hooks/trace` | `PostToolUse` hook → `.agent-config/trace/<session-id>.jsonl` | Per-tool-call evidence for `reflect`, `stuck-detector`, evolution detectors. Zero LLM cost. |
| 2 | `hooks/recall` | `SessionStart` hook → injects last 5 memory + ADR entries | Recovers prior context automatically. Default ON; opt-out via `.agent-config/recall.disabled`. |
| 3 | Fail-safe hook convention | `CONVENTIONS.md` + `hooks/_lib/fail-safe.sh` | Hooks never block the host session — trap errors, exit 0, log quietly. |
| 4 | Markdown flat-line format | `EVOLUTION.md` per-line entries (`**F-NNN** time [signal] | path | desc`) | Greppable, diff-friendly, LLM-friendly. Replaces table form. |
| 5 | `shouldTrackProject` exclusion gate | `apm-builder/lib/should-track.ts` + `hooks/_lib/should-track.sh` | Per-project + global exclude lists. Default-skips `~/.config`, `~/Downloads`, `/tmp`, `/var`. |
| 6 | Harness adapters + modes | `apm-builder/lib/harness-adapters/` + `apm-builder/modes/{code,design,ops}.json` | Real Claude Code adapter; stubs for codex/gemini/copilot/pi. Mode files documented as a hint for `reflect` and `skill-gap-detector`. |

## Rejected anti-patterns

The claude-mem deep-dive surfaced a number of architectural choices we deliberately declined:

- **No daemon.** All work happens inside one-shot hook scripts that fire on lifecycle events. No background process, no IPC.
- **No DB.** Trace data is JSONL on disk. Recall reads markdown files directly. No SQLite, no schemas, no migrations.
- **No vector index.** Recall uses mtime-sorted recency; "what did I learn yesterday" is the 80% case and is enough.
- **No per-tool LLM call.** Trace is a structured log, not a per-call extraction step. Higher-level skills consume the JSONL on demand.
- **No global state.** Everything writes under `.agent-config/` at the repo root, gitignored, per-project.

## Files added

- `CONVENTIONS.md` — fail-safe rule, flat-line format, per-project state dir, cross-harness contract.
- `hooks/_lib/{fail-safe,should-track}.sh` — shared bash helpers for hooks.
- `hooks/trace/{SKILL.md,hooks/trace.sh}` — JSONL trace hook.
- `hooks/recall/{SKILL.md,hooks/recall.sh}` — SessionStart context injection.
- `apm-builder/lib/should-track.ts` — TypeScript exclusion gate (mirror of the bash version).
- `apm-builder/lib/harness-adapters/` — types, real Claude Code adapter, stubs for codex/gemini/copilot/pi, env-detecting picker.
- `apm-builder/modes/{code,design,ops}.json` + `README.md` — mode files referenced from `skills/skill-gap-detector` and `skills/reflect`.
- Tests: `apm-builder/tests/should-track.test.ts` (5 cases), `apm-builder/tests/harness-adapters/claude-code.test.ts` (8 cases).

## Files updated

- `skills/evolution-changelog/SKILL.md` — flat-line format documented as the EVOLUTION.md spec.
- `skills/skill-gap-detector/SKILL.md` and `skills/reflect/SKILL.md` — `--mode <name>` hint section added.
- `hooks/tts-announcer/hooks/{notify-tts,subagent-stop-tts}.sh` — adopted the fail-safe trap.
- `.gitignore` — adds `.agent-config/`.
- `README.md` — Layout updated (3 hooks now: tts-announcer, trace, recall), new `## Conventions` section linking to `CONVENTIONS.md`, components table regenerated by `npm run docs`.

## Verification

- `npm test` — 184 passed (171 baseline + 13 new).
- `npm run validate` — OK (50 components, 6 unchanged warnings).
- `npm run smoke` — 7 passed.
- `npx tsc --noEmit` — clean.
- `npm run build -- --target claude-code --filter trace` — emits `dist/claude-code/.claude/settings.fragment.json` and `dist/claude-code/hooks/trace.sh`.
- Manually verified `recall.sh` JSON output is parseable JSON via `python3 -c "json.loads(...)"`.

## Test plan

- [ ] Confirm components table regenerated correctly (50 entries, includes `trace` + `recall`).
- [ ] Wire `trace` and `recall` hooks into a real Claude Code session (drop them in `.claude/settings.json`) and verify `.agent-config/trace/<sid>.jsonl` accumulates lines and that `additionalContext` reaches the model on session start.
- [ ] Add `npm test` and `npx tsc --noEmit` to CI if not already there.

## Reference

claude-mem deep-dive (research doc — local) informed the design choices. The PR distills the high-leverage patterns without inheriting the runtime overhead.