### PR TITLE
polish: CHANGELOG + CONTRIBUTING (libfossil-level hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+The `agent-config` repo is a multi-harness component monorepo without a
+single canonical version tag at the repo root. Components are released
+through the `apm-builder` pipeline; sub-packages may carry their own tags
+(e.g. `pikchr-generator@v0.2.0`).
+
+This file tracks notable monorepo-level changes — adoption of new patterns,
+harness adapter changes, taxonomy shifts. The format is loosely based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- 5 must-have subagents brought in from `wshobson/agents`.
+- 6 claude-mem-inspired patterns: trace, recall, fail-safe, flat-line,
+  `shouldTrackProject`, adapters+modes.
+- 7 new Evolution skills: gap-detector, reflect, memorize, eval-runner,
+  linter, stuck-detector, changelog.
+- `career-interview` skill brought in from `agent-plugins`.
+- `pikchr-generator@v0.2.0` sub-package release with idempotent release-tag
+  pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to agent-config
+
+Thanks for your interest in `agent-config`, a multi-harness configuration
+monorepo for AI agent skills, plugins, hooks, agents, and MCP integrations
+across 6 platforms (Claude Code, APM, Codex, Gemini CLI, Copilot CLI, Pi).
+
+## Development setup
+
+Requires Node 20 or newer.
+
+```
+git clone https://github.com/danmestas/agent-config
+cd agent-config
+npm install
+npm run validate
+```
+
+`npm run validate` checks that all components conform to the canonical
+schemas documented in `TAXONOMY.md` and `CONVENTIONS.md`.
+
+## Running tests
+
+```
+npm test            # full vitest suite
+npm run smoke       # smoke tests only
+npm run typecheck   # tsc --noEmit
+npm run test:watch  # watch mode
+```
+
+`npm test` and `npm run validate` together form the canonical pre-PR gate.
+
+## Building
+
+```
+npm run build       # transpile components for all 6 harnesses
+npm run watch       # rebuild on change
+npm run docs        # regenerate component docs
+```
+
+The transpiler in `apm-builder/` reads canonical-format components and
+emits per-harness artifacts under `dist/` and `marketplace/`.
+
+## Component types
+
+- `skills/` — skills (canonical `SKILL.md` format).
+- `plugins/` — plugin components.
+- `hooks/` — hook scripts.
+- `agents/` — subagent definitions.
+- `apm-builder/` — transpiler and validation tooling.
+- `marketplace/` — published artifacts.
+
+## Adding a new component
+
+1. Pick the right type directory.
+2. Follow the canonical schema documented in `TAXONOMY.md` and `CONVENTIONS.md`.
+3. Run `npm run validate` to verify schema compliance.
+4. Run `npm test` for any cross-cutting tests.
+5. Run `npm run build` to confirm the transpiler emits all six harness
+   variants without errors.
+
+## Submitting changes
+
+1. Open a feature branch off `main`. Direct commits to `main` are not accepted.
+2. Run `npm run validate`, `npm test`, and `npm run typecheck` locally
+   before pushing.
+3. Open a PR; CI will re-run validation, tests, and typecheck.
+
+## Reporting issues
+
+Open an issue at https://github.com/danmestas/agent-config/issues with
+reproduction steps and which target harness is affected (Claude Code, APM,
+Codex, Gemini CLI, Copilot CLI, or Pi).


### PR DESCRIPTION
## Summary

Matches the `bones` polish template, adapted for this TS/JS monorepo. Adds `CHANGELOG.md` (loosely Keep-a-Changelog) and `CONTRIBUTING.md` (modeled on libfossil's structure but with npm/vitest commands).

## What's in here

- **`CHANGELOG.md`** — Acknowledges the monorepo's unusual versioning (no canonical repo-level tag; sub-packages tagged independently like `pikchr-generator@v0.2.0`). Rolls recent additions (wshobson agents, claude-mem patterns, Evolution skills, career-interview) under `[Unreleased]`.
- **`CONTRIBUTING.md`** — npm-based dev setup, `validate` + `test` + `typecheck` gate, the `apm-builder` transpiler explanation, canonical-component authoring flow pointing at `TAXONOMY.md` and `CONVENTIONS.md`.

## What's NOT in here

- No README badges (deferred across the polish program).
- No version-tag scheme proposal — left as-is per existing structure.
- No CODE_OF_CONDUCT / SECURITY / issue templates.
- No README rewrite.

## Test plan

- [x] All `npm` scripts referenced in CONTRIBUTING exist in `package.json`
- [x] Schema reference docs (`TAXONOMY.md`, `CONVENTIONS.md`) exist in repo root
- [x] CHANGELOG honestly describes the non-standard versioning