### PR TITLE
fix: builtinDir resolution + OAuth auth detection in docker tests

### DIFF
--- a/apm-builder/lib/ac/run.ts
+++ b/apm-builder/lib/ac/run.ts
@@ -115,8 +115,11 @@ export async function runAc(argv: string[], deps: RunDeps = {}): Promise<number>
 
   const projectDir = deps.projectDir ?? process.cwd();
   const userDir = deps.userDir ?? path.join(os.homedir(), '.config', 'agent-config');
+  // run.ts lives at <repo>/apm-builder/lib/ac/run.ts — walk up 3 dirs to the repo
+  // root where personas/ and modes/ live.
   const builtinDir =
-    deps.builtinDir ?? path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+    deps.builtinDir ??
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
   const dirs = { projectDir, userDir, builtinDir };
 
   const env: NodeJS.ProcessEnv = { ...process.env, AC_WRAPPED: '1', AC_HARNESS: target };

--- a/apm-builder/tests/integration/docker/test-runner.sh
+++ b/apm-builder/tests/integration/docker/test-runner.sh
@@ -47,12 +47,15 @@ if $DRY_RUN; then
   exit 0
 fi
 
-# API key presence map
+# Auth presence — accept either an API key env var OR mounted OAuth credentials.
+# (Mount with: docker run -v $HOME/.claude:/root/.claude:ro ...)
+declare -A HARNESS_AUTH
+[[ -n "${ANTHROPIC_API_KEY:-}" || -f "$HOME/.claude/.credentials.json" ]] && HARNESS_AUTH[claude]=ok || HARNESS_AUTH[claude]=
+[[ -n "${OPENAI_API_KEY:-}" || -f "$HOME/.codex/auth.json" || -d "$HOME/.codex" ]] && HARNESS_AUTH[codex]=ok || HARNESS_AUTH[codex]=
+[[ -n "${GEMINI_API_KEY:-}" || -d "$HOME/.gemini" ]] && HARNESS_AUTH[gemini]=ok || HARNESS_AUTH[gemini]=
+[[ -n "${ANTHROPIC_API_KEY:-}" || -f "$HOME/.claude/.credentials.json" ]] && HARNESS_AUTH[pi]=ok || HARNESS_AUTH[pi]=
 declare -A HARNESS_KEY
-HARNESS_KEY[claude]="${ANTHROPIC_API_KEY:-}"
-HARNESS_KEY[codex]="${OPENAI_API_KEY:-}"
-HARNESS_KEY[gemini]="${GEMINI_API_KEY:-}"
-HARNESS_KEY[pi]="${ANTHROPIC_API_KEY:-}"
+for h in claude codex gemini pi; do HARNESS_KEY[$h]="${HARNESS_AUTH[$h]}"; done
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -66,7 +69,7 @@ for harness in "${HARNESSES[@]}"; do
 
   api_key="${HARNESS_KEY[$harness]}"
   if [[ -z "$api_key" ]]; then
-    echo "[SKIP] $harness: API key not set — skipping all scenarios"
+    echo "[SKIP] $harness: no auth (no API key env var, no OAuth credentials mounted) — skipping all scenarios"
     SKIP_COUNT=$(( SKIP_COUNT + ${#SCENARIOS[@]} ))
     echo ""
     continue


### PR DESCRIPTION
## Summary

Follow-up fixes surfaced by running the docker test matrix from PR #70 against real harnesses with OAuth credentials.

### Bug 1 — \`apm-builder/lib/ac/run.ts:118-119\` (builtinDir resolution)

Was:
\`\`\`ts
const builtinDir = deps.builtinDir ?? path.dirname(path.dirname(fileURLToPath(import.meta.url)));
\`\`\`

From \`run.ts\` at \`<repo>/apm-builder/lib/ac/run.ts\`, that walks up only to \`<repo>/apm-builder/lib\` — missing the \`personas/\` and \`modes/\` dirs at the repo root. Result: any \`ac claude --persona backend\` invocation hit \`findPersona\` and threw "persona not found" with exit code 2.

Fixed to walk up 3 dirs to the actual repo root.

### Bug 2 — \`apm-builder/tests/integration/docker/test-runner.sh\` (auth detection)

Originally only checked for API key env vars. But the user's machine uses OAuth — keys live in \`~/.claude/.credentials.json\`, not env vars. The runner skipped everything even when the OAuth dir was mounted into the container.

Fixed to accept either an API key env var OR mounted OAuth credentials as valid auth.

## Test results (after fixes)

\`\`\`
=== ac docker test matrix ===
--- harness: claude ---
[PASS] 01-no-flags / 02-persona-only / 03-mode-only / 04-persona-and-mode / 05-no-filter
--- harness: codex ---
[PASS] 01-no-flags / 02-persona-only / 03-mode-only / 04-persona-and-mode / 05-no-filter
--- harness: gemini ---
[SKIP] gemini: no auth (no API key env var, no OAuth credentials mounted)
--- harness: pi ---
[PASS] 01-no-flags / 02-persona-only / 03-mode-only / 04-persona-and-mode / 05-no-filter

=== Results: 15 PASS | 0 FAIL | 5 SKIP ===
\`\`\`

15/15 active scenarios pass against real Claude Code, Codex, and Pi binaries with OAuth-mounted creds. Gemini skips (you don't have it configured locally — separate auth-setup task).

## Run command

\`\`\`bash
docker run --rm \
  -v ~/.claude:/root/.claude:ro \
  -v ~/.codex:/root/.codex:ro \
  agent-config-test
\`\`\`

(Add \`-e GEMINI_API_KEY\` or mount \`~/.gemini\` once you set Gemini up.)

## Test plan

- [x] Both fixes verified against real harnesses
- [x] 238 host tests still pass
- [x] No new tests required (the docker matrix IS the test for these bugs)