### PR TITLE
feat: ac wrapper + persona/mode component types (Plan 9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .agents/
 .codex/
 .worktrees/
-docs/
 node_modules/
 dist/
 release-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 release-artifacts/
 *.tsbuildinfo
 .vitest-cache/
+docs/superpowers/specs/
+docs/superpowers/plans/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ dependencies:
 
 Adapters emit native artifacts for each harness when a skill declares it in `targets:`. Run `npm run build -- --target <harness>` to generate the per-harness output under `dist/<harness>/`. Install paths follow each harness's convention.
 
+## Configuring with `ac`
+
+`ac` is a wrapper around your harness binary that activates a persona and/or
+mode for a single session, filtering skills and injecting prompt scaffolding.
+Today's full-load behavior is preserved when you don't use it.
+
+```bash
+ac claude --persona backend --mode focused
+```
+
+See [docs/USING-AC.md](docs/USING-AC.md) for installation, authoring personas,
+and troubleshooting.
+
 ## Categories
 
 ### Software design philosophy (BackPressure)

--- a/apm-builder/ac.ts
+++ b/apm-builder/ac.ts
@@ -1,8 +1,32 @@
 #!/usr/bin/env node
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runAc } from './lib/ac/run.ts';
+import { listCommand } from './lib/ac/introspect.ts';
 
 const argv = process.argv.slice(2);
-runAc(argv).then(
+const homeDirs = () => ({
+  projectDir: process.cwd(),
+  userDir: path.join(os.homedir(), '.config', 'agent-config'),
+  builtinDir: path.dirname(path.dirname(fileURLToPath(import.meta.url))),
+});
+
+async function main(): Promise<number> {
+  if (argv[0] === 'list') {
+    const what = argv[1];
+    if (what !== 'personas' && what !== 'modes') {
+      process.stderr.write('ac list: expected "personas" or "modes"\n');
+      return 2;
+    }
+    await listCommand(what, { ...homeDirs(), print: (l) => process.stdout.write(l + '\n') });
+    return 0;
+  }
+  // Default: ac <harness> [flags] -- <harness args>
+  return runAc(argv);
+}
+
+main().then(
   (code) => process.exit(code),
   (err) => {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);

--- a/apm-builder/ac.ts
+++ b/apm-builder/ac.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { runAc } from './lib/ac/run.ts';
+
+const argv = process.argv.slice(2);
+runAc(argv).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+  },
+);

--- a/apm-builder/ac.ts
+++ b/apm-builder/ac.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runAc } from './lib/ac/run.ts';
-import { listCommand } from './lib/ac/introspect.ts';
+import { listCommand, showCommand, doctorCommand } from './lib/ac/introspect.ts';
 
 const argv = process.argv.slice(2);
 const homeDirs = () => ({
@@ -21,6 +21,31 @@ async function main(): Promise<number> {
     }
     await listCommand(what, { ...homeDirs(), print: (l) => process.stdout.write(l + '\n') });
     return 0;
+  }
+  if (argv[0] === 'show') {
+    const kind = argv[1];
+    if (kind !== 'persona' && kind !== 'mode' && kind !== 'effective') {
+      process.stderr.write('ac show: expected "persona <name>" | "mode <name>" | "effective ..."\n');
+      return 2;
+    }
+    const name = argv[2];
+    await showCommand(
+      { kind: kind as 'persona' | 'mode' | 'effective', name },
+      { ...homeDirs(), print: (l) => process.stdout.write(l + '\n') },
+    );
+    return 0;
+  }
+  if (argv[0] === 'doctor') {
+    const harnessConfigRoots = {
+      'claude-code': path.join(os.homedir(), '.claude'),
+      apm: path.join(os.homedir(), '.apm'),
+      gemini: path.join(os.homedir(), '.gemini'),
+      pi: path.join(os.homedir(), '.pi'),
+    };
+    return doctorCommand({
+      harnessConfigRoots,
+      print: (l) => process.stdout.write(l + '\n'),
+    });
   }
   // Default: ac <harness> [flags] -- <harness args>
   return runAc(argv);

--- a/apm-builder/adapters/apm.ts
+++ b/apm-builder/adapters/apm.ts
@@ -85,6 +85,11 @@ export const apmAdapter: Adapter = {
         return emitRules(component, ctx);
       case 'plugin':
         return emitPlugin(component, ctx);
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       default:
         throw new Error(`apm adapter: type "${component.manifest.type}" not yet implemented`);
     }

--- a/apm-builder/adapters/claude-code.ts
+++ b/apm-builder/adapters/claude-code.ts
@@ -31,6 +31,11 @@ export const claudeCodeAdapter: Adapter = {
         return emitMcp(component);
       case 'plugin':
         return emitPlugin(component, ctx);
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       default:
         throw new Error(`claude-code adapter: type "${component.manifest.type}" not yet implemented`);
     }

--- a/apm-builder/adapters/codex.ts
+++ b/apm-builder/adapters/codex.ts
@@ -32,6 +32,11 @@ export const codexAdapter: Adapter = {
         return emitHook(component);
       case 'mcp':
         return emitMcp(component, ctx);
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       // plugin is schema-rejected for codex (see Plan 1's validate.ts).
       default:
         throw new Error(

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -22,6 +22,11 @@ export const copilotAdapter: Adapter = {
           `copilot adapter: type "${component.manifest.type}" not supported by Copilot CLI ` +
             `(see compatibility matrix in spec). Remove "copilot" from the component's targets.`,
         );
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       default:
         throw new Error(
           `copilot adapter: unknown component type "${component.manifest.type}"`,

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -35,25 +35,19 @@ export const copilotAdapter: Adapter = {
   },
 };
 
-function emitInstructions(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
-  // Collect all components contributing to copilot-instructions.md.
-  const rules = selectRules(ctx.allComponents, 'copilot', 'project');
-  const skills = ctx.allComponents
+/**
+ * Compose copilot-instructions.md content from a filtered set of components.
+ * Exported so the CLI `docs --target copilot` can reuse it directly.
+ */
+export function composeCopilotInstructions(allComponents: ComponentSource[]): string {
+  const rules = selectRules(allComponents, 'copilot', 'project');
+  const skills = allComponents
     .filter(
       (c) =>
         c.manifest.type === 'skill' &&
         c.manifest.targets.includes('copilot'),
     )
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
-
-  // Pick a canonical owner: alphabetically-first project rule, or, if no rules, alphabetically-first skill.
-  const owner = rules[0] ?? skills[0];
-  if (!owner || owner.manifest.name !== component.manifest.name) return [];
-
-  // For rule components that are user-scoped, opt out (Copilot has no user scope).
-  if (component.manifest.type === 'rules' && (component.manifest.scope ?? 'project') !== 'project') {
-    return [];
-  }
 
   const sections: string[] = [];
   if (rules.length > 0) sections.push(`# Rules\n\n${composeRulesBody(rules)}`);
@@ -63,8 +57,32 @@ function emitInstructions(component: ComponentSource, ctx: AdapterContext): Emit
       .join('\n');
     sections.push(`# Skills\n\n${skillSections}`);
   }
-  if (sections.length === 0) return [];
-  const content = sections.join('\n');
+  return sections.join('\n');
+}
+
+function emitInstructions(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {
+  const allComponents = ctx.allComponents;
+
+  // Pick a canonical owner: alphabetically-first project rule, or, if no rules, alphabetically-first skill.
+  const rules = selectRules(allComponents, 'copilot', 'project');
+  const skills = allComponents
+    .filter(
+      (c) =>
+        c.manifest.type === 'skill' &&
+        c.manifest.targets.includes('copilot'),
+    )
+    .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
+
+  const owner = rules[0] ?? skills[0];
+  if (!owner || owner.manifest.name !== component.manifest.name) return [];
+
+  // For rule components that are user-scoped, opt out (Copilot has no user scope).
+  if (component.manifest.type === 'rules' && (component.manifest.scope ?? 'project') !== 'project') {
+    return [];
+  }
+
+  const content = composeCopilotInstructions(allComponents);
+  if (!content) return [];
   return [{ path: 'copilot-instructions.md', content }];
 }
 

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -48,6 +48,11 @@ export const geminiAdapter: Adapter = {
         return emitHook(component);
       case 'mcp':
         return emitMcp(component);
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       // agent and plugin are schema-rejected by validate.ts (compatibility matrix).
       default:
         throw new Error(

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -28,6 +28,11 @@ export const piAdapter: Adapter = {
         return emitHookExtension(component);
       case 'mcp':
         return emitMcpStub(component);
+      case 'persona':
+      case 'mode':
+        // Personas and modes are harness-agnostic, consumed by `ac` at resolution
+        // time. Not emitted per-target. See spec §5.2.
+        return [];
       default:
         throw new Error(`pi adapter: type "${component.manifest.type}" not supported`);
     }

--- a/apm-builder/cli.ts
+++ b/apm-builder/cli.ts
@@ -9,6 +9,8 @@ import { validateComponents } from './lib/validate.ts';
 import { runBuild } from './lib/build.ts';
 import { matchesGlob } from './lib/glob.ts';
 import { updateReadme } from './lib/docs.ts';
+import { composeAgentsMd } from './lib/agents-md.ts';
+import { composeCopilotInstructions } from './adapters/copilot.ts';
 import { TARGETS, type Target } from './lib/types.ts';
 import { listImplementedTargets } from './adapters/index.ts';
 import { runEvolution } from './lib/evolution/orchestrator.ts';
@@ -125,14 +127,53 @@ const watchCmd = defineCommand({
 
 const docsCmd = defineCommand({
   meta: { name: 'docs', description: 'Regenerate the components table in README.md (preserves hand-written sections)' },
-  async run() {
-    const repoRoot = process.cwd();
-    const readmePath = path.join(repoRoot, 'README.md');
-    const components = await discoverComponents(repoRoot);
-    const existing = await fs.readFile(readmePath, 'utf8').catch(() => null);
-    const md = updateReadme(existing, components);
-    await fs.writeFile(readmePath, md);
-    console.log(pc.green(`wrote README.md (${components.length} components).`));
+  args: {
+    target: { type: 'string', description: 'Filter docs to a specific harness target (codex | copilot)' },
+    resolution: { type: 'string', description: 'Path to resolution artifact (filters skills per skillsDrop)' },
+    out: { type: 'string', description: 'Output path (default: AGENTS.md or copilot-instructions.md per target)' },
+    repo: { type: 'string', description: 'Repo root to discover components from (default: cwd)' },
+  },
+  async run({ args }) {
+    const repoRoot = args.repo ?? process.cwd();
+
+    if (!args.target) {
+      // Default behavior: regenerate README.md components table.
+      const readmePath = path.join(repoRoot, 'README.md');
+      const components = await discoverComponents(repoRoot);
+      const existing = await fs.readFile(readmePath, 'utf8').catch(() => null);
+      const md = updateReadme(existing, components);
+      await fs.writeFile(readmePath, md);
+      console.log(pc.green(`wrote README.md (${components.length} components).`));
+      return;
+    }
+
+    // Load resolution artifact for filtering if provided.
+    let drop: Set<string> | null = null;
+    if (args.resolution) {
+      const r = JSON.parse(await fs.readFile(args.resolution, 'utf8'));
+      drop = new Set<string>(r.skillsDrop ?? []);
+    }
+
+    // Discover and filter components.
+    const allComponents = await discoverComponents(repoRoot);
+    const components = drop
+      ? allComponents.filter((c) => c.manifest.type !== 'skill' || !drop!.has(c.manifest.name))
+      : allComponents;
+
+    if (args.target === 'codex') {
+      const outPath = args.out ?? path.join(repoRoot, 'AGENTS.md');
+      const content = composeAgentsMd({ target: 'codex', components, sectionOrder: ['rules', 'agents', 'skills'] });
+      await fs.writeFile(outPath, content);
+      console.log(pc.green(`wrote ${outPath} (${components.length} components).`));
+    } else if (args.target === 'copilot') {
+      const outPath = args.out ?? path.join(repoRoot, 'copilot-instructions.md');
+      const content = composeCopilotInstructions(components);
+      await fs.writeFile(outPath, content);
+      console.log(pc.green(`wrote ${outPath} (${components.length} components).`));
+    } else {
+      console.log(pc.red(`unknown target: ${args.target}. Valid: codex, copilot`));
+      process.exit(1);
+    }
   },
 });
 

--- a/apm-builder/lib/ac/introspect.ts
+++ b/apm-builder/lib/ac/introspect.ts
@@ -1,0 +1,31 @@
+import { listAllPersonas, type DiscoveryDirs } from '../persona.ts';
+import { listAllModes } from '../mode.ts';
+
+export interface IntrospectDeps extends DiscoveryDirs {
+  print: (line: string) => void;
+}
+
+export async function listCommand(
+  what: 'personas' | 'modes',
+  deps: IntrospectDeps,
+): Promise<void> {
+  if (what === 'personas') {
+    const all = await listAllPersonas(deps);
+    if (all.length === 0) {
+      deps.print('(no personas found)');
+      return;
+    }
+    for (const p of all) {
+      deps.print(`${p.manifest.name.padEnd(20)} v${p.manifest.version.padEnd(8)} [${p.source}]  ${p.manifest.description}`);
+    }
+  } else {
+    const all = await listAllModes(deps);
+    if (all.length === 0) {
+      deps.print('(no modes found)');
+      return;
+    }
+    for (const m of all) {
+      deps.print(`${m.manifest.name.padEnd(20)} v${m.manifest.version.padEnd(8)} [${m.source}]  ${m.manifest.description}`);
+    }
+  }
+}

--- a/apm-builder/lib/ac/introspect.ts
+++ b/apm-builder/lib/ac/introspect.ts
@@ -1,5 +1,7 @@
-import { listAllPersonas, type DiscoveryDirs } from '../persona.ts';
-import { listAllModes } from '../mode.ts';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { listAllPersonas, findPersona, type DiscoveryDirs } from '../persona.ts';
+import { listAllModes, findMode } from '../mode.ts';
 
 export interface IntrospectDeps extends DiscoveryDirs {
   print: (line: string) => void;
@@ -28,4 +30,79 @@ export async function listCommand(
       deps.print(`${m.manifest.name.padEnd(20)} v${m.manifest.version.padEnd(8)} [${m.source}]  ${m.manifest.description}`);
     }
   }
+}
+
+export interface ShowOptions {
+  kind: 'persona' | 'mode' | 'effective';
+  name?: string;
+  persona?: string;
+  mode?: string;
+}
+
+export async function showCommand(
+  opts: ShowOptions,
+  deps: IntrospectDeps,
+): Promise<void> {
+  if (opts.kind === 'persona') {
+    if (!opts.name) throw new Error('ac show persona <name>: name required');
+    const f = await findPersona(opts.name, deps);
+    deps.print(`name: ${f.manifest.name}`);
+    deps.print(`version: ${f.manifest.version}`);
+    deps.print(`source: ${f.source} (${f.filepath})`);
+    deps.print(`description: ${f.manifest.description}`);
+    deps.print(`targets: ${f.manifest.targets.join(', ')}`);
+    deps.print(`categories: ${f.manifest.categories.join(', ')}`);
+    deps.print(`skill_include: ${(f.manifest.skill_include ?? []).join(', ')}`);
+    deps.print(`skill_exclude: ${(f.manifest.skill_exclude ?? []).join(', ')}`);
+    if (f.body.trim()) {
+      deps.print('');
+      deps.print('--- body ---');
+      deps.print(f.body.trim());
+    }
+    return;
+  }
+  if (opts.kind === 'mode') {
+    if (!opts.name) throw new Error('ac show mode <name>: name required');
+    const f = await findMode(opts.name, deps);
+    deps.print(`name: ${f.manifest.name}`);
+    deps.print(`version: ${f.manifest.version}`);
+    deps.print(`source: ${f.source} (${f.filepath})`);
+    deps.print(`description: ${f.manifest.description}`);
+    deps.print(`targets: ${f.manifest.targets.join(', ')}`);
+    deps.print(`categories: ${f.manifest.categories.join(', ')}`);
+    deps.print(`skill_include: ${(f.manifest.skill_include ?? []).join(', ')}`);
+    deps.print(`skill_exclude: ${(f.manifest.skill_exclude ?? []).join(', ')}`);
+    deps.print('');
+    deps.print('--- mode prompt body (injected as additional context when active) ---');
+    deps.print(f.body.trim());
+    return;
+  }
+  // 'effective' is wired in the run.ts flow path; printed here.
+  throw new Error('ac show effective: not yet implemented');
+}
+
+export interface DoctorDeps {
+  /** Map from target name → expected install root (the dir where the filter hook should live). */
+  harnessConfigRoots: Record<string, string>;
+  print: (line: string) => void;
+}
+
+export async function doctorCommand(deps: DoctorDeps): Promise<number> {
+  let problems = 0;
+  for (const [target, root] of Object.entries(deps.harnessConfigRoots)) {
+    const expected = path.join(root, 'hooks', `ac-filter-${target}`);
+    try {
+      await fs.access(expected);
+      deps.print(`[ok]  ${target}: ${expected}`);
+    } catch {
+      deps.print(`[!!]  ${target}: missing ${expected}`);
+      problems += 1;
+    }
+  }
+  if (problems > 0) {
+    deps.print('');
+    deps.print(`${problems} harness(es) missing filter hooks. Install with:`);
+    deps.print('  apm-builder install --target <harness>');
+  }
+  return problems === 0 ? 0 : 1;
 }

--- a/apm-builder/lib/ac/prelaunch.ts
+++ b/apm-builder/lib/ac/prelaunch.ts
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export interface PrelaunchOptions {
+  resolutionPath: string;
+  originalCwd: string;
+}
+
+export interface PrelaunchResult {
+  tempdir: string;
+  /** Cleanup function — call on session end. Best-effort. */
+  cleanup: () => Promise<void>;
+}
+
+async function runApmBuilderDocs(
+  target: 'codex' | 'copilot',
+  resolutionPath: string,
+  outFile: string,
+  originalCwd: string,
+): Promise<void> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const cli = path.resolve(here, '..', '..', 'cli.ts');
+  const tsx = path.resolve(here, '..', '..', '..', 'node_modules', '.bin', 'tsx');
+  await new Promise<void>((resolveCb, reject) => {
+    const child = spawn(
+      process.execPath,
+      [tsx, cli, 'docs', '--target', target, '--resolution', resolutionPath, '--out', outFile, '--repo', originalCwd],
+      { stdio: 'inherit' },
+    );
+    child.on('error', reject);
+    child.on('close', (code) => (code === 0 ? resolveCb() : reject(new Error(`apm-builder docs exited ${code}`))));
+  });
+}
+
+async function symlinkProjectFiles(originalCwd: string, tempdir: string): Promise<void> {
+  // Symlink common project files so the harness can still read them.
+  const toLink = ['.git', 'package.json', 'tsconfig.json', '.env'];
+  for (const name of toLink) {
+    const src = path.join(originalCwd, name);
+    try {
+      await fs.access(src);
+      await fs.symlink(src, path.join(tempdir, name));
+    } catch {
+      // skip missing
+    }
+  }
+}
+
+export async function prelaunchComposeCodex(opts: PrelaunchOptions): Promise<PrelaunchResult> {
+  const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-prelaunch-'));
+  await runApmBuilderDocs('codex', opts.resolutionPath, path.join(tempdir, 'AGENTS.md'), opts.originalCwd);
+  await symlinkProjectFiles(opts.originalCwd, tempdir);
+  return {
+    tempdir,
+    cleanup: async () => {
+      try {
+        await fs.rm(tempdir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+export async function prelaunchComposeCopilot(opts: PrelaunchOptions): Promise<PrelaunchResult> {
+  const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-prelaunch-'));
+  await runApmBuilderDocs('copilot', opts.resolutionPath, path.join(tempdir, 'copilot-instructions.md'), opts.originalCwd);
+  await symlinkProjectFiles(opts.originalCwd, tempdir);
+  return {
+    tempdir,
+    cleanup: async () => {
+      try {
+        await fs.rm(tempdir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}

--- a/apm-builder/lib/ac/run.ts
+++ b/apm-builder/lib/ac/run.ts
@@ -7,6 +7,7 @@ import { findMode } from '../mode.ts';
 import { resolve, writeResolutionArtifact } from '../resolution.ts';
 import { discoverComponents } from '../discover.ts';
 import type { Target } from '../types.ts';
+import { prelaunchComposeCodex, prelaunchComposeCopilot } from './prelaunch.ts';
 
 export interface ParsedAcArgs {
   harness: string;
@@ -132,6 +133,20 @@ export async function runAc(argv: string[], deps: RunDeps = {}): Promise<number>
     env.AC_RESOLUTION_PATH = artifactPath;
   }
 
+  let cwd = process.cwd();
+  let cleanup: (() => Promise<void>) | undefined;
+  if (target === 'codex' && env.AC_RESOLUTION_PATH) {
+    const r = await prelaunchComposeCodex({ resolutionPath: env.AC_RESOLUTION_PATH, originalCwd: cwd });
+    cwd = r.tempdir;
+    env.AC_ORIGINAL_CWD = process.cwd();
+    cleanup = r.cleanup;
+  } else if (target === 'copilot' && env.AC_RESOLUTION_PATH) {
+    const r = await prelaunchComposeCopilot({ resolutionPath: env.AC_RESOLUTION_PATH, originalCwd: cwd });
+    cwd = r.tempdir;
+    env.AC_ORIGINAL_CWD = process.cwd();
+    cleanup = r.cleanup;
+  }
+
   const bin = (deps.resolveHarnessBin ?? defaultResolveHarnessBin)(args.harness);
   if (deps.exec) {
     return deps.exec(bin, args.harnessArgs, env);
@@ -140,8 +155,11 @@ export async function runAc(argv: string[], deps: RunDeps = {}): Promise<number>
   // directly without an extra dep; spawning + forwarding signals + exiting
   // on close achieves the same outcome from the user's perspective.
   return new Promise<number>((resolveCb, reject) => {
-    const child = spawn(bin, args.harnessArgs, { stdio: 'inherit', env });
+    const child = spawn(bin, args.harnessArgs, { stdio: 'inherit', env, cwd });
     child.on('error', reject);
-    child.on('close', (code) => resolveCb(code ?? 0));
+    child.on('close', async (code) => {
+      if (cleanup) await cleanup();
+      resolveCb(code ?? 0);
+    });
   });
 }

--- a/apm-builder/lib/ac/run.ts
+++ b/apm-builder/lib/ac/run.ts
@@ -1,0 +1,147 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+import { findPersona } from '../persona.ts';
+import { findMode } from '../mode.ts';
+import { resolve, writeResolutionArtifact } from '../resolution.ts';
+import { discoverComponents } from '../discover.ts';
+import type { Target } from '../types.ts';
+
+export interface ParsedAcArgs {
+  harness: string;
+  persona?: string;
+  mode?: string;
+  noFilter: boolean;
+  verbose: boolean;
+  harnessArgs: string[];
+}
+
+const HARNESS_ALIASES: Record<string, Target> = {
+  claude: 'claude-code',
+  'claude-code': 'claude-code',
+  apm: 'apm',
+  codex: 'codex',
+  gemini: 'gemini',
+  copilot: 'copilot',
+  pi: 'pi',
+};
+
+export function parseAcArgs(argv: string[]): ParsedAcArgs {
+  if (argv.length === 0 || argv[0]!.startsWith('--')) {
+    throw new Error('ac: missing harness name. Usage: ac <harness> [flags] -- <harness args>');
+  }
+  const out: ParsedAcArgs = {
+    harness: argv[0]!,
+    noFilter: false,
+    verbose: false,
+    harnessArgs: [],
+  };
+  let i = 1;
+  while (i < argv.length) {
+    const tok = argv[i]!;
+    if (tok === '--') {
+      out.harnessArgs = argv.slice(i + 1);
+      return out;
+    }
+    if (tok === '--persona') {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith('--')) {
+        throw new Error('ac: --persona requires a value');
+      }
+      out.persona = v;
+      i += 2;
+      continue;
+    }
+    if (tok === '--mode') {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith('--')) {
+        throw new Error('ac: --mode requires a value');
+      }
+      out.mode = v;
+      i += 2;
+      continue;
+    }
+    if (tok === '--no-filter') {
+      out.noFilter = true;
+      i += 1;
+      continue;
+    }
+    if (tok === '--verbose') {
+      out.verbose = true;
+      i += 1;
+      continue;
+    }
+    throw new Error(`ac: unrecognized flag "${tok}". (ac flags must come before "--")`);
+  }
+  return out;
+}
+
+export interface RunDeps {
+  /** Override discovery roots (test injection). */
+  projectDir?: string;
+  userDir?: string;
+  builtinDir?: string;
+  /** Override harness binary lookup (test injection). */
+  resolveHarnessBin?: (harness: string) => string;
+  /** Catalog provider (test injection). */
+  loadCatalog?: () => Promise<any[]>;
+  /** Hook called instead of execvp; used in tests to avoid replacing the process. */
+  exec?: (bin: string, args: string[], env: NodeJS.ProcessEnv) => never | Promise<number>;
+}
+
+function defaultResolveHarnessBin(harness: string): string {
+  const target = HARNESS_ALIASES[harness];
+  if (!target) throw new Error(`ac: unknown harness "${harness}"`);
+  // The actual on-PATH binary differs from the target name in some cases.
+  const binNames: Record<Target, string> = {
+    'claude-code': 'claude',
+    apm: 'apm',
+    codex: 'codex',
+    gemini: 'gemini',
+    copilot: 'copilot',
+    pi: 'pi',
+  };
+  return binNames[target];
+}
+
+export async function runAc(argv: string[], deps: RunDeps = {}): Promise<number> {
+  const args = parseAcArgs(argv);
+  const target = HARNESS_ALIASES[args.harness];
+  if (!target) {
+    throw new Error(`ac: unknown harness "${args.harness}". Recognized: ${Object.keys(HARNESS_ALIASES).join(', ')}`);
+  }
+
+  const projectDir = deps.projectDir ?? process.cwd();
+  const userDir = deps.userDir ?? path.join(os.homedir(), '.config', 'agent-config');
+  const builtinDir =
+    deps.builtinDir ?? path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+  const dirs = { projectDir, userDir, builtinDir };
+
+  const env: NodeJS.ProcessEnv = { ...process.env, AC_WRAPPED: '1', AC_HARNESS: target };
+
+  if (!args.noFilter && (args.persona || args.mode)) {
+    const persona = args.persona ? (await findPersona(args.persona, dirs)).manifest : undefined;
+    const found = args.mode ? await findMode(args.mode, dirs) : undefined;
+    const mode = found?.manifest;
+    const modeBody = found?.body;
+
+    const catalog = await (deps.loadCatalog ?? (async () => discoverComponents(builtinDir)))();
+    const resolution = resolve({ catalog, persona, mode, modeBody, harness: target });
+    const artifactPath = await writeResolutionArtifact(resolution);
+    env.AC_RESOLUTION_PATH = artifactPath;
+  }
+
+  const bin = (deps.resolveHarnessBin ?? defaultResolveHarnessBin)(args.harness);
+  if (deps.exec) {
+    return deps.exec(bin, args.harnessArgs, env);
+  }
+  // Real execution: spawn and inherit stdio. We cannot use execvp from Node
+  // directly without an extra dep; spawning + forwarding signals + exiting
+  // on close achieves the same outcome from the user's perspective.
+  return new Promise<number>((resolveCb, reject) => {
+    const child = spawn(bin, args.harnessArgs, { stdio: 'inherit', env });
+    child.on('error', reject);
+    child.on('close', (code) => resolveCb(code ?? 0));
+  });
+}

--- a/apm-builder/lib/discover.ts
+++ b/apm-builder/lib/discover.ts
@@ -4,7 +4,16 @@ import matter from 'gray-matter';
 import { ManifestSchema } from './schema.ts';
 import type { ComponentSource } from './types.ts';
 
-const COMPONENT_DIRS = ['skills', 'plugins', 'rules', 'hooks', 'agents', 'mcp'] as const;
+const COMPONENT_DIRS = ['skills', 'plugins', 'rules', 'hooks', 'agents', 'mcp', 'personas', 'modes'] as const;
+
+const DIR_FILENAME: Partial<Record<string, string>> = {
+  personas: 'persona.md',
+  modes: 'mode.md',
+};
+
+function getComponentFilename(dir: string): string {
+  return DIR_FILENAME[dir] ?? 'SKILL.md';
+}
 
 export async function discoverComponents(repoRoot: string): Promise<ComponentSource[]> {
   const components: ComponentSource[] = [];
@@ -19,7 +28,7 @@ export async function discoverComponents(repoRoot: string): Promise<ComponentSou
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const componentDir = path.join(dir, entry.name);
-      const skillPath = path.join(componentDir, 'SKILL.md');
+      const skillPath = path.join(componentDir, getComponentFilename(top));
       const skillExists = await fs.stat(skillPath).then(() => true).catch(() => false);
       if (!skillExists) continue;
       const raw = await fs.readFile(skillPath, 'utf8');

--- a/apm-builder/lib/mode.ts
+++ b/apm-builder/lib/mode.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { ModeSchema, type ModeManifest } from './schema.ts';
+import type { DiscoveryDirs } from './persona.ts';
+
+export interface FoundMode {
+  manifest: ModeManifest;
+  body: string;
+  source: 'project' | 'user' | 'builtin';
+  filepath: string;
+}
+
+const TIERS: Array<keyof DiscoveryDirs> = ['projectDir', 'userDir', 'builtinDir'];
+const TIER_NAMES: Record<keyof DiscoveryDirs, FoundMode['source']> = {
+  projectDir: 'project',
+  userDir: 'user',
+  builtinDir: 'builtin',
+};
+
+function resolveTierRoot(tier: keyof DiscoveryDirs, dirs: DiscoveryDirs): string {
+  switch (tier) {
+    case 'projectDir':
+      return path.join(dirs.projectDir, '.agent-config', 'modes');
+    case 'userDir':
+      return path.join(dirs.userDir, 'modes');
+    case 'builtinDir':
+      return path.join(dirs.builtinDir, 'modes');
+  }
+}
+
+async function listModeFilenames(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.isFile() && e.name.endsWith('.md')) out.push(path.join(dir, e.name));
+      else if (e.isDirectory()) {
+        const candidate = path.join(dir, e.name, 'mode.md');
+        try {
+          await fs.access(candidate);
+          out.push(candidate);
+        } catch {
+          // not a mode dir
+        }
+      }
+    }
+  } catch {
+    // dir doesn't exist
+  }
+  return out;
+}
+
+export async function findMode(name: string, dirs: DiscoveryDirs): Promise<FoundMode> {
+  const seen: string[] = [];
+  for (const tier of TIERS) {
+    const root = resolveTierRoot(tier, dirs);
+    const files = await listModeFilenames(root);
+    for (const filepath of files) {
+      const raw = await fs.readFile(filepath, 'utf8');
+      const parsed = matter(raw);
+      const result = ModeSchema.safeParse(parsed.data);
+      if (!result.success) continue;
+      seen.push(result.data.name);
+      if (result.data.name === name) {
+        return {
+          manifest: result.data,
+          body: parsed.content,
+          source: TIER_NAMES[tier],
+          filepath,
+        };
+      }
+    }
+  }
+  throw new Error(
+    `mode not found: "${name}". Available: ${seen.length === 0 ? '(none)' : seen.join(', ')}`,
+  );
+}
+
+export async function listAllModes(dirs: DiscoveryDirs): Promise<FoundMode[]> {
+  const found = new Map<string, FoundMode>();
+  for (const tier of TIERS) {
+    const root = resolveTierRoot(tier, dirs);
+    const files = await listModeFilenames(root);
+    for (const filepath of files) {
+      const raw = await fs.readFile(filepath, 'utf8');
+      const parsed = matter(raw);
+      const result = ModeSchema.safeParse(parsed.data);
+      if (!result.success) continue;
+      if (!found.has(result.data.name)) {
+        found.set(result.data.name, {
+          manifest: result.data,
+          body: parsed.content,
+          source: TIER_NAMES[tier],
+          filepath,
+        });
+      }
+    }
+  }
+  return Array.from(found.values()).sort((a, b) =>
+    a.manifest.name.localeCompare(b.manifest.name),
+  );
+}

--- a/apm-builder/lib/persona.ts
+++ b/apm-builder/lib/persona.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { PersonaSchema, type PersonaManifest } from './schema.ts';
+
+export interface DiscoveryDirs {
+  /** Project-scoped: <cwd>/.agent-config/personas/ (or modes/). */
+  projectDir: string;
+  /** User-scoped: ~/.config/agent-config/. */
+  userDir: string;
+  /** Built-in: agent-config/. */
+  builtinDir: string;
+}
+
+export interface FoundPersona {
+  manifest: PersonaManifest;
+  body: string;
+  source: 'project' | 'user' | 'builtin';
+  filepath: string;
+}
+
+const TIERS: Array<keyof DiscoveryDirs> = ['projectDir', 'userDir', 'builtinDir'];
+const TIER_NAMES: Record<keyof DiscoveryDirs, FoundPersona['source']> = {
+  projectDir: 'project',
+  userDir: 'user',
+  builtinDir: 'builtin',
+};
+
+async function listPersonaFilenames(dir: string): Promise<string[]> {
+  // The 3 tiers each store personas slightly differently:
+  //   projectDir: <projectDir>/.agent-config/personas/<name>.md
+  //   userDir:    <userDir>/personas/<name>.md
+  //   builtinDir: <builtinDir>/personas/<name>/persona.md
+  // The caller ensures each `dir` is rooted appropriately before invoking.
+  // For listing, we just glob *.md and *.{persona,mode}.md and dirs containing persona.md.
+  // This helper is shared with mode.ts in pattern.
+  const out: string[] = [];
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.isFile() && e.name.endsWith('.md')) out.push(path.join(dir, e.name));
+      else if (e.isDirectory()) {
+        const candidate = path.join(dir, e.name, 'persona.md');
+        try {
+          await fs.access(candidate);
+          out.push(candidate);
+        } catch {
+          // not a persona dir
+        }
+      }
+    }
+  } catch {
+    // dir doesn't exist
+  }
+  return out;
+}
+
+function resolveTierRoot(tier: keyof DiscoveryDirs, dirs: DiscoveryDirs): string {
+  switch (tier) {
+    case 'projectDir':
+      return path.join(dirs.projectDir, '.agent-config', 'personas');
+    case 'userDir':
+      return path.join(dirs.userDir, 'personas');
+    case 'builtinDir':
+      return path.join(dirs.builtinDir, 'personas');
+  }
+}
+
+export async function findPersona(
+  name: string,
+  dirs: DiscoveryDirs,
+): Promise<FoundPersona> {
+  const seen: string[] = [];
+  for (const tier of TIERS) {
+    const root = resolveTierRoot(tier, dirs);
+    const files = await listPersonaFilenames(root);
+    for (const filepath of files) {
+      const raw = await fs.readFile(filepath, 'utf8');
+      const parsed = matter(raw);
+      const result = PersonaSchema.safeParse(parsed.data);
+      if (!result.success) continue; // skip invalid; validate.ts catches them at build
+      seen.push(result.data.name);
+      if (result.data.name === name) {
+        return {
+          manifest: result.data,
+          body: parsed.content,
+          source: TIER_NAMES[tier],
+          filepath,
+        };
+      }
+    }
+  }
+  throw new Error(
+    `persona not found: "${name}". Available: ${seen.length === 0 ? '(none)' : seen.join(', ')}`,
+  );
+}
+
+export async function listAllPersonas(dirs: DiscoveryDirs): Promise<FoundPersona[]> {
+  const found = new Map<string, FoundPersona>();
+  for (const tier of TIERS) {
+    const root = resolveTierRoot(tier, dirs);
+    const files = await listPersonaFilenames(root);
+    for (const filepath of files) {
+      const raw = await fs.readFile(filepath, 'utf8');
+      const parsed = matter(raw);
+      const result = PersonaSchema.safeParse(parsed.data);
+      if (!result.success) continue;
+      // Higher-priority tier already won; don't overwrite.
+      if (!found.has(result.data.name)) {
+        found.set(result.data.name, {
+          manifest: result.data,
+          body: parsed.content,
+          source: TIER_NAMES[tier],
+          filepath,
+        });
+      }
+    }
+  }
+  return Array.from(found.values()).sort((a, b) =>
+    a.manifest.name.localeCompare(b.manifest.name),
+  );
+}

--- a/apm-builder/lib/resolution.ts
+++ b/apm-builder/lib/resolution.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import type { ComponentSource, Target } from './types.ts';
 import type { PersonaManifest, ModeManifest } from './schema.ts';
 
@@ -90,4 +93,11 @@ export function resolve(opts: ResolveOptions): Resolution {
       categories: effectiveCategories ? Array.from(effectiveCategories) : [],
     },
   };
+}
+
+export async function writeResolutionArtifact(r: Resolution): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-sess-'));
+  const filepath = path.join(dir, 'resolution.json');
+  await fs.writeFile(filepath, JSON.stringify(r, null, 2) + '\n');
+  return filepath;
 }

--- a/apm-builder/lib/resolution.ts
+++ b/apm-builder/lib/resolution.ts
@@ -1,0 +1,93 @@
+import type { ComponentSource, Target } from './types.ts';
+import type { PersonaManifest, ModeManifest } from './schema.ts';
+
+export interface Resolution {
+  schemaVersion: 1;
+  harness: Target;
+  skillsDrop: string[];
+  skillsKeep: string[] | null;
+  modePrompt: string;
+  metadata: {
+    persona: string | null;
+    mode: string | null;
+    categories: string[];
+  };
+}
+
+export interface ResolveOptions {
+  catalog: ComponentSource[];
+  persona?: PersonaManifest;
+  mode?: ModeManifest;
+  /** Mode body string (the markdown body of the mode component, used as prompt scaffolding). */
+  modeBody?: string;
+  harness: Target;
+}
+
+export function resolve(opts: ResolveOptions): Resolution {
+  const { catalog, persona, mode, modeBody, harness } = opts;
+
+  // No persona, no mode → identity (no filter).
+  if (!persona && !mode) {
+    return {
+      schemaVersion: 1,
+      harness,
+      skillsDrop: [],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: null, mode: null, categories: [] },
+    };
+  }
+
+  // Effective categories: intersection if both, single if one.
+  let effectiveCategories: Set<string> | null = null;
+  if (persona && mode) {
+    const p = new Set(persona.categories);
+    effectiveCategories = new Set(mode.categories.filter((c) => p.has(c)));
+  } else if (persona) {
+    effectiveCategories = new Set(persona.categories);
+  } else if (mode) {
+    effectiveCategories = new Set(mode.categories);
+  }
+
+  const includeNames = new Set([
+    ...(persona?.skill_include ?? []),
+    ...(mode?.skill_include ?? []),
+  ]);
+  const excludeNames = new Set([
+    ...(persona?.skill_exclude ?? []),
+    ...(mode?.skill_exclude ?? []),
+  ]);
+
+  const skillsDrop: string[] = [];
+  for (const c of catalog) {
+    if (c.manifest.type !== 'skill') continue;
+    const skillCategory = (c.manifest as any).category?.primary as string | undefined;
+
+    // Forced exclude wins.
+    if (excludeNames.has(c.manifest.name)) {
+      skillsDrop.push(c.manifest.name);
+      continue;
+    }
+    // Forced include wins over category mismatch.
+    if (includeNames.has(c.manifest.name)) continue;
+    // Universal default — uncategorized skills always load.
+    if (skillCategory === undefined) continue;
+    // Category match.
+    if (effectiveCategories && effectiveCategories.has(skillCategory)) continue;
+    // Otherwise: drop.
+    skillsDrop.push(c.manifest.name);
+  }
+
+  return {
+    schemaVersion: 1,
+    harness,
+    skillsDrop,
+    skillsKeep: null,
+    modePrompt: modeBody ?? '',
+    metadata: {
+      persona: persona?.name ?? null,
+      mode: mode?.name ?? null,
+      categories: effectiveCategories ? Array.from(effectiveCategories) : [],
+    },
+  };
+}

--- a/apm-builder/lib/schema.ts
+++ b/apm-builder/lib/schema.ts
@@ -59,7 +59,7 @@ const ManifestBaseSchema = z
     version: z.string().regex(SEMVER_RE, 'version must be valid semver'),
     description: z.string().min(1),
     category: CategoryBlock.optional(),
-    type: z.enum(['skill', 'plugin', 'hook', 'agent', 'rules', 'mcp', 'mode'] as const),
+    type: z.enum(['skill', 'plugin', 'hook', 'agent', 'rules', 'mcp'] as const),
     targets: z.array(z.enum(TARGETS as unknown as [Target, ...Target[]])).min(1),
     author: z.string().optional(),
     license: LicenseField.optional(),

--- a/apm-builder/lib/schema.ts
+++ b/apm-builder/lib/schema.ts
@@ -89,9 +89,19 @@ export const PersonaSchema = ManifestBaseSchema.extend({
 
 export type PersonaManifest = z.infer<typeof PersonaSchema>;
 
+export const ModeSchema = ManifestBaseSchema.extend({
+  type: z.literal('mode'),
+  categories: z.array(z.string()).min(0),
+  skill_include: z.array(z.string()).default([]),
+  skill_exclude: z.array(z.string()).default([]),
+}).strict();
+
+export type ModeManifest = z.infer<typeof ModeSchema>;
+
 export const ManifestSchema = z.discriminatedUnion('type', [
   ManifestBaseSchema,
   PersonaSchema,
+  ModeSchema,
 ]);
 
 export type Manifest = z.infer<typeof ManifestSchema>;

--- a/apm-builder/lib/schema.ts
+++ b/apm-builder/lib/schema.ts
@@ -53,13 +53,13 @@ const LicenseAttribution = z
   .strict();
 const LicenseField = z.union([z.string(), LicenseAttribution]);
 
-export const ManifestSchema = z
+const ManifestBaseSchema = z
   .object({
     name: z.string().regex(NAME_RE, 'name must be kebab-case lowercase'),
     version: z.string().regex(SEMVER_RE, 'version must be valid semver'),
     description: z.string().min(1),
     category: CategoryBlock.optional(),
-    type: z.enum(COMPONENT_TYPES as unknown as [ComponentType, ...ComponentType[]]),
+    type: z.enum(['skill', 'plugin', 'hook', 'agent', 'rules', 'mcp', 'mode'] as const),
     targets: z.array(z.enum(TARGETS as unknown as [Target, ...Target[]])).min(1),
     author: z.string().optional(),
     license: LicenseField.optional(),
@@ -79,5 +79,19 @@ export const ManifestSchema = z
       .optional(),
   })
   .strict();
+
+export const PersonaSchema = ManifestBaseSchema.extend({
+  type: z.literal('persona'),
+  categories: z.array(z.string()).min(0),
+  skill_include: z.array(z.string()).default([]),
+  skill_exclude: z.array(z.string()).default([]),
+}).strict();
+
+export type PersonaManifest = z.infer<typeof PersonaSchema>;
+
+export const ManifestSchema = z.discriminatedUnion('type', [
+  ManifestBaseSchema,
+  PersonaSchema,
+]);
 
 export type Manifest = z.infer<typeof ManifestSchema>;

--- a/apm-builder/lib/types.ts
+++ b/apm-builder/lib/types.ts
@@ -64,6 +64,10 @@ export interface ComponentManifest {
   before?: string[];
   after?: string[];
   overrides?: Partial<Record<Target, Record<string, unknown>>>;
+  // persona / mode specific
+  categories?: string[];
+  skill_include?: string[];
+  skill_exclude?: string[];
 }
 
 export interface EmittedFile {

--- a/apm-builder/lib/types.ts
+++ b/apm-builder/lib/types.ts
@@ -1,4 +1,4 @@
-export const COMPONENT_TYPES = ['skill', 'plugin', 'hook', 'agent', 'rules', 'mcp'] as const;
+export const COMPONENT_TYPES = ['skill', 'plugin', 'hook', 'agent', 'rules', 'mcp', 'persona', 'mode'] as const;
 export type ComponentType = typeof COMPONENT_TYPES[number];
 
 export const TARGETS = ['claude-code', 'apm', 'codex', 'gemini', 'copilot', 'pi'] as const;

--- a/apm-builder/lib/validate.ts
+++ b/apm-builder/lib/validate.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ComponentSource, ComponentType, Target } from './types.ts';
 
@@ -9,12 +10,14 @@ export interface ValidationError {
 
 type Cell = 'ok' | 'warn' | 'error';
 const MATRIX: Record<ComponentType, Record<Target, Cell>> = {
-  skill:  { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'warn',  pi: 'ok' },
-  plugin: { 'claude-code': 'ok',    apm: 'ok', codex: 'error', gemini: 'error', copilot: 'error', pi: 'ok' },
-  hook:   { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'warn' },
-  agent:  { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'error', copilot: 'error', pi: 'ok' },
-  rules:  { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'ok' },
-  mcp:    { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'error', pi: 'warn' },
+  skill:   { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'warn',  pi: 'ok' },
+  plugin:  { 'claude-code': 'ok',    apm: 'ok', codex: 'error', gemini: 'error', copilot: 'error', pi: 'ok' },
+  hook:    { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'warn' },
+  agent:   { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'error', copilot: 'error', pi: 'ok' },
+  rules:   { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'ok' },
+  mcp:     { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'error', pi: 'warn' },
+  persona: { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'ok' },
+  mode:    { 'claude-code': 'ok',    apm: 'ok', codex: 'ok',    gemini: 'ok',    copilot: 'ok',    pi: 'ok' },
 };
 
 function validTypesForTarget(target: Target): ComponentType[] {
@@ -141,6 +144,104 @@ export function validateComponents(components: ComponentSource[]): ValidationErr
         componentName: c.manifest.name,
         message: 'skill is missing a category — add `category: { primary: <category> }` to frontmatter',
       });
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Async validation layer: TAXONOMY cross-ref + mode body-size limits
+// ---------------------------------------------------------------------------
+
+async function loadValidCategories(repoRoot: string): Promise<Set<string>> {
+  const taxonomyPath = path.join(repoRoot, 'TAXONOMY.md');
+  const text = await fs.readFile(taxonomyPath, 'utf8');
+  // Categories appear as ### headings: "### 1. Economy", "### 2. Workflow", ...
+  const matches = text.matchAll(/^### \d+\.\s+(\w[\w-]*)/gm);
+  return new Set(Array.from(matches, (m) => m[1].toLowerCase()));
+}
+
+/**
+ * Async extension of validateComponents.
+ * Runs the synchronous checks first, then adds:
+ *   1. persona/mode categories cross-ref against TAXONOMY.md
+ *   2. persona/mode skill_include/skill_exclude cross-ref against known skills
+ *   3. mode body size limit (error >4096 bytes, warning >1024 bytes)
+ *
+ * @param components  Discovered component sources.
+ * @param repoRoot    Absolute path to the repository root (where TAXONOMY.md lives).
+ *                    Defaults to cwd so tests can omit it when they don't need taxonomy checks.
+ */
+export async function validateAll(
+  components: ComponentSource[],
+  repoRoot: string = process.cwd(),
+): Promise<ValidationError[]> {
+  const errors = validateComponents(components);
+
+  const allSkillNames = new Set(
+    components
+      .filter((c) => c.manifest.type === 'skill')
+      .map((c) => c.manifest.name),
+  );
+
+  let validCats: Set<string> | null = null;
+  async function getValidCats(): Promise<Set<string>> {
+    if (!validCats) validCats = await loadValidCategories(repoRoot);
+    return validCats;
+  }
+
+  for (const component of components) {
+    const { manifest } = component;
+    if (manifest.type !== 'persona' && manifest.type !== 'mode') continue;
+
+    const cats: Set<string> = await getValidCats();
+
+    for (const cat of manifest.categories ?? []) {
+      if (!cats.has(cat.toLowerCase())) {
+        errors.push({
+          severity: 'error',
+          componentName: manifest.name,
+          message: `category "${cat}" not in TAXONOMY.md (valid: ${Array.from(cats).join(', ')})`,
+        });
+      }
+    }
+
+    for (const inc of manifest.skill_include ?? []) {
+      if (!allSkillNames.has(inc)) {
+        errors.push({
+          severity: 'error',
+          componentName: manifest.name,
+          message: `skill_include references unknown skill: ${inc}`,
+        });
+      }
+    }
+
+    for (const exc of manifest.skill_exclude ?? []) {
+      if (!allSkillNames.has(exc)) {
+        errors.push({
+          severity: 'error',
+          componentName: manifest.name,
+          message: `skill_exclude references unknown skill: ${exc}`,
+        });
+      }
+    }
+
+    if (manifest.type === 'mode') {
+      const len = Buffer.byteLength(component.body, 'utf8');
+      if (len > 4096) {
+        errors.push({
+          severity: 'error',
+          componentName: manifest.name,
+          message: `mode body too long: ${len} bytes (max 4096)`,
+        });
+      } else if (len > 1024) {
+        errors.push({
+          severity: 'warning',
+          componentName: manifest.name,
+          message: `mode body is ${len} bytes (>1024 warns; long prompts cost real tokens every session)`,
+        });
+      }
     }
   }
 

--- a/apm-builder/lib/validate.ts
+++ b/apm-builder/lib/validate.ts
@@ -159,7 +159,7 @@ async function loadValidCategories(repoRoot: string): Promise<Set<string>> {
   const text = await fs.readFile(taxonomyPath, 'utf8');
   // Categories appear as ### headings: "### 1. Economy", "### 2. Workflow", ...
   const matches = text.matchAll(/^### \d+\.\s+(\w[\w-]*)/gm);
-  return new Set(Array.from(matches, (m) => m[1].toLowerCase()));
+  return new Set(Array.from(matches, (m) => m[1]!.toLowerCase()));
 }
 
 /**

--- a/apm-builder/tests/ac-cli.test.ts
+++ b/apm-builder/tests/ac-cli.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { parseAcArgs } from '../lib/ac/run.ts';
+
+describe('parseAcArgs', () => {
+  it('splits ac flags from harness flags at --', () => {
+    const r = parseAcArgs(['claude', '--persona', 'backend', '--', '--resume', 'sess']);
+    expect(r.harness).toBe('claude');
+    expect(r.persona).toBe('backend');
+    expect(r.harnessArgs).toEqual(['--resume', 'sess']);
+  });
+
+  it('treats trailing args as harness args when no -- present', () => {
+    const r = parseAcArgs(['claude', '--persona', 'backend']);
+    expect(r.harnessArgs).toEqual([]);
+  });
+
+  it('handles --no-filter flag', () => {
+    const r = parseAcArgs(['claude', '--no-filter']);
+    expect(r.noFilter).toBe(true);
+  });
+
+  it('throws on missing harness name', () => {
+    expect(() => parseAcArgs(['--persona', 'backend'])).toThrow(/harness/i);
+  });
+
+  it('throws on --persona without value', () => {
+    expect(() => parseAcArgs(['claude', '--persona'])).toThrow(/--persona/);
+  });
+});

--- a/apm-builder/tests/ac-introspect.test.ts
+++ b/apm-builder/tests/ac-introspect.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { listCommand } from '../lib/ac/introspect.ts';
+
+describe('ac list', () => {
+  it('lists all personas', async () => {
+    const builtinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-builtin-'));
+    await fs.mkdir(path.join(builtinDir, 'personas', 'one'), { recursive: true });
+    await fs.writeFile(
+      path.join(builtinDir, 'personas', 'one', 'persona.md'),
+      `---
+name: one
+version: 1.0.0
+type: persona
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    const out: string[] = [];
+    await listCommand('personas', {
+      projectDir: '/nonexistent',
+      userDir: '/nonexistent',
+      builtinDir,
+      print: (line) => out.push(line),
+    });
+    expect(out.some((l) => l.includes('one'))).toBe(true);
+    expect(out.some((l) => l.includes('builtin'))).toBe(true);
+  });
+});

--- a/apm-builder/tests/ac-introspect.test.ts
+++ b/apm-builder/tests/ac-introspect.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { listCommand } from '../lib/ac/introspect.ts';
+import { listCommand, showCommand, doctorCommand } from '../lib/ac/introspect.ts';
 
 describe('ac list', () => {
   it('lists all personas', async () => {
@@ -29,5 +29,58 @@ categories: [tooling]
     });
     expect(out.some((l) => l.includes('one'))).toBe(true);
     expect(out.some((l) => l.includes('builtin'))).toBe(true);
+  });
+});
+
+describe('ac show', () => {
+  it('prints persona details', async () => {
+    const builtinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-show-'));
+    await fs.mkdir(path.join(builtinDir, 'personas', 'one'), { recursive: true });
+    await fs.writeFile(
+      path.join(builtinDir, 'personas', 'one', 'persona.md'),
+      `---
+name: one
+version: 1.0.0
+type: persona
+description: backend
+targets: [claude-code]
+categories: [tooling, workflow]
+skill_include: [debugging]
+skill_exclude: [frontend-design]
+---
+
+readme body
+`,
+    );
+    const out: string[] = [];
+    await showCommand({ kind: 'persona', name: 'one' }, {
+      projectDir: '/nonexistent',
+      userDir: '/nonexistent',
+      builtinDir,
+      print: (l) => out.push(l),
+    });
+    const text = out.join('\n');
+    expect(text).toMatch(/categories:.*tooling.*workflow/);
+    expect(text).toMatch(/skill_include:.*debugging/);
+  });
+});
+
+describe('ac doctor', () => {
+  it('reports missing per-harness filter hooks', async () => {
+    const harnessRoots = {
+      'claude-code': '/nonexistent/claude',
+      apm: '/nonexistent/apm',
+      gemini: '/nonexistent/gemini',
+      pi: '/nonexistent/pi',
+    };
+    const out: string[] = [];
+    const code = await doctorCommand({
+      harnessConfigRoots: harnessRoots,
+      print: (l) => out.push(l),
+    });
+    expect(code).not.toBe(0);
+    const text = out.join('\n');
+    expect(text).toMatch(/claude-code/);
+    expect(text).toMatch(/missing|not.*installed/i);
   });
 });

--- a/apm-builder/tests/ac-prelaunch.test.ts
+++ b/apm-builder/tests/ac-prelaunch.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { prelaunchComposeCodex } from '../lib/ac/prelaunch.ts';
+import { prelaunchComposeCodex, prelaunchComposeCopilot } from '../lib/ac/prelaunch.ts';
 
 describe('prelaunchComposeCodex', () => {
   it('writes AGENTS.md to a tempdir and returns it as new cwd', async () => {
@@ -24,6 +24,29 @@ describe('prelaunchComposeCodex', () => {
     expect(result.tempdir).toMatch(/ac-prelaunch-/);
     const agentsMd = path.join(result.tempdir, 'AGENTS.md');
     const stat = await fs.stat(agentsMd);
+    expect(stat.isFile()).toBe(true);
+  });
+});
+
+describe('prelaunchComposeCopilot', () => {
+  it('writes copilot-instructions.md to tempdir', async () => {
+    const resPath = path.join(os.tmpdir(), `ac-test-cop-${Date.now()}.json`);
+    await fs.writeFile(resPath, JSON.stringify({
+      schemaVersion: 1,
+      harness: 'copilot',
+      skillsDrop: [],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: null, mode: null, categories: [] },
+    }));
+
+    const result = await prelaunchComposeCopilot({
+      resolutionPath: resPath,
+      originalCwd: process.cwd(),
+    });
+
+    const ci = path.join(result.tempdir, 'copilot-instructions.md');
+    const stat = await fs.stat(ci);
     expect(stat.isFile()).toBe(true);
   });
 });

--- a/apm-builder/tests/ac-prelaunch.test.ts
+++ b/apm-builder/tests/ac-prelaunch.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { prelaunchComposeCodex } from '../lib/ac/prelaunch.ts';
+
+describe('prelaunchComposeCodex', () => {
+  it('writes AGENTS.md to a tempdir and returns it as new cwd', async () => {
+    const resPath = path.join(os.tmpdir(), `ac-test-res-${Date.now()}.json`);
+    await fs.writeFile(resPath, JSON.stringify({
+      schemaVersion: 1,
+      harness: 'codex',
+      skillsDrop: [],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: null, mode: null, categories: [] },
+    }));
+
+    const result = await prelaunchComposeCodex({
+      resolutionPath: resPath,
+      originalCwd: process.cwd(),
+    });
+
+    expect(result.tempdir).toMatch(/ac-prelaunch-/);
+    const agentsMd = path.join(result.tempdir, 'AGENTS.md');
+    const stat = await fs.stat(agentsMd);
+    expect(stat.isFile()).toBe(true);
+  });
+});

--- a/apm-builder/tests/adapter-persona-noop.test.ts
+++ b/apm-builder/tests/adapter-persona-noop.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { claudeCodeAdapter } from '../adapters/claude-code.ts';
+import { apmAdapter } from '../adapters/apm.ts';
+import { codexAdapter } from '../adapters/codex.ts';
+import { copilotAdapter } from '../adapters/copilot.ts';
+import { geminiAdapter } from '../adapters/gemini.ts';
+import { piAdapter } from '../adapters/pi.ts';
+import type { ComponentSource, AdapterContext } from '../lib/types.ts';
+
+const adapters = [
+  ['claude-code', claudeCodeAdapter],
+  ['apm', apmAdapter],
+  ['codex', codexAdapter],
+  ['copilot', copilotAdapter],
+  ['gemini', geminiAdapter],
+  ['pi', piAdapter],
+] as const;
+
+const ctx: AdapterContext = { allComponents: [], config: {} };
+
+function fixture(type: 'persona' | 'mode'): ComponentSource {
+  return {
+    relativeDir: `${type}s/test`,
+    dir: `/tmp/${type}s/test`,
+    body: '',
+    manifest: {
+      name: 'test',
+      version: '1.0.0',
+      type,
+      description: '',
+      targets: ['claude-code', 'apm', 'codex', 'copilot', 'gemini', 'pi'],
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any,
+  };
+}
+
+describe('adapters: persona/mode are no-ops', () => {
+  for (const [name, adapter] of adapters) {
+    it(`${name}: persona returns []`, async () => {
+      const out = await adapter.emit(fixture('persona'), ctx);
+      expect(out).toEqual([]);
+    });
+    it(`${name}: mode returns []`, async () => {
+      const out = await adapter.emit(fixture('mode'), ctx);
+      expect(out).toEqual([]);
+    });
+  }
+});

--- a/apm-builder/tests/adapter-persona-noop.test.ts
+++ b/apm-builder/tests/adapter-persona-noop.test.ts
@@ -16,7 +16,7 @@ const adapters = [
   ['pi', piAdapter],
 ] as const;
 
-const ctx: AdapterContext = { allComponents: [], config: {} };
+const ctx: AdapterContext = { allComponents: [], config: {}, repoRoot: '/tmp' };
 
 function fixture(type: 'persona' | 'mode'): ComponentSource {
   return {

--- a/apm-builder/tests/cli.test.ts
+++ b/apm-builder/tests/cli.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+
+describe('apm-builder docs --target --resolution', () => {
+  it('regenerates AGENTS.md filtered per resolution artifact (codex target)', async () => {
+    // Set up minimal repo with two skills, both targeting codex.
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'docs-cmd-'));
+    await fs.mkdir(path.join(repo, 'skills', 'a'), { recursive: true });
+    await fs.mkdir(path.join(repo, 'skills', 'b'), { recursive: true });
+    await fs.writeFile(
+      path.join(repo, 'skills', 'a', 'SKILL.md'),
+      `---
+name: a
+version: 1.0.0
+type: skill
+description: A
+targets: [codex]
+category:
+  primary: tooling
+---
+A body
+`,
+    );
+    await fs.writeFile(
+      path.join(repo, 'skills', 'b', 'SKILL.md'),
+      `---
+name: b
+version: 1.0.0
+type: skill
+description: B
+targets: [codex]
+category:
+  primary: workflow
+---
+B body
+`,
+    );
+
+    // Write resolution artifact dropping 'b'.
+    const resPath = path.join(repo, 'res.json');
+    await fs.writeFile(resPath, JSON.stringify({
+      schemaVersion: 1,
+      harness: 'codex',
+      skillsDrop: ['b'],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: 'p', mode: null, categories: ['tooling'] },
+    }));
+
+    const outPath = path.join(repo, 'AGENTS.md');
+
+    // Run the command using tsx from project root, passing --repo to scope discovery.
+    execSync(
+      `node_modules/.bin/tsx apm-builder/cli.ts docs --target codex --resolution ${resPath} --repo ${repo} --out ${outPath}`,
+      { cwd: process.cwd() },
+    );
+
+    const out = await fs.readFile(outPath, 'utf8');
+    expect(out).toMatch(/A body/);
+    expect(out).not.toMatch(/B body/);
+  }, 30_000);
+});

--- a/apm-builder/tests/discover.test.ts
+++ b/apm-builder/tests/discover.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { discoverComponents } from '../lib/discover.ts';
 
@@ -32,5 +34,47 @@ describe('discoverComponents', () => {
   it('surfaces the offending file path when frontmatter is invalid', async () => {
     const BAD_ROOT = path.resolve(fileURLToPath(import.meta.url), '../fixtures/discover-invalid');
     await expect(discoverComponents(BAD_ROOT)).rejects.toThrow(/skills\/bad\/SKILL\.md/);
+  });
+
+  it('finds personas under personas/', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'discover-'));
+    await fs.mkdir(path.join(tmp, 'personas', 'test-persona'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmp, 'personas', 'test-persona', 'persona.md'),
+      `---
+name: test-persona
+version: 1.0.0
+type: persona
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+
+body
+`,
+    );
+    const result = await discoverComponents(tmp);
+    expect(result.find((c) => c.manifest.type === 'persona' && c.manifest.name === 'test-persona')).toBeDefined();
+  });
+
+  it('finds modes under modes/', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'discover-'));
+    await fs.mkdir(path.join(tmp, 'modes', 'test-mode'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmp, 'modes', 'test-mode', 'mode.md'),
+      `---
+name: test-mode
+version: 1.0.0
+type: mode
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+
+You are in test mode.
+`,
+    );
+    const result = await discoverComponents(tmp);
+    expect(result.find((c) => c.manifest.type === 'mode' && c.manifest.name === 'test-mode')).toBeDefined();
   });
 });

--- a/apm-builder/tests/fixtures/fake-harness.sh
+++ b/apm-builder/tests/fixtures/fake-harness.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Fake harness — prints argv and selected env to stdout as JSON.
+node -e '
+const argv = process.argv.slice(1);
+const env = {};
+for (const k of Object.keys(process.env)) {
+  if (k.startsWith("AC_")) env[k] = process.env[k];
+}
+process.stdout.write(JSON.stringify({ argv, env }));
+' -- "$@"

--- a/apm-builder/tests/integration/ac-fake-harness.test.ts
+++ b/apm-builder/tests/integration/ac-fake-harness.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runAc } from '../../lib/ac/run.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FAKE = path.resolve(__dirname, '..', 'fixtures', 'fake-harness.sh');
+
+describe('ac integration with stub harness', () => {
+  it('exec passes through harness args and sets AC_WRAPPED', async () => {
+    const captured: { bin: string; args: string[]; env: NodeJS.ProcessEnv } = {
+      bin: '',
+      args: [],
+      env: {},
+    };
+    await runAc(['claude', '--', 'foo', 'bar'], {
+      resolveHarnessBin: () => FAKE,
+      exec: async (bin, args, env) => {
+        captured.bin = bin;
+        captured.args = args;
+        captured.env = env;
+        return 0;
+      },
+    });
+    expect(captured.bin).toBe(FAKE);
+    expect(captured.args).toEqual(['foo', 'bar']);
+    expect(captured.env.AC_WRAPPED).toBe('1');
+    expect(captured.env.AC_HARNESS).toBe('claude-code');
+    expect(captured.env.AC_RESOLUTION_PATH).toBeUndefined(); // no persona/mode
+  });
+
+  it('with --persona, sets AC_RESOLUTION_PATH to a readable JSON file', async () => {
+    const captured: { env: NodeJS.ProcessEnv } = { env: {} };
+    // Provide a built-in dir with a fake persona & catalog.
+    const tmp = path.join('/tmp', `ac-builtin-${Date.now()}`);
+    const fs = await import('node:fs/promises');
+    await fs.mkdir(path.join(tmp, 'personas', 'tester'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmp, 'personas', 'tester', 'persona.md'),
+      `---
+name: tester
+version: 1.0.0
+type: persona
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    await runAc(['claude', '--persona', 'tester'], {
+      builtinDir: tmp,
+      projectDir: '/nonexistent',
+      userDir: '/nonexistent',
+      resolveHarnessBin: () => FAKE,
+      exec: async (_bin, _args, env) => {
+        captured.env = env;
+        return 0;
+      },
+      loadCatalog: async () => [],
+    });
+    expect(captured.env.AC_RESOLUTION_PATH).toBeDefined();
+    const content = await fs.readFile(captured.env.AC_RESOLUTION_PATH!, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed.metadata.persona).toBe('tester');
+  });
+});

--- a/apm-builder/tests/mode.test.ts
+++ b/apm-builder/tests/mode.test.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { ModeSchema } from '../lib/schema.ts';
+import { findMode } from '../lib/mode.ts';
 
 describe('ModeSchema', () => {
   it('accepts a minimal valid mode', () => {
@@ -37,5 +41,32 @@ describe('ModeSchema', () => {
       categories: ['tooling'],
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('findMode', () => {
+  it('finds a mode in user-scope dir and parses the body', async () => {
+    const userDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-user-'));
+    await fs.mkdir(path.join(userDir, 'modes'));
+    await fs.writeFile(
+      path.join(userDir, 'modes', 'focused.md'),
+      `---
+name: focused
+version: 1.0.0
+type: mode
+description: focus
+targets: [claude-code]
+categories: [tooling]
+---
+
+You are in focused mode.
+`,
+    );
+    const result = await findMode('focused', {
+      projectDir: '/nonexistent',
+      userDir,
+      builtinDir: '/nonexistent',
+    });
+    expect(result.body.trim()).toBe('You are in focused mode.');
   });
 });

--- a/apm-builder/tests/mode.test.ts
+++ b/apm-builder/tests/mode.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { ModeSchema } from '../lib/schema.ts';
+
+describe('ModeSchema', () => {
+  it('accepts a minimal valid mode', () => {
+    const result = ModeSchema.safeParse({
+      name: 'focused',
+      version: '1.0.0',
+      type: 'mode',
+      description: 'Single-task focus',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults skill_include and skill_exclude to empty arrays', () => {
+    const result = ModeSchema.parse({
+      name: 'focused',
+      version: '1.0.0',
+      type: 'mode',
+      description: 'x',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.skill_include).toEqual([]);
+    expect(result.skill_exclude).toEqual([]);
+  });
+
+  it('rejects type other than "mode"', () => {
+    const result = ModeSchema.safeParse({
+      name: 'focused',
+      version: '1.0.0',
+      type: 'persona',
+      description: 'x',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apm-builder/tests/persona.test.ts
+++ b/apm-builder/tests/persona.test.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { PersonaSchema } from '../lib/schema.ts';
+import { findPersona } from '../lib/persona.ts';
 
 describe('PersonaSchema', () => {
   it('accepts a minimal valid persona', () => {
@@ -48,5 +52,89 @@ describe('PersonaSchema', () => {
       categories: ['tooling'],
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('findPersona (3-tier discovery)', () => {
+  it('finds a persona in user-scope dir', async () => {
+    const userDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-user-'));
+    await fs.mkdir(path.join(userDir, 'personas'));
+    await fs.writeFile(
+      path.join(userDir, 'personas', 'mine.md'),
+      `---
+name: mine
+version: 1.0.0
+type: persona
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    const result = await findPersona('mine', {
+      projectDir: '/nonexistent',
+      userDir,
+      builtinDir: '/nonexistent',
+    });
+    expect(result.manifest.name).toBe('mine');
+    expect(result.source).toBe('user');
+  });
+
+  it('project-scope wins over user-scope', async () => {
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-proj-'));
+    const userDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-user-'));
+    await fs.mkdir(path.join(projectDir, '.agent-config', 'personas'), { recursive: true });
+    await fs.mkdir(path.join(userDir, 'personas'));
+    await fs.writeFile(
+      path.join(projectDir, '.agent-config', 'personas', 'mine.md'),
+      `---
+name: mine
+version: 1.0.0
+type: persona
+description: project
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    await fs.writeFile(
+      path.join(userDir, 'personas', 'mine.md'),
+      `---
+name: mine
+version: 1.0.0
+type: persona
+description: user
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    const result = await findPersona('mine', {
+      projectDir,
+      userDir,
+      builtinDir: '/nonexistent',
+    });
+    expect(result.manifest.description).toBe('project');
+    expect(result.source).toBe('project');
+  });
+
+  it('throws with a list of available names when not found', async () => {
+    const userDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-user-'));
+    await fs.mkdir(path.join(userDir, 'personas'));
+    await fs.writeFile(
+      path.join(userDir, 'personas', 'one.md'),
+      `---
+name: one
+version: 1.0.0
+type: persona
+description: t
+targets: [claude-code]
+categories: [tooling]
+---
+`,
+    );
+    await expect(
+      findPersona('nope', { projectDir: '/nonexistent', userDir, builtinDir: '/nonexistent' }),
+    ).rejects.toThrow(/one/);
   });
 });

--- a/apm-builder/tests/persona.test.ts
+++ b/apm-builder/tests/persona.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { PersonaSchema } from '../lib/schema.ts';
+
+describe('PersonaSchema', () => {
+  it('accepts a minimal valid persona', () => {
+    const result = PersonaSchema.safeParse({
+      name: 'backend',
+      version: '1.0.0',
+      type: 'persona',
+      description: 'Backend dev work',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults skill_include and skill_exclude to empty arrays', () => {
+    const result = PersonaSchema.parse({
+      name: 'backend',
+      version: '1.0.0',
+      type: 'persona',
+      description: 'Backend dev work',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.skill_include).toEqual([]);
+    expect(result.skill_exclude).toEqual([]);
+  });
+
+  it('rejects missing categories field', () => {
+    const result = PersonaSchema.safeParse({
+      name: 'backend',
+      version: '1.0.0',
+      type: 'persona',
+      description: 'Backend dev work',
+      targets: ['claude-code'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects type other than "persona"', () => {
+    const result = PersonaSchema.safeParse({
+      name: 'backend',
+      version: '1.0.0',
+      type: 'skill',
+      description: 'x',
+      targets: ['claude-code'],
+      categories: ['tooling'],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apm-builder/tests/resolution.test.ts
+++ b/apm-builder/tests/resolution.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { resolve } from '../lib/resolution.ts';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { resolve, writeResolutionArtifact } from '../lib/resolution.ts';
 import type { ComponentSource } from '../lib/types.ts';
 
 const skill = (name: string, category: string | undefined): ComponentSource => ({
@@ -130,5 +133,38 @@ describe('resolve', () => {
     const r = resolve({ catalog, persona, harness: 'claude-code' });
     expect(r.metadata.persona).toBe('p');
     expect(r.metadata.categories).toContain('tooling');
+  });
+});
+
+describe('writeResolutionArtifact', () => {
+  it('writes JSON to a tempfile and returns the path', async () => {
+    const r: any = {
+      schemaVersion: 1,
+      harness: 'claude-code',
+      skillsDrop: ['a'],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: null, mode: null, categories: [] },
+    };
+    const filepath = await writeResolutionArtifact(r);
+    expect(filepath).toMatch(/resolution\.json$/);
+    const content = await fs.readFile(filepath, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed.harness).toBe('claude-code');
+    expect(parsed.skillsDrop).toEqual(['a']);
+  });
+
+  it('uses a session-scoped tempdir under os.tmpdir', async () => {
+    const r: any = {
+      schemaVersion: 1,
+      harness: 'claude-code',
+      skillsDrop: [],
+      skillsKeep: null,
+      modePrompt: '',
+      metadata: { persona: null, mode: null, categories: [] },
+    };
+    const filepath = await writeResolutionArtifact(r);
+    expect(filepath.startsWith(os.tmpdir())).toBe(true);
+    expect(path.basename(path.dirname(filepath))).toMatch(/^ac-sess-/);
   });
 });

--- a/apm-builder/tests/resolution.test.ts
+++ b/apm-builder/tests/resolution.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from '../lib/resolution.ts';
+import type { ComponentSource } from '../lib/types.ts';
+
+const skill = (name: string, category: string | undefined): ComponentSource => ({
+  relativeDir: `skills/${name}`,
+  dir: `/tmp/skills/${name}`,
+  body: '',
+  manifest: {
+    name,
+    version: '1.0.0',
+    type: 'skill',
+    description: '',
+    targets: ['claude-code'],
+    ...(category ? { category: { primary: category } } : {}),
+  } as any,
+});
+
+describe('resolve', () => {
+  it('returns full catalog when no persona or mode is given', () => {
+    const catalog = [skill('a', 'tooling'), skill('b', 'workflow')];
+    const r = resolve({ catalog, harness: 'claude-code' });
+    expect(r.skillsKeep).toBeNull();
+    expect(r.skillsDrop).toEqual([]);
+    expect(r.modePrompt).toBe('');
+  });
+
+  it('drops skills outside persona categories', () => {
+    const catalog = [skill('a', 'tooling'), skill('b', 'workflow')];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({ catalog, persona, harness: 'claude-code' });
+    expect(r.skillsDrop).toContain('b');
+    expect(r.skillsDrop).not.toContain('a');
+  });
+
+  it('keeps uncategorized skills (universal default)', () => {
+    const catalog = [skill('a', 'tooling'), skill('b', undefined)];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({ catalog, persona, harness: 'claude-code' });
+    expect(r.skillsDrop).not.toContain('b');
+  });
+
+  it('skill_include forces inclusion across categories', () => {
+    const catalog = [skill('a', 'tooling'), skill('b', 'workflow')];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling'],
+      skill_include: ['b'],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({ catalog, persona, harness: 'claude-code' });
+    expect(r.skillsDrop).not.toContain('b');
+  });
+
+  it('skill_exclude wins over category match', () => {
+    const catalog = [skill('a', 'tooling')];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: ['a'],
+    } as any;
+    const r = resolve({ catalog, persona, harness: 'claude-code' });
+    expect(r.skillsDrop).toContain('a');
+  });
+
+  it('persona ∩ mode categories', () => {
+    const catalog = [skill('a', 'tooling'), skill('b', 'workflow'), skill('c', 'philosophy')];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling', 'workflow'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const mode = {
+      name: 'm',
+      type: 'mode',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({ catalog, persona, mode, harness: 'claude-code' });
+    expect(r.skillsDrop).toContain('b'); // in persona but not in mode
+    expect(r.skillsDrop).toContain('c'); // in neither
+    expect(r.skillsDrop).not.toContain('a'); // in both
+  });
+
+  it('mode body becomes mode_prompt', () => {
+    const catalog = [skill('a', 'tooling')];
+    const mode = {
+      name: 'm',
+      type: 'mode',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({
+      catalog,
+      mode,
+      modeBody: 'You are in focused mode.\n',
+      harness: 'claude-code',
+    });
+    expect(r.modePrompt).toBe('You are in focused mode.\n');
+  });
+
+  it('emits resolved metadata', () => {
+    const catalog = [skill('a', 'tooling')];
+    const persona = {
+      name: 'p',
+      type: 'persona',
+      categories: ['tooling'],
+      skill_include: [],
+      skill_exclude: [],
+    } as any;
+    const r = resolve({ catalog, persona, harness: 'claude-code' });
+    expect(r.metadata.persona).toBe('p');
+    expect(r.metadata.categories).toContain('tooling');
+  });
+});

--- a/apm-builder/tests/types.test.ts
+++ b/apm-builder/tests/types.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { COMPONENT_TYPES } from '../lib/types';
+
+describe('COMPONENT_TYPES', () => {
+  it('includes persona', () => {
+    expect(COMPONENT_TYPES).toContain('persona');
+  });
+  it('includes mode', () => {
+    expect(COMPONENT_TYPES).toContain('mode');
+  });
+});

--- a/apm-builder/tests/validate.test.ts
+++ b/apm-builder/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateComponents } from '../lib/validate.ts';
+import { validateComponents, validateAll } from '../lib/validate.ts';
 import type { ComponentSource } from '../lib/types.ts';
 
 function mk(overrides: Partial<ComponentSource['manifest']>): ComponentSource {
@@ -136,5 +136,85 @@ describe('validateComponents — Gemini-specific rejections', () => {
       mk({ name: 'pl', type: 'plugin', targets: ['gemini'], includes: [] }),
     ]);
     expect(errors.some((e) => e.severity === 'error' && /plugin.*gemini/i.test(e.message))).toBe(true);
+  });
+});
+
+describe('persona/mode validation', () => {
+  // repoRoot points at the actual TAXONOMY.md in the worktree
+  const REPO_ROOT = new URL('../..', import.meta.url).pathname;
+
+  it('rejects persona with category not in TAXONOMY', async () => {
+    const errors = await validateAll(
+      [
+        {
+          relativeDir: 'personas/bad',
+          manifest: {
+            name: 'bad',
+            version: '1.0.0',
+            type: 'persona',
+            description: 'bad',
+            targets: ['claude-code'],
+            categories: ['notARealCategory'],
+            skill_include: [],
+            skill_exclude: [],
+          },
+          body: '',
+          dir: '/tmp/bad',
+        } as any,
+      ],
+      REPO_ROOT,
+    );
+    expect(errors.some((e) => e.message.includes('notARealCategory'))).toBe(true);
+  });
+
+  it('rejects persona referencing nonexistent skill in skill_include', async () => {
+    const errors = await validateAll(
+      [
+        {
+          relativeDir: 'personas/bad',
+          manifest: {
+            name: 'bad',
+            version: '1.0.0',
+            type: 'persona',
+            description: 'bad',
+            targets: ['claude-code'],
+            categories: ['tooling'],
+            skill_include: ['definitelyNotARealSkill'],
+            skill_exclude: [],
+          },
+          body: '',
+          dir: '/tmp/bad',
+        } as any,
+      ],
+      REPO_ROOT,
+    );
+    expect(errors.some((e) => e.message.includes('definitelyNotARealSkill'))).toBe(true);
+  });
+
+  it('rejects mode body > 4096 bytes', async () => {
+    const longBody = 'x'.repeat(4097);
+    const errors = await validateAll(
+      [
+        {
+          relativeDir: 'modes/long',
+          manifest: {
+            name: 'long',
+            version: '1.0.0',
+            type: 'mode',
+            description: 't',
+            targets: ['claude-code'],
+            categories: ['tooling'],
+            skill_include: [],
+            skill_exclude: [],
+          },
+          body: longBody,
+          dir: '/tmp/long',
+        } as any,
+      ],
+      REPO_ROOT,
+    );
+    expect(
+      errors.some((e) => e.message.toLowerCase().includes('too long') || e.message.includes('4096')),
+    ).toBe(true);
   });
 });

--- a/docs/USING-AC.md
+++ b/docs/USING-AC.md
@@ -1,0 +1,166 @@
+# Using `ac` — Persona + Mode wrapper
+
+`ac` is an opt-in wrapper that filters which skills your harness loads,
+based on a named **persona** (long-lived role) and **mode** (ephemeral
+intent). Today's behavior is preserved — invoke harnesses without `ac`
+and nothing changes.
+
+## What's shipped today (Plan 9)
+
+`ac` ships **Path B (additionalContext-only)** for all 4 runtime-hook
+harnesses (Claude Code, APM, Gemini, Pi). Skill descriptions still load
+into the system prompt, but the model is instructed via injected context
+to ignore out-of-scope skills. This delivers **false-activation prevention**
+but does **not** reduce token cost.
+
+For Codex and Copilot, `ac` does **pre-launch compose** — writes a filtered
+`AGENTS.md` / `copilot-instructions.md` to a per-session tempdir before
+exec'ing the harness. This DOES achieve token reduction for those two.
+
+A future Plan 9b will extend pre-launch compose (or equivalent skill
+catalog mutation) to the other 4 harnesses for full token reduction.
+
+## Quick start
+
+```bash
+# Install (one-time)
+npm install -g @agent-config/apm-builder
+
+# List available personas / modes
+ac list personas
+ac list modes
+
+# Use a persona for a session
+ac claude --persona backend
+ac claude --persona frontend
+
+# Combine with a mode
+ac claude --persona backend --mode focused
+
+# Pass through harness args after --
+ac claude --persona backend -- --resume sess-123
+
+# Bypass filtering for one invocation
+ac claude --no-filter
+
+# Verify the filter glue is installed for each harness
+ac doctor
+
+# Inspect a persona or mode before launching
+ac show persona backend
+ac show mode focused
+```
+
+## Authoring your own personas / modes
+
+User-scope:
+
+```bash
+mkdir -p ~/.config/agent-config/personas
+cat > ~/.config/agent-config/personas/oncall.md <<'EOF'
+---
+name: oncall
+version: 1.0.0
+type: persona
+description: On-call rotation — observability + incident response
+targets: [claude-code, apm]
+categories: [tooling, integrations]
+skill_include: [debugging, signoz-dashboard-builder]
+skill_exclude: []
+---
+
+# On-call Persona
+EOF
+```
+
+Project-scope (for monorepo per-subproject personas):
+
+```bash
+mkdir -p .agent-config/personas
+cat > .agent-config/personas/this-repo-backend.md <<'EOF'
+---
+name: this-repo-backend
+version: 1.0.0
+type: persona
+description: This repo's backend slice
+targets: [claude-code]
+categories: [tooling, workflow]
+skill_include: []
+skill_exclude: []
+---
+EOF
+```
+
+Project-scope wins over user-scope wins over built-in.
+
+Modes follow the same shape under `modes/<name>/mode.md`. The body of a mode is injected as additional context when active.
+
+## Built-in personas (shipped with agent-config)
+
+| Persona | Use when |
+|---------|----------|
+| backend | Go / server-side / observability work |
+| frontend | Datastar / UI / client-side work |
+| personal | Journaling, knowledge-base, non-code |
+| taxes | Tax prep / document handling |
+| aviation | Flight planning, ops references |
+
+## Built-in modes
+
+| Mode | Effect |
+|------|--------|
+| code | TDD discipline, philosophy + tooling skills emphasized |
+| design | Design systems + interaction patterns |
+| ops | Infra / observability emphasis |
+| focused | Single-task focus, no scope creep |
+
+## Troubleshooting
+
+- `ac claude` runs but skills aren't filtered → run `ac doctor`. Likely
+  the per-harness filter hook isn't installed in `~/.claude/hooks/`.
+  Reinstall with `apm-builder install --target claude-code`.
+
+- "persona not found" → `ac list personas` to see what's discoverable.
+
+- Wrong skills appearing/disappearing → inspect with `ac show persona <name>`
+  to see the resolved categories and include/exclude lists.
+
+- Codex / Copilot have no runtime hook — `ac` writes a filtered AGENTS.md
+  / copilot-instructions.md to a tempdir per session. Your project files
+  (`.git`, `package.json`, `tsconfig.json`, `.env`) are symlinked. If your
+  tooling expects specific files in the cwd, add them to
+  `apm-builder/lib/ac/prelaunch.ts`'s `toLink` list.
+
+## Architecture
+
+```
+USER CONFIG  (~/.claude/, ~/.codex/, etc.)  ← user owns
+       ▲
+       │ additive layer
+AC WRAPPER  (ac <harness> [--persona X] [--mode Y] -- ...)
+       │   1. Resolve persona+mode → JSON resolution artifact
+       │   2. Export AC_WRAPPED + AC_HARNESS + AC_RESOLUTION_PATH
+       │   3. (Codex/Copilot) compose tempdir; (others) hook reads env
+       │   4. exec harness
+       ▼
+HARNESS reads filtered config / hook injects additionalContext
+```
+
+Resolution artifact at `$AC_RESOLUTION_PATH`:
+
+```json
+{
+  "schemaVersion": 1,
+  "harness": "claude-code",
+  "skillsDrop": ["frontend-design"],
+  "skillsKeep": null,
+  "modePrompt": "...",
+  "metadata": {"persona": "backend", "mode": "focused", "categories": [...]}
+}
+```
+
+## See also
+
+- Spec: `docs/superpowers/specs/2026-04-28-config-scoping-design.md` (local-only)
+- Plan: `docs/superpowers/plans/2026-04-28-config-scoping-plan.md` (local-only)
+- TAXONOMY.md — the 8 categories used in personas/modes

--- a/hooks/ac-filter-apm/SKILL.md
+++ b/hooks/ac-filter-apm/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ac-filter-apm
+version: 0.1.0
+description: >
+  Hook component that reads the AC resolution artifact and injects the active
+  persona/mode context (mode prompt + out-of-scope skill list) as additionalContext
+  into APM's SessionStart hook. Used when `ac` wraps APM with a persona/mode.
+  Path B implementation: additionalContext-only support (skill descriptions still
+  load into context normally, yielding no token savings). See CONVENTIONS.md for
+  fail-safe hook requirements.
+type: hook
+targets:
+  - apm
+category:
+  primary: context-management
+  secondary: [economy]
+hooks:
+  SessionStart:
+    command: hooks/filter.sh
+---
+
+# ac-filter-apm
+
+SessionStart hook for APM that reads the AC resolution artifact (`$AC_RESOLUTION_PATH`)
+and injects the active persona/mode context as additionalContext. Complements
+[`ac-filter-claude-code`](../ac-filter-claude-code/SKILL.md) for the APM harness.
+
+## Design
+
+When `ac` launches APM with a persona/mode active, it:
+1. Writes a JSON resolution artifact to a temporary path
+2. Sets `AC_WRAPPED=1` and exports `AC_RESOLUTION_PATH` to the environment
+3. APM's SessionStart hooks read that artifact and inject context
+
+This hook reads the artifact and emits:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Active persona/mode: PersonaName\n\n<mode_prompt body>\n\nThe following skills are out-of-scope for this session and should not be invoked: skill-a, skill-b, ..."
+  }
+}
+```
+
+When `AC_WRAPPED` is unset (normal APM usage without `ac`), the hook exits 0 with `{}` (no-op).
+
+## Output format — Path B (additionalContext-only)
+
+Path B means additionalContext is the only supported injection mechanism in APM's
+SessionStart hook schema. Skill descriptions still load into context normally
+(no token savings).
+
+When active, additionalContext includes:
+- Header line showing the active persona/mode name (informational).
+- Mode prompt body (may be multi-line markdown).
+- Out-of-scope skill notice (if skillsDrop list is non-empty).
+
+When inactive (no `AC_WRAPPED`), exits 0 with `{}`.
+
+## Implementation notes
+
+- Reads JSON from stdin (required by hook protocol; content is ignored).
+- Writes JSON to stdout.
+- Exits 0 always (fail-safe per CONVENTIONS.md).
+- Uses `jq` when available for correct JSON escaping; falls back to `python3` or shell.
+- Logs errors to stderr but never fails loudly.
+
+## Fail-safe behavior
+
+Hooks must NOT block the session even on error. The hook:
+- Exits 0 always, regardless of parsing errors.
+- Swallows failures via `|| true` on individual commands.
+- Logs unrecoverable errors to stderr (silent by default).
+
+See [`CONVENTIONS.md`](../../CONVENTIONS.md) for the fail-safe rule.

--- a/hooks/ac-filter-apm/hooks/filter.sh
+++ b/hooks/ac-filter-apm/hooks/filter.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+##
+# SessionStart hook for APM that reads the AC resolution artifact and injects
+# the active persona/mode context (mode prompt + out-of-scope skill list) as
+# additionalContext. Path B implementation: additionalContext-only.
+#
+# Protocol: reads JSON from stdin, writes JSON to stdout, exits 0 always.
+##
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  set +e
+  trap 'exit 0' ERR
+}
+
+failsafe::trap_errors 2>/dev/null || true
+
+# Consume stdin (required by hook protocol; we don't need its contents here).
+# shellcheck disable=SC2162
+read -r -t 1 < <(cat)
+
+# No-op when not launched via `ac`.
+if [[ -z "${AC_WRAPPED}" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# No-op when resolution path is missing or file doesn't exist.
+if [[ -z "${AC_RESOLUTION_PATH}" ]] || [[ ! -f "${AC_RESOLUTION_PATH}" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Parse resolution artifact.
+# Extract fields. Prefer jq; fall back to grep/sed for minimal environments.
+
+mode_name=""
+mode_prompt=""
+skills_drop_json=""
+
+if command -v jq &>/dev/null; then
+  mode_name=$(jq -r '.mode.name // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+  mode_prompt=$(jq -r '.mode.body // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+  skills_drop_json=$(jq -r '.skillsDrop | join(", ") // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+else
+  # Fallback to grep/sed (minimal environment).
+  mode_name=$(grep -o '"name":"[^"]*"' "${AC_RESOLUTION_PATH}" 2>/dev/null | head -1 | sed 's/"name":"\|"//g') || true
+  # This is a crude fallback for mode_prompt (multiline body); skip if jq unavailable.
+  skills_drop_json=$(grep -o '"skillsDrop":\[[^]]*\]' "${AC_RESOLUTION_PATH}" 2>/dev/null | sed 's/"skillsDrop":\["\|"\|"//g' | sed 's/","/,/g') || true
+fi
+
+# Build additionalContext body.
+
+context_parts=()
+
+# Header line showing active persona/mode (informational).
+if [[ -n "${mode_name}" ]]; then
+  context_parts+=("## Active mode: ${mode_name}")
+fi
+
+# Mode prompt body (may be multi-line markdown).
+if [[ -n "${mode_prompt}" ]]; then
+  context_parts+=("${mode_prompt}")
+fi
+
+# Out-of-scope skill notice.
+if [[ -n "${skills_drop_json}" ]]; then
+  context_parts+=("The following skills are out-of-scope for this session and should not be invoked: ${skills_drop_json}")
+fi
+
+# Nothing to inject → no-op.
+if [[ ${#context_parts[@]} -eq 0 ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Join parts with double newline.
+additional_context=$(printf '%s\n\n' "${context_parts[@]}" | sed '$ s/\n\n$//')
+
+# Emit JSON using jq when available for correct escaping; fallback otherwise.
+if command -v jq &>/dev/null; then
+  jq -n \
+    --arg context "${additional_context}" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: $context
+      }
+    }' 2>/dev/null || echo '{}'
+elif command -v python3 &>/dev/null; then
+  python3 -c "
+import json
+import sys
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': '''${additional_context}'''
+    }
+}
+print(json.dumps(output))
+" 2>/dev/null || echo '{}'
+else
+  # Last resort: shell-based escaping (imperfect but fail-safe).
+  # Replace " with \" and newlines with \n.
+  escaped=$(printf '%s' "${additional_context}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"${escaped}\"}}"
+fi
+
+exit 0

--- a/hooks/ac-filter-apm/tests/filter.test.sh
+++ b/hooks/ac-filter-apm/tests/filter.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+##
+# Smoke tests for ac-filter-apm/hooks/filter.sh
+#
+# Case 1: AC not active → no-op {} output.
+# Case 2: AC active with a resolution artifact → additionalContext injected.
+#
+##
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER_SH="${SCRIPT_DIR}/../hooks/filter.sh"
+
+# Test case 1: AC not active (AC_WRAPPED unset) → output is {}
+echo "Test 1: AC not active (AC_WRAPPED unset) → no-op"
+unset AC_WRAPPED
+unset AC_RESOLUTION_PATH
+output=$(echo '{}' | bash "${FILTER_SH}")
+if [[ "${output}" == '{}' ]]; then
+  echo "PASS"
+else
+  echo "FAIL: Expected '{}', got '${output}'"
+  exit 1
+fi
+
+# Test case 2: AC active with resolution artifact
+echo "Test 2: AC active with resolution artifact → additionalContext included"
+
+# Create a temporary resolution artifact.
+tmpfile=$(mktemp)
+trap "rm -f ${tmpfile}" EXIT
+
+cat > "${tmpfile}" <<'EOF'
+{
+  "mode": {
+    "name": "TestMode",
+    "body": "This is a test mode prompt.\nMultiline supported."
+  },
+  "skillsDrop": ["skill-a", "skill-b"]
+}
+EOF
+
+export AC_WRAPPED=1
+export AC_RESOLUTION_PATH="${tmpfile}"
+
+output=$(echo '{}' | bash "${FILTER_SH}")
+
+# Verify the output contains hookSpecificOutput, SessionStart, and additionalContext.
+if echo "${output}" | grep -q "hookSpecificOutput" && \
+   echo "${output}" | grep -q "SessionStart" && \
+   echo "${output}" | grep -q "additionalContext" && \
+   echo "${output}" | grep -q "TestMode"; then
+  echo "PASS"
+else
+  echo "FAIL: Output missing expected fields or values"
+  echo "Output: ${output}"
+  exit 1
+fi

--- a/hooks/ac-filter-claude-code/SKILL.md
+++ b/hooks/ac-filter-claude-code/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ac-filter-claude-code
+version: 1.0.0
+type: hook
+description: ac wrapper filter for Claude Code — reads $AC_RESOLUTION_PATH and injects mode prompt + out-of-scope skill list as additionalContext
+targets: [claude-code]
+category:
+  primary: context-management
+  secondary: [economy]
+hooks:
+  SessionStart:
+    command: hooks/filter.sh
+    matcher: "*"
+---
+
+# ac-filter-claude-code
+
+Companion hook for the `ac` wrapper. When `ac claude --persona X --mode Y`
+runs, the wrapper writes a resolution artifact and exports `AC_RESOLUTION_PATH`.
+This hook reads that artifact at SessionStart and injects `additionalContext`
+into the session so Claude honours the active persona/mode constraints.
+
+When `ac` is not in use (no `AC_WRAPPED` env var), this hook is a no-op.
+
+## Implementation note
+
+**Path B — additionalContext only.** Research into the Claude Code SessionStart
+hook output schema (docs.anthropic.com/en/docs/claude-code/hooks) confirms that
+the only supported output key for injecting content is `additionalContext` inside
+`hookSpecificOutput`. There is no documented `skillsToRemove`, `disabledSkills`,
+or equivalent key that would allow the hook to mutate the loaded skill catalog at
+runtime. As a result, this implementation injects the mode prompt body plus a
+prose instruction listing out-of-scope skills; the skill descriptions themselves
+still load into the context window (no token savings). This is a known limitation.
+A future Plan 9b can revisit with Path C (pre-launch compose: `ac` rewrites
+`~/.claude/settings.json` / symlinks a curated `.claude/skills/` directory before
+exec) to achieve full token reduction.
+
+## Output format
+
+When active, the hook emits:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "...<modePrompt>...\n\nThe following skills are out-of-scope for this session and should not be invoked: skill-a, skill-b, ..."
+  }
+}
+```
+
+When inactive (no `AC_WRAPPED`), the hook exits 0 with `{}` — Claude Code
+treats the absence of `additionalContext` as a no-op.

--- a/hooks/ac-filter-claude-code/hooks/filter.sh
+++ b/hooks/ac-filter-claude-code/hooks/filter.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SessionStart hook for ac-filter-claude-code.
+#
+# When `ac` launches Claude Code it sets AC_WRAPPED=1 and writes a resolution
+# artifact to a temp path exported as AC_RESOLUTION_PATH. This hook reads that
+# artifact and injects the mode prompt + out-of-scope skill list as
+# additionalContext so Claude honours the active persona/mode constraints.
+#
+# When AC_WRAPPED is unset this hook exits 0 with {} (no-op).
+#
+# Path B implementation: only additionalContext is supported by Claude Code's
+# SessionStart hook output schema. Skill descriptions still load into context
+# (no token savings). See SKILL.md for full rationale and Plan 9b path C notes.
+#
+# Protocol: reads JSON from stdin, writes JSON to stdout, exits 0 always.
+
+# shellcheck shell=bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  set +e
+  trap 'exit 0' ERR
+}
+
+failsafe::trap_errors 2>/dev/null || true
+
+# Consume stdin (required by hook protocol; we don't need its contents here).
+input="$(cat 2>/dev/null || true)"
+# Silence unused-variable warning from shellcheck — input is consumed per protocol.
+: "${input}"
+
+# No-op when not launched via `ac`.
+if [[ -z "${AC_WRAPPED:-}" ]]; then
+  printf '{}\n'
+  exit 0
+fi
+
+# No-op when resolution path is missing or file doesn't exist.
+if [[ -z "${AC_RESOLUTION_PATH:-}" ]] || [[ ! -f "${AC_RESOLUTION_PATH}" ]]; then
+  printf '[ac-filter-claude-code] AC_WRAPPED set but AC_RESOLUTION_PATH missing or unreadable\n' >&2
+  printf '{}\n'
+  exit 0
+fi
+
+# Parse resolution artifact.
+resolution="$(cat "${AC_RESOLUTION_PATH}" 2>/dev/null || true)"
+if [[ -z "${resolution}" ]]; then
+  printf '[ac-filter-claude-code] resolution artifact is empty\n' >&2
+  printf '{}\n'
+  exit 0
+fi
+
+# Extract fields. Prefer jq; fall back to grep/sed for minimal environments.
+if command -v jq >/dev/null 2>&1; then
+  mode_prompt="$(printf '%s' "${resolution}" | jq -r '.modePrompt // ""' 2>/dev/null || true)"
+  skills_drop_json="$(printf '%s' "${resolution}" | jq -r '.skillsDrop // [] | join(", ")' 2>/dev/null || true)"
+  persona="$(printf '%s' "${resolution}" | jq -r '.metadata.persona // ""' 2>/dev/null || true)"
+  mode="$(printf '%s' "${resolution}" | jq -r '.metadata.mode // ""' 2>/dev/null || true)"
+else
+  # Minimal fallback — best-effort extraction without jq.
+  mode_prompt="$(printf '%s' "${resolution}" | grep -o '"modePrompt"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/' | head -1 || true)"
+  skills_drop_json="$(printf '%s' "${resolution}" | grep -o '"skillsDrop"[[:space:]]*:[[:space:]]*\[[^]]*\]' | sed 's/.*\[\(.*\)\]/\1/' | tr -d '"' | tr ',' ', ' | head -1 || true)"
+  persona=""
+  mode=""
+fi
+
+# Build additionalContext body.
+context_parts=()
+
+# Header line showing active persona/mode (informational).
+if [[ -n "${persona}" ]] || [[ -n "${mode}" ]]; then
+  header="<!-- ac session: persona=${persona:-none} mode=${mode:-none} -->"
+  context_parts+=("${header}")
+fi
+
+# Mode prompt body (may be multi-line markdown).
+if [[ -n "${mode_prompt}" ]]; then
+  context_parts+=("${mode_prompt}")
+fi
+
+# Out-of-scope skill notice.
+if [[ -n "${skills_drop_json}" ]]; then
+  context_parts+=("The following skills are out-of-scope for this session and should not be invoked: ${skills_drop_json}.")
+fi
+
+# Nothing to inject → no-op.
+if [[ ${#context_parts[@]} -eq 0 ]]; then
+  printf '{}\n'
+  exit 0
+fi
+
+# Join parts with double newline.
+additional_context=""
+for part in "${context_parts[@]}"; do
+  if [[ -n "${additional_context}" ]]; then
+    additional_context="${additional_context}
+
+${part}"
+  else
+    additional_context="${part}"
+  fi
+done
+
+# Emit JSON using jq when available for correct escaping; fallback otherwise.
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "${additional_context}" \
+    | jq -Rs '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: .}}' 2>/dev/null \
+    || printf '{}\n'
+else
+  # Manual escaping fallback.
+  ctx="${additional_context//\\/\\\\}"
+  ctx="${ctx//\"/\\\"}"
+  ctx="${ctx//$'\n'/\\n}"
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "${ctx}"
+fi
+
+exit 0

--- a/hooks/ac-filter-claude-code/tests/filter.test.sh
+++ b/hooks/ac-filter-claude-code/tests/filter.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+dir="$(cd "$(dirname "$0")/.." && pwd)"
+script="$dir/hooks/filter.sh"
+
+# Case 1: AC not active → no-op {} output.
+out=$(echo '{}' | env -u AC_WRAPPED -u AC_RESOLUTION_PATH "$script")
+if [[ "$out" != "{}" ]]; then
+  echo "FAIL: expected {} when AC not active, got: $out" >&2
+  exit 1
+fi
+echo "PASS: no-op when AC not active"
+
+# Case 2: AC active with a resolution artifact.
+tmp=$(mktemp -d)
+cat > "$tmp/resolution.json" <<EOF
+{
+  "schemaVersion": 1,
+  "harness": "claude-code",
+  "skillsDrop": ["a", "b"],
+  "skillsKeep": null,
+  "modePrompt": "Stay focused.",
+  "metadata": {"persona": "p", "mode": "m", "categories": []}
+}
+EOF
+out=$(echo '{}' | AC_WRAPPED=1 AC_RESOLUTION_PATH="$tmp/resolution.json" "$script")
+
+# Expect output to reference the mode prompt and/or out-of-scope skill list.
+if ! echo "$out" | grep -qE "Stay focused|out-of-scope"; then
+  echo "FAIL: expected output to reference filter or prompt, got: $out" >&2
+  rm -rf "$tmp"
+  exit 1
+fi
+echo "PASS: filter emits expected output for active session"
+
+rm -rf "$tmp"

--- a/hooks/ac-filter-gemini/SKILL.md
+++ b/hooks/ac-filter-gemini/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ac-filter-gemini
+version: 0.1.0
+description: >
+  Hook component that reads the AC resolution artifact and injects the active
+  persona/mode context (mode prompt + out-of-scope skill list) as additionalContext
+  into Gemini's SessionStart hook. Used when `ac` wraps Gemini with a persona/mode.
+  Path B implementation: additionalContext-only support (skill descriptions still
+  load into context normally, yielding no token savings). See CONVENTIONS.md for
+  fail-safe hook requirements.
+type: hook
+targets:
+  - gemini
+category:
+  primary: context-management
+  secondary: [economy]
+hooks:
+  SessionStart:
+    command: hooks/filter.sh
+---
+
+# ac-filter-gemini
+
+SessionStart hook for Gemini that reads the AC resolution artifact (`$AC_RESOLUTION_PATH`)
+and injects the active persona/mode context as additionalContext. Complements
+[`ac-filter-claude-code`](../ac-filter-claude-code/SKILL.md) and [`ac-filter-apm`](../ac-filter-apm/SKILL.md)
+for the Gemini harness.
+
+## Design
+
+When `ac` launches Gemini with a persona/mode active, it:
+1. Writes a JSON resolution artifact to a temporary path
+2. Sets `AC_WRAPPED=1` and exports `AC_RESOLUTION_PATH` to the environment
+3. Gemini's SessionStart hooks read that artifact and inject context
+
+This hook reads the artifact and emits:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Active persona/mode: PersonaName\n\n<mode_prompt body>\n\nThe following skills are out-of-scope for this session and should not be invoked: skill-a, skill-b, ..."
+  }
+}
+```
+
+When `AC_WRAPPED` is unset (normal Gemini usage without `ac`), the hook exits 0 with `{}` (no-op).
+
+## Output format — Path B (additionalContext-only)
+
+Path B means additionalContext is the only supported injection mechanism in Gemini's
+SessionStart hook schema. Skill descriptions still load into context normally
+(no token savings).
+
+When active, additionalContext includes:
+- Header line showing the active persona/mode name (informational).
+- Mode prompt body (may be multi-line markdown).
+- Out-of-scope skill notice (if skillsDrop list is non-empty).
+
+When inactive (no `AC_WRAPPED`), exits 0 with `{}`.
+
+## Implementation notes
+
+- Reads JSON from stdin (required by hook protocol; content is ignored).
+- Writes valid JSON to stdout (Gemini's JSON-on-stdout contract).
+- Exits 0 always (fail-safe per CONVENTIONS.md).
+- Uses `jq` when available for correct JSON escaping; falls back to `python3` or shell.
+- Logs errors to stderr but never fails loudly.
+
+## Fail-safe behavior
+
+Hooks must NOT block the session even on error. The hook:
+- Exits 0 always, regardless of parsing errors.
+- Swallows failures via `|| true` on individual commands.
+- Logs unrecoverable errors to stderr (silent by default).
+
+See [`CONVENTIONS.md`](../../CONVENTIONS.md) for the fail-safe rule.

--- a/hooks/ac-filter-gemini/hooks/filter.sh
+++ b/hooks/ac-filter-gemini/hooks/filter.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+##
+# SessionStart hook for Gemini that reads the AC resolution artifact and injects
+# the active persona/mode context (mode prompt + out-of-scope skill list) as
+# additionalContext. Emits valid JSON on stdout per Gemini's hook contract.
+# Path B implementation: additionalContext-only.
+#
+# Protocol: reads JSON from stdin, writes JSON to stdout, exits 0 always.
+##
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  set +e
+  trap 'exit 0' ERR
+}
+
+failsafe::trap_errors 2>/dev/null || true
+
+# Consume stdin (required by hook protocol; we don't need its contents here).
+# shellcheck disable=SC2162
+read -r -t 1 < <(cat)
+
+# No-op when not launched via `ac`.
+if [[ -z "${AC_WRAPPED}" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# No-op when resolution path is missing or file doesn't exist.
+if [[ -z "${AC_RESOLUTION_PATH}" ]] || [[ ! -f "${AC_RESOLUTION_PATH}" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Parse resolution artifact.
+# Extract fields. Prefer jq; fall back to grep/sed for minimal environments.
+
+mode_name=""
+mode_prompt=""
+skills_drop_json=""
+
+if command -v jq &>/dev/null; then
+  mode_name=$(jq -r '.mode.name // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+  mode_prompt=$(jq -r '.mode.body // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+  skills_drop_json=$(jq -r '.skillsDrop | join(", ") // empty' "${AC_RESOLUTION_PATH}" 2>/dev/null) || true
+else
+  # Fallback to grep/sed (minimal environment).
+  mode_name=$(grep -o '"name":"[^"]*"' "${AC_RESOLUTION_PATH}" 2>/dev/null | head -1 | sed 's/"name":"\|"//g') || true
+  # This is a crude fallback for mode_prompt (multiline body); skip if jq unavailable.
+  skills_drop_json=$(grep -o '"skillsDrop":\[[^]]*\]' "${AC_RESOLUTION_PATH}" 2>/dev/null | sed 's/"skillsDrop":\["\|"\|"//g' | sed 's/","/,/g') || true
+fi
+
+# Build additionalContext body.
+
+context_parts=()
+
+# Header line showing active persona/mode (informational).
+if [[ -n "${mode_name}" ]]; then
+  context_parts+=("## Active mode: ${mode_name}")
+fi
+
+# Mode prompt body (may be multi-line markdown).
+if [[ -n "${mode_prompt}" ]]; then
+  context_parts+=("${mode_prompt}")
+fi
+
+# Out-of-scope skill notice.
+if [[ -n "${skills_drop_json}" ]]; then
+  context_parts+=("The following skills are out-of-scope for this session and should not be invoked: ${skills_drop_json}")
+fi
+
+# Nothing to inject → no-op.
+if [[ ${#context_parts[@]} -eq 0 ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Join parts with double newline.
+additional_context=$(printf '%s\n\n' "${context_parts[@]}" | sed '$ s/\n\n$//')
+
+# Emit JSON using jq when available for correct escaping; fallback otherwise.
+if command -v jq &>/dev/null; then
+  jq -n \
+    --arg context "${additional_context}" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: $context
+      }
+    }' 2>/dev/null || echo '{}'
+elif command -v python3 &>/dev/null; then
+  python3 -c "
+import json
+import sys
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': '''${additional_context}'''
+    }
+}
+print(json.dumps(output))
+" 2>/dev/null || echo '{}'
+else
+  # Last resort: shell-based escaping (imperfect but fail-safe).
+  # Replace " with \" and newlines with \n.
+  escaped=$(printf '%s' "${additional_context}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"${escaped}\"}}"
+fi
+
+exit 0

--- a/hooks/ac-filter-gemini/tests/filter.test.sh
+++ b/hooks/ac-filter-gemini/tests/filter.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+##
+# Smoke tests for ac-filter-gemini/hooks/filter.sh
+#
+# Case 1: AC not active → no-op {} output.
+# Case 2: AC active with a resolution artifact → additionalContext injected.
+#
+##
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER_SH="${SCRIPT_DIR}/../hooks/filter.sh"
+
+# Test case 1: AC not active (AC_WRAPPED unset) → output is {}
+echo "Test 1: AC not active (AC_WRAPPED unset) → no-op"
+unset AC_WRAPPED
+unset AC_RESOLUTION_PATH
+output=$(echo '{}' | bash "${FILTER_SH}")
+if [[ "${output}" == '{}' ]]; then
+  echo "PASS"
+else
+  echo "FAIL: Expected '{}', got '${output}'"
+  exit 1
+fi
+
+# Test case 2: AC active with resolution artifact
+echo "Test 2: AC active with resolution artifact → additionalContext included"
+
+# Create a temporary resolution artifact.
+tmpfile=$(mktemp)
+trap "rm -f ${tmpfile}" EXIT
+
+cat > "${tmpfile}" <<'EOF'
+{
+  "mode": {
+    "name": "TestMode",
+    "body": "This is a test mode prompt.\nMultiline supported."
+  },
+  "skillsDrop": ["skill-a", "skill-b"]
+}
+EOF
+
+export AC_WRAPPED=1
+export AC_RESOLUTION_PATH="${tmpfile}"
+
+output=$(echo '{}' | bash "${FILTER_SH}")
+
+# Verify the output contains hookSpecificOutput, SessionStart, and additionalContext.
+if echo "${output}" | grep -q "hookSpecificOutput" && \
+   echo "${output}" | grep -q "SessionStart" && \
+   echo "${output}" | grep -q "additionalContext" && \
+   echo "${output}" | grep -q "TestMode"; then
+  echo "PASS"
+else
+  echo "FAIL: Output missing expected fields or values"
+  echo "Output: ${output}"
+  exit 1
+fi

--- a/hooks/ac-filter-pi/SKILL.md
+++ b/hooks/ac-filter-pi/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ac-filter-pi
+version: 0.1.0
+description: >
+  Hook component that reads the AC resolution artifact and injects the active
+  persona/mode context (mode prompt + out-of-scope skill list) via Pi's
+  additionalContext on session_start. Used when `ac` wraps Pi with a persona/mode.
+  Path B implementation: additionalContext-only support via sendUserMessage
+  (not setActiveTools). See CONVENTIONS.md for fail-safe hook requirements.
+type: hook
+targets:
+  - pi
+category:
+  primary: context-management
+  secondary: [economy]
+hooks:
+  session_start:
+    command: index.ts
+---
+
+# ac-filter-pi
+
+SessionStart hook for Pi that reads the AC resolution artifact (`$AC_RESOLUTION_PATH`)
+and injects the active persona/mode context via additionalContext. Complements
+[`ac-filter-claude-code`](../ac-filter-claude-code/SKILL.md),
+[`ac-filter-apm`](../ac-filter-apm/SKILL.md), and
+[`ac-filter-gemini`](../ac-filter-gemini/SKILL.md) for their respective harnesses.
+
+## Design
+
+When `ac` launches Pi with a persona/mode active, it:
+1. Writes a JSON resolution artifact to a temporary path
+2. Sets `AC_WRAPPED=1` and exports `AC_RESOLUTION_PATH` to the environment
+3. Pi's session_start hooks read that artifact and inject context
+
+This hook reads the artifact and:
+- Emits the mode prompt via `pi.sendUserMessage(..., { deliverAs: "steer" })`
+- Includes out-of-scope skill notice (if skillsDrop list is non-empty)
+
+When `AC_WRAPPED` is unset (normal Pi usage without `ac`), the hook is a no-op.
+
+## Output format — Path B (additionalContext-only via sendUserMessage)
+
+Path B means additionalContext is injected via `pi.sendUserMessage()` with
+`deliverAs: "steer"` option. Skill descriptions still load into context normally
+(no token savings).
+
+When active, the message includes:
+- Mode prompt body (may be multi-line markdown).
+- Out-of-scope skill notice (if skillsDrop list is non-empty).
+
+When inactive (no `AC_WRAPPED`), the hook exits silently (no-op).
+
+## Implementation notes
+
+- Loads resolution from `$AC_RESOLUTION_PATH` environment variable (if set).
+- Reads JSON and extracts `modePrompt`, `skillsDrop` fields.
+- Uses `pi.sendUserMessage()` to inject context (Path B marker; Path A deferred to Plan 9b).
+- Falls back gracefully if `$AC_WRAPPED` is unset or artifact missing.
+
+## Fail-safe behavior
+
+Hooks must NOT block the session even on error. The hook:
+- Catches JSON parse errors and silently returns if the artifact is malformed.
+- Never throws; always succeeds.
+
+See [`CONVENTIONS.md`](../../CONVENTIONS.md) for the fail-safe rule.

--- a/hooks/ac-filter-pi/index.ts.tmpl
+++ b/hooks/ac-filter-pi/index.ts.tmpl
@@ -1,0 +1,43 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { readFileSync } from "node:fs";
+
+interface Resolution {
+  schemaVersion: 1;
+  harness: string;
+  skillsDrop: string[];
+  skillsKeep: string[] | null;
+  modePrompt: string;
+  metadata: { persona: string | null; mode: string | null; categories: string[] };
+}
+
+function loadResolution(): Resolution | null {
+  if (!process.env.AC_WRAPPED) return null;
+  const p = process.env.AC_RESOLUTION_PATH;
+  if (!p) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as Resolution;
+  } catch {
+    return null;
+  }
+}
+
+export default function acFilterPi(pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, _ctx) => {
+    const r = loadResolution();
+    if (!r) return;
+
+    // Path B: additionalContext only. Tell the model which skills are out of
+    // scope; do NOT use pi.setActiveTools() to physically remove them
+    // (that's Path A, deferred to Plan 9b).
+    const parts: string[] = [];
+    if (r.modePrompt.trim()) parts.push(r.modePrompt.trim());
+    if (r.skillsDrop.length > 0) {
+      parts.push(
+        `The following skills are out-of-scope for this session and should not be invoked: ${r.skillsDrop.join(", ")}.`,
+      );
+    }
+    if (parts.length > 0) {
+      pi.sendUserMessage(parts.join("\n\n"), { deliverAs: "steer" });
+    }
+  });
+}

--- a/hooks/ac-filter-pi/tests/filter.test.ts
+++ b/hooks/ac-filter-pi/tests/filter.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+describe('ac-filter-pi template (Path B)', () => {
+  it('exports a default function and uses sendUserMessage (not setActiveTools)', async () => {
+    const tmpl = await fs.readFile(
+      path.join(HERE, '..', 'index.ts.tmpl'),
+      'utf8',
+    );
+    // Remove comments to ensure setActiveTools is not actually invoked (only mentioned in docs)
+    const codeWithoutComments = tmpl.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(tmpl).toMatch(/export default function/);
+    expect(tmpl).toMatch(/AC_RESOLUTION_PATH/);
+    expect(tmpl).toMatch(/session_start/);
+    expect(tmpl).toMatch(/sendUserMessage/);
+    expect(codeWithoutComments).not.toMatch(/setActiveTools/);
+  });
+});

--- a/modes/code/mode.md
+++ b/modes/code/mode.md
@@ -1,0 +1,29 @@
+---
+name: code
+version: 1.0.0
+type: mode
+description: "Software development tasks: writing, reviewing, refactoring, debugging code."
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [tooling, workflow]
+skill_include: []
+skill_exclude: []
+---
+
+You are in code mode, focused on software development tasks.
+
+Your responsibilities:
+- Write, review, refactor, and debug code with attention to quality
+- Observe patterns: bugs, fixes, refactors, features, tests, performance work, code review
+- Remember context: architecture, performance patterns, build tooling, design principles
+
+Mode-aware philosophy:
+- Lean on philosophy skills: Ousterhout (deep modules), TigerStyle (safety), idiomatic language guides, HIPP (zero-config simplicity), DX audits
+- Default to test-driven development: write tests first, code second
+- Prioritize code quality reviews using structural principles
+- Track performance and architectural patterns across sessions
+
+When in code mode, optimize for:
+- Correctness and safety over convenience
+- Clarity and maintainability over cleverness
+- Testing and verification before shipping
+- Consistent tooling and build practices

--- a/modes/design/mode.md
+++ b/modes/design/mode.md
@@ -1,0 +1,30 @@
+---
+name: design
+version: 1.0.0
+type: mode
+description: UI, UX, interaction, and visual design tasks.
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [tooling, workflow, integrations]
+skill_include: []
+skill_exclude: []
+---
+
+You are in design mode, focused on UI, UX, interaction, and visual design.
+
+Your responsibilities:
+- Design interactions, affordances, and visual layouts with user-centered thinking
+- Observe patterns: affordances, feedback, mapping, error prevention, accessibility, density
+- Remember context: interaction patterns, information density, accessibility standards, visual language
+
+Mode-aware philosophy:
+- Lean on philosophy skills: Norman (usability principles), DX audits, frontend design systems
+- Prioritize user feedback and error prevention
+- Respect information density and cognitive load
+- Apply accessibility standards from the start
+
+When in design mode, optimize for:
+- User clarity and discoverability
+- Consistency across interactions
+- Accessibility and inclusion
+- Feedback and error handling
+- Visual and interaction coherence

--- a/modes/focused/mode.md
+++ b/modes/focused/mode.md
@@ -1,0 +1,14 @@
+---
+name: focused
+version: 1.0.0
+type: mode
+description: Single-task deep focus, no scope creep
+targets: [claude-code, apm, gemini, codex, copilot, pi]
+categories: [tooling]
+skill_include: []
+skill_exclude: []
+---
+
+You are in focused mode. Stay on the current task. Do not refactor adjacent code,
+do not propose unrelated improvements. If you notice something else, mention it
+in one line and move on.

--- a/modes/ops/mode.md
+++ b/modes/ops/mode.md
@@ -1,0 +1,30 @@
+---
+name: ops
+version: 1.0.0
+type: mode
+description: "Operations, infrastructure, deployment, observability, and on-call work."
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [integrations, tooling]
+skill_include: []
+skill_exclude: []
+---
+
+You are in ops mode, focused on operations, infrastructure, deployment, and on-call work.
+
+Your responsibilities:
+- Manage infrastructure, deployments, alerting, and incident response
+- Observe patterns: incidents, deploys, rollbacks, alerts, permissions, configuration drift
+- Remember context: runbooks, alerting rules, permission models, infrastructure topology, incident history
+
+Mode-aware philosophy:
+- Lean on philosophy skills: TigerStyle (safety-critical systems), HIPP (simplicity and reliability), SigNoz dashboard building
+- Prioritize system reliability and incident prevention
+- Document runbooks and playbooks for repeatability
+- Maintain clear audit trails and permission models
+
+When in ops mode, optimize for:
+- System reliability and uptime
+- Fast incident detection and response
+- Safe, reversible deployments
+- Clear observability and alerting
+- Minimal configuration drift and technical debt

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "apm-builder": "./apm-builder/cli.ts",
+    "ac": "./apm-builder/ac.ts"
+  },
   "scripts": {
     "validate": "tsx apm-builder/cli.ts validate",
     "build": "tsx apm-builder/cli.ts build",

--- a/personas/aviation/persona.md
+++ b/personas/aviation/persona.md
@@ -1,0 +1,16 @@
+---
+name: aviation
+version: 1.0.0
+type: persona
+description: Aviation / flight planning work
+targets: [claude-code, codex, gemini, copilot]
+categories: [tooling, integrations, memory-management]
+skill_include: []
+skill_exclude: []
+---
+
+# Aviation Persona
+
+Aviation context — flight planning, charts, ops references. Keeps integrations
+and tooling but drops language-specific coding skills. Optimized for
+cross-session memory of flight plans, briefing data, and aviation procedures.

--- a/personas/backend/persona.md
+++ b/personas/backend/persona.md
@@ -1,0 +1,16 @@
+---
+name: backend
+version: 1.0.0
+type: persona
+description: Backend dev work — Go, observability, infra, philosophy
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [tooling, workflow, context-management, evolution, backpressure]
+skill_include: [idiomatic-go]
+skill_exclude: [datastar-tao, datastar-patterns, datastar]
+---
+
+# Backend Persona
+
+For sessions focused on Go, server-side, infra, observability, debugging.
+Includes idiomatic-go for language-specific philosophy. Excludes Datastar and
+frontend-design specific skills to keep context lean.

--- a/personas/frontend/persona.md
+++ b/personas/frontend/persona.md
@@ -1,0 +1,15 @@
+---
+name: frontend
+version: 1.0.0
+type: persona
+description: Frontend / Datastar work
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [tooling, workflow, context-management, backpressure]
+skill_include: [datastar-tao, datastar-patterns]
+skill_exclude: [idiomatic-go]
+---
+
+# Frontend Persona
+
+For sessions focused on Datastar, UI, client-side. Forces Datastar skills to
+load and excludes Go-specific ones to keep frontend context clear.

--- a/personas/personal/persona.md
+++ b/personas/personal/persona.md
@@ -1,0 +1,16 @@
+---
+name: personal
+version: 1.0.0
+type: persona
+description: Personal projects, journaling, knowledge-base maintenance
+targets: [claude-code, apm, codex, gemini, copilot, pi]
+categories: [memory-management, context-management]
+skill_include: [knowledge-base-overview, memorize]
+skill_exclude: []
+---
+
+# Personal Persona
+
+Drops all coding-specific skills. Keeps memory and knowledge-base primitives.
+Optimized for journaling, personal project tracking, and knowledge-base
+maintenance across sessions.

--- a/personas/taxes/persona.md
+++ b/personas/taxes/persona.md
@@ -1,0 +1,15 @@
+---
+name: taxes
+version: 1.0.0
+type: persona
+description: Tax preparation / non-code document work
+targets: [claude-code, codex, gemini, copilot]
+categories: [memory-management]
+skill_include: []
+skill_exclude: []
+---
+
+# Taxes Persona
+
+Strips out all engineering skills. Keeps memory primitives only. Optimized for
+document-handling tasks like tax preparation, bookkeeping, and administrative work.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['apm-builder/**/*.test.ts'],
+    include: ['apm-builder/**/*.test.ts', 'hooks/**/*.test.ts'],
     globals: false,
   },
 });


### PR DESCRIPTION
## Summary

Plan 9 ships an opt-in `ac` wrapper layer on top of all 6 supported harnesses, with persona and mode as new component types.

- New persona + mode component types in the schema (validated, discoverable, marketplace-able)
- `ac` wrapper binary: resolves persona+mode → JSON resolution artifact → exec's harness with env pointer
- 4 runtime filter hooks (Claude Code, APM, Gemini, Pi) — Path B (additionalContext-only)
- Pre-launch compose for Codex + Copilot — full skill catalog filtering via tempdir
- 5 built-in personas: backend, frontend, personal, taxes, aviation
- 4 built-in modes: code, design, ops, focused
- 25 commits, +3085 / -37 across 57 files
- 238 tests passing (was 184 on main); 54 new tests
- 68 components total (was 55)

## Known limitation (Path B)

Claude Code, APM, Gemini, and Pi runtime hooks ship Path B: skill descriptions still load into the system prompt; the hook injects `additionalContext` instructing the model to ignore out-of-scope skills. **False-activation prevention works; token-bloat reduction does not** for these 4. Codex + Copilot DO get token reduction via pre-launch compose. Future Plan 9b can extend pre-launch compose (Path C) to the runtime-hook harnesses.

This was verified empirically: Claude Code's SessionStart hook output schema only supports `hookSpecificOutput.additionalContext`; there is no `skillsToRemove` API.

## Architecture

- Resolution algorithm runs once in `ac` per session. The artifact at `$AC_RESOLUTION_PATH` is a single source of truth — hooks are flat consumers, no algorithm replication across harnesses (Ousterhout-driven simplification from spec self-review)
- Default behavior is opt-in: `claude` direct → today's full catalog; `ac claude --persona X` → filtered
- Skills with no `category` field stay universal (always-load) — backward compatible
- Personas/modes have 3-tier discovery: `<cwd>/.agent-config/` (project) > `~/.config/agent-config/` (user) > built-ins shipped with `agent-config`

## Files of interest

- `apm-builder/lib/resolution.ts` — pure `resolve()` + `writeResolutionArtifact()`
- `apm-builder/lib/ac/run.ts` — wrapper entry, arg parsing, env export, exec
- `apm-builder/lib/ac/prelaunch.ts` — Codex/Copilot pre-launch compose
- `apm-builder/lib/ac/introspect.ts` — `list`, `show`, `doctor` subcommands
- `hooks/ac-filter-{claude-code,apm,gemini,pi}/` — 4 filter hooks
- `personas/`, `modes/` — built-in components
- `docs/USING-AC.md` — runbook

## Test plan

- [x] All existing tests still pass (184 baseline + 54 new = 238)
- [x] `apm-builder validate` passes (68 components, 7 pre-existing warnings)
- [x] `ac list personas/modes` works
- [x] `ac show persona/mode` works
- [x] `ac doctor` correctly reports missing filter hooks
- [ ] Manual end-to-end: invoke \`ac claude --persona backend\` and verify filtered behavior
- [ ] Manual end-to-end: invoke \`ac codex --persona backend\` and verify tempdir AGENTS.md is composed