### PR TITLE
feat(plugins): add monorepo-profiles — atomic profile switching for Claude Code

### DIFF
--- a/plugins/monorepo-profiles/.claude-plugin/plugin.json
+++ b/plugins/monorepo-profiles/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "monorepo-profiles",
+  "version": "0.1.0",
+  "description": "Atomic per-monorepo profile switching: MCP servers, permissions, plugins, skills, agents, AGENTS.md fragments.",
+  "author": { "name": "dmestas" }
+}

--- a/plugins/monorepo-profiles/.claude-plugin/profile.schema.json
+++ b/plugins/monorepo-profiles/.claude-plugin/profile.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://example.invalid/monorepo-profiles/profile.schema.json",
+  "title": "monorepo-profiles profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+$",
+      "description": "Must equal the JSON filename stem."
+    },
+    "description": { "type": "string" },
+    "mcp_servers": {
+      "type": "object",
+      "description": "Same shape as .mcp.json's mcpServers. Profile fully owns this key.",
+      "additionalProperties": {
+        "type": "object",
+        "anyOf": [
+          { "required": ["command"] },
+          { "required": ["url"] }
+        ],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "url": { "type": "string" }
+        }
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": { "type": "array", "items": { "type": "string" } },
+        "deny":  { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[\\w-]+@[\\w-]+$",
+        "description": "Plugin id in the form 'name@marketplace'."
+      }
+    },
+    "local_skills": {
+      "type": "string",
+      "description": "Path relative to repo root pointing to a directory of skills."
+    },
+    "local_agents": {
+      "type": "string",
+      "description": "Path relative to repo root pointing to a directory of agents."
+    },
+    "instruction_fragments": {
+      "type": "array",
+      "description": "Supplementary fragments not on the CLAUDE.md cwd cascade.",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/plugins/monorepo-profiles/.gitignore
+++ b/plugins/monorepo-profiles/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+test/.tmp/

--- a/plugins/monorepo-profiles/README.md
+++ b/plugins/monorepo-profiles/README.md
@@ -1,0 +1,43 @@
+# monorepo-profiles
+
+Atomic profile switching for Claude Code in monorepos. Define a profile per
+sub-stack (frontend, backend), commit it, and `/profile switch <name>` swaps
+MCP servers, permissions, plugins, skills, agents, and supplementary
+instruction fragments.
+
+See `docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md` for the
+v0.1 design and `docs/superpowers/specs/2026-04-29-monorepo-profiles-v0.2-design.md`
+for v0.2 (`/profile validate`, `/profile diff`, JSON Schema, drift detail).
+
+## Repository placement
+
+This plugin lives under `agent-config/plugins/` but is **harness-specific by design** —
+unlike sibling skill bundles, it has no `SKILL.md`, is not transpiled by `apm-builder`,
+and ships only a Claude Code shell (`commands/`, `hooks/`, `bin/mr-profile.mjs`). The
+core script (`bin/mr-profile.mjs`) is harness-agnostic Node ESM and could be invoked
+from a Cursor/Codex/Gemini hook in the future, but no such adapters ship today.
+
+The standalone marketplace.json was removed when this plugin was vendored into
+`agent-config`; install it via the agent-config plugin pipeline (or copy the dir
+into `~/.claude/plugins/cache/` for local dev).
+
+## Editor schema setup (optional)
+
+The plugin ships a JSON Schema for profile files. To get autocomplete, hover docs,
+and typo detection in VS Code or Cursor, add to `.vscode/settings.json` in your
+monorepo:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".claude/profiles/*.json"],
+      "url": "/absolute/path/to/monorepo-profiles/.claude-plugin/profile.schema.json"
+    }
+  ]
+}
+```
+
+The plugin's install path is shown by `/plugin` in Claude Code. For team-shareable
+editor config, copy the schema into your repo (e.g. to `.claude/profile.schema.json`)
+and commit it.

--- a/plugins/monorepo-profiles/bin/mr-profile.mjs
+++ b/plugins/monorepo-profiles/bin/mr-profile.mjs
@@ -1,0 +1,649 @@
+#!/usr/bin/env node
+// monorepo-profiles CLI. Subcommands: switch, status, validate, diff, session-start.
+
+import { readFile, writeFile, symlink, lstat, unlink, readlink, stat, access } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+
+async function readJsonOrEmpty(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') return {};
+    throw e;
+  }
+}
+
+function renderMcpBytes(existing, profile) {
+  const next = { ...existing, mcpServers: profile.mcp_servers ?? {} };
+  return JSON.stringify(next, null, 2) + '\n';
+}
+
+function renderPermissionsBytes(existing, profile) {
+  const next = {
+    ...existing,
+    permissions: {
+      ...(existing.permissions ?? {}),
+      allow: profile.permissions?.allow ?? [],
+      deny:  profile.permissions?.deny  ?? []
+    }
+  };
+  return JSON.stringify(next, null, 2) + '\n';
+}
+
+export function diffMcpKeys(existing, profile) {
+  const have = existing.mcpServers ?? {};
+  const want = profile.mcp_servers ?? {};
+  const haveKeys = Object.keys(have);
+  const wantKeys = Object.keys(want);
+  const added = wantKeys.filter(k => !(k in have));
+  const removed = haveKeys.filter(k => !(k in want));
+  // JSON.stringify is order-sensitive: hand-edited .mcp.json with reordered keys
+  // will read as "changed" even when the value semantics match.
+  const changed = wantKeys
+    .filter(k => k in have)
+    .filter(k => JSON.stringify(have[k]) !== JSON.stringify(want[k]));
+  return { added, removed, changed };
+}
+
+export function diffPermissionKeys(existing, profile) {
+  const have = existing.permissions ?? {};
+  const want = profile.permissions ?? {};
+  const haveAllow = have.allow ?? [];
+  const wantAllow = want.allow ?? [];
+  const haveDeny = have.deny ?? [];
+  const wantDeny = want.deny ?? [];
+  return {
+    allowAdded:   wantAllow.filter(x => !haveAllow.includes(x)),
+    allowRemoved: haveAllow.filter(x => !wantAllow.includes(x)),
+    denyAdded:    wantDeny.filter(x => !haveDeny.includes(x)),
+    denyRemoved:  haveDeny.filter(x => !wantDeny.includes(x))
+  };
+}
+
+export function diffPluginKeys(currentSettings, prevProfile, newProfile) {
+  const current = { ...(currentSettings.enabledPlugins ?? {}) };
+  const projected = { ...current };
+  const newPlugins = newProfile.plugins ?? [];
+  const prevPlugins = prevProfile?.plugins ?? [];
+  for (const k of newPlugins) projected[k] = true;
+  for (const k of prevPlugins.filter(p => !newPlugins.includes(p))) delete projected[k];
+
+  const added = [];
+  const removed = [];
+  const allKeys = new Set([...Object.keys(current), ...Object.keys(projected)]);
+  for (const k of allKeys) {
+    const wasEnabled = current[k] === true;
+    const willBeEnabled = projected[k] === true;
+    if (wasEnabled && !willBeEnabled) removed.push(k);
+    else if (!wasEnabled && willBeEnabled) added.push(k);
+    // both true → no change; both falsy → no change
+  }
+  return { added, removed };
+}
+
+export function validateProfile(obj, expectedName) {
+  const errors = [];
+  if (typeof obj !== 'object' || obj === null) {
+    errors.push("profile must be a JSON object");
+    return errors;
+  }
+  if (typeof obj.name !== 'string') {
+    errors.push("missing or non-string 'name'");
+  } else if (obj.name !== expectedName) {
+    errors.push(`name '${obj.name}' does not match filename '${expectedName}'`);
+  }
+  return errors;
+}
+
+export async function loadProfile(repoRoot, name) {
+  const path = join(repoRoot, '.claude', 'profiles', `${name}.json`);
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      throw new Error(`profile '${name}' not found at ${path}`);
+    }
+    throw e;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`profile '${name}' has invalid JSON at ${path}: ${e.message}`);
+  }
+  const errors = validateProfile(parsed, name);
+  if (errors.length > 0) {
+    throw new Error(`profile '${name}' invalid: ${errors.join('; ')}`);
+  }
+  return parsed;
+}
+
+export async function applyMcp(repoRoot, profile) {
+  const path = join(repoRoot, '.mcp.json');
+  const existing = await readJsonOrEmpty(path);
+  await writeFile(path, renderMcpBytes(existing, profile));
+}
+
+export async function applyPermissions(repoRoot, profile) {
+  const path = join(repoRoot, '.claude', 'settings.local.json');
+  const existing = await readJsonOrEmpty(path);
+  await writeFile(path, renderPermissionsBytes(existing, profile));
+}
+
+export async function applyPlugins(homeClaudeDir, prevProfile, newProfile) {
+  const path = join(homeClaudeDir, 'settings.json');
+  const settings = await readJsonOrEmpty(path);
+  const enabled = { ...(settings.enabledPlugins ?? {}) };
+
+  const toEnable  = newProfile.plugins ?? [];
+  const prevPlugins = prevProfile?.plugins ?? [];
+  const toDisable = prevPlugins.filter(p => !toEnable.includes(p));
+
+  for (const k of toEnable) enabled[k] = true;
+  for (const k of toDisable) delete enabled[k];
+
+  const next = { ...settings, enabledPlugins: enabled };
+  await writeFile(path, JSON.stringify(next, null, 2) + '\n');
+}
+
+async function safeSymlink(target, linkPath) {
+  try {
+    const st = await lstat(linkPath);
+    if (!st.isSymbolicLink()) {
+      throw new Error(`refusing to replace non-symlink at ${linkPath}; remove manually`);
+    }
+    await unlink(linkPath);
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  await symlink(target, linkPath);
+}
+
+export async function applySymlinks(homeClaudeDir, repoRoot, profile) {
+  if (profile.local_skills) {
+    await safeSymlink(
+      join(repoRoot, profile.local_skills),
+      join(homeClaudeDir, 'skills', profile.name)
+    );
+  }
+  if (profile.local_agents) {
+    await safeSymlink(
+      join(repoRoot, profile.local_agents),
+      join(homeClaudeDir, 'agents', profile.name)
+    );
+  }
+}
+
+export async function renderInstructions(repoRoot, profile) {
+  const fragments = profile.instruction_fragments ?? [];
+  const parts = [];
+  for (const rel of fragments) {
+    const full = join(repoRoot, rel);
+    try {
+      parts.push(await readFile(full, 'utf8'));
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        process.stderr.write(`warning: instruction fragment not found, skipping: ${full}\n`);
+        continue;
+      }
+      throw e;
+    }
+  }
+  return parts.join('\n\n---\n\n');
+}
+
+export async function readActiveProfileName(repoRoot) {
+  try {
+    const txt = await readFile(join(repoRoot, '.claude', 'active-profile'), 'utf8');
+    const name = txt.trim();
+    return name || null;
+  } catch (e) {
+    if (e.code === 'ENOENT') return null;
+    throw e;
+  }
+}
+
+export async function cmdSessionStart({ repoRoot, homeClaudeDir, stdout = process.stdout }) {
+  const name = await readActiveProfileName(repoRoot);
+  if (!name) return 0;
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    process.stderr.write(`session-start: ${e.message}\n`);
+    return 0;
+  }
+  let text;
+  try {
+    text = await renderInstructions(repoRoot, profile);
+  } catch (e) {
+    process.stderr.write(`session-start: failed to render instruction fragments: ${e.message}\n`);
+    return 0;
+  }
+  if (!text) return 0;
+  const out = {
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: text }
+  };
+  stdout.write(JSON.stringify(out));
+  return 0;
+}
+
+function sha(s) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+async function readOrEmpty(path) {
+  try { return await readFile(path, 'utf8'); }
+  catch (e) { if (e.code === 'ENOENT') return ''; throw e; }
+}
+
+export async function cmdStatus({ repoRoot, homeClaudeDir, stdout = process.stdout }) {
+  const name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stdout.write('no active profile (run /profile switch <name>)\n');
+    return 0;
+  }
+  const profile = await loadProfile(repoRoot, name);
+
+  const lines = [`active profile: ${name}`];
+  let anyDrift = false;
+
+  const driftLabel = (sha1, sha2, keyCount) => {
+    if (sha1 === sha2) return '✓';
+    anyDrift = true;
+    if (keyCount === 0) return '✗ drifted (formatting only)';
+    return `✗ drifted (${keyCount} key${keyCount === 1 ? ' differs' : 's differ'})`;
+  };
+
+  // .mcp.json
+  const mcpPath = join(repoRoot, '.mcp.json');
+  const mcpOnDisk = await readOrEmpty(mcpPath);
+  const mcpExisting = await readJsonOrEmpty(mcpPath);
+  const mcpExpected = renderMcpBytes(mcpExisting, profile);
+  const mcpDiff = diffMcpKeys(mcpExisting, profile);
+  const mcpKeyCount = mcpDiff.added.length + mcpDiff.removed.length + mcpDiff.changed.length;
+  lines.push(`.mcp.json: ${driftLabel(sha(mcpOnDisk), sha(mcpExpected), mcpKeyCount)}`);
+
+  // settings.local.json
+  const permsPath = join(repoRoot, '.claude', 'settings.local.json');
+  const permsOnDisk = await readOrEmpty(permsPath);
+  const permsExisting = await readJsonOrEmpty(permsPath);
+  const permsExpected = renderPermissionsBytes(permsExisting, profile);
+  const permsDiff = diffPermissionKeys(permsExisting, profile);
+  const permsKeyCount = permsDiff.allowAdded.length + permsDiff.allowRemoved.length
+                      + permsDiff.denyAdded.length + permsDiff.denyRemoved.length;
+  lines.push(`settings.local.json: ${driftLabel(sha(permsOnDisk), sha(permsExpected), permsKeyCount)}`);
+
+  // enabledPlugins (presence-only check, unchanged label semantics from v0.1)
+  const settingsPath = join(homeClaudeDir, 'settings.json');
+  const settingsExisting = await readJsonOrEmpty(settingsPath);
+  const expectedKeys = profile.plugins ?? [];
+  const enabledOk = expectedKeys.every(k => settingsExisting.enabledPlugins?.[k] === true);
+  if (!enabledOk) anyDrift = true;
+  lines.push(`enabledPlugins: ${enabledOk ? '✓ all required present' : '✗ missing required'}`);
+
+  // symlinks
+  const checkSym = async (link, expectedTarget) => {
+    if (!expectedTarget) return '— (not in profile)';
+    try {
+      const st = await lstat(link);
+      if (!st.isSymbolicLink()) { anyDrift = true; return '✗ not a symlink'; }
+      const t = await readlink(link);
+      if (t === expectedTarget) return '✓';
+      anyDrift = true;
+      return '✗ wrong target';
+    } catch (e) {
+      if (e.code === 'ENOENT') { anyDrift = true; return '✗ missing'; }
+      throw e;
+    }
+  };
+  const skillLink = join(homeClaudeDir, 'skills', name);
+  const agentLink = join(homeClaudeDir, 'agents', name);
+  lines.push(`skills symlink: ${await checkSym(skillLink, profile.local_skills && join(repoRoot, profile.local_skills))}`);
+  lines.push(`agents symlink: ${await checkSym(agentLink, profile.local_agents && join(repoRoot, profile.local_agents))}`);
+
+  stdout.write(lines.join('\n') + '\n');
+  if (anyDrift) stdout.write('\nRun /profile diff for details.\n');
+  return 0;
+}
+
+async function pathExists(p) {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function validateProfileExtended(repoRoot, profile) {
+  const issues = [];
+  // mcp servers must have command or url
+  // Mirror of profile.schema.json — keep in sync.
+  for (const [name, entry] of Object.entries(profile.mcp_servers ?? {})) {
+    const hasCommand = typeof entry?.command === 'string' && entry.command.length > 0;
+    const hasUrl = typeof entry?.url === 'string' && entry.url.length > 0;
+    if (!hasCommand && !hasUrl) {
+      issues.push({ level: 'error', message: `mcp_servers.${name}: missing 'command' or 'url'` });
+    }
+  }
+  // plugin id pattern
+  // Mirror of profile.schema.json — keep in sync.
+  const pluginRe = /^[\w-]+@[\w-]+$/;
+  for (const [i, p] of (profile.plugins ?? []).entries()) {
+    if (typeof p !== 'string' || !pluginRe.test(p)) {
+      issues.push({ level: 'warn', message: `plugins[${i}]: '${p}' does not match 'name@marketplace' pattern` });
+    }
+  }
+  // fragment paths exist
+  for (const [i, frag] of (profile.instruction_fragments ?? []).entries()) {
+    if (!await pathExists(join(repoRoot, frag))) {
+      issues.push({ level: 'warn', message: `instruction_fragments[${i}]: '${frag}' does not exist` });
+    }
+  }
+  // local_skills / local_agents source dirs exist
+  for (const field of ['local_skills', 'local_agents']) {
+    const path = profile[field];
+    if (path && !await pathExists(join(repoRoot, path))) {
+      issues.push({ level: 'error', message: `${field}: '${path}' does not exist (apply would create a dangling symlink)` });
+    }
+  }
+  return issues;
+}
+
+function summarizeProfile(profile) {
+  const parts = [];
+  const numPlugins = (profile.plugins ?? []).length;
+  if (numPlugins) parts.push(`${numPlugins} plugin${numPlugins === 1 ? '' : 's'}`);
+  const numMcp = Object.keys(profile.mcp_servers ?? {}).length;
+  if (numMcp) parts.push(`${numMcp} mcp server${numMcp === 1 ? '' : 's'}`);
+  const numFrag = (profile.instruction_fragments ?? []).length;
+  if (numFrag) parts.push(`${numFrag} fragment${numFrag === 1 ? '' : 's'}`);
+  if (profile.local_skills) parts.push('skills');
+  if (profile.local_agents) parts.push('agents');
+  return parts.length ? `(${parts.join(', ')})` : '';
+}
+
+export async function cmdValidate({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  const explicit = !!name;
+  if (!name) name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  if (!explicit) stdout.write(`Using active profile '${name}'.\n`);
+
+  const issues = await validateProfileExtended(repoRoot, profile);
+  const errors = issues.filter(i => i.level === 'error');
+  const warnings = issues.filter(i => i.level === 'warn');
+
+  if (errors.length === 0 && warnings.length === 0) {
+    const summary = summarizeProfile(profile);
+    stdout.write(`Profile '${name}': ✓ valid${summary ? ' ' + summary : ''}\n`);
+    return 0;
+  }
+
+  const e = errors.length, w = warnings.length;
+  stdout.write(`Profile '${name}': ✗ ${e} error${e === 1 ? '' : 's'}, ${w} warning${w === 1 ? '' : 's'}\n`);
+  for (const issue of issues) {
+    const tag = issue.level === 'error' ? 'ERROR' : 'WARN ';
+    stdout.write(`  ${tag}  ${issue.message}\n`);
+  }
+  return errors.length > 0 ? 1 : 0;
+}
+
+export async function cmdDiff({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  const explicit = !!name;
+  if (!name) name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  // prev profile for plugin projection
+  const activeName = await readActiveProfileName(repoRoot);
+  let prevProfile = null;
+  if (activeName && activeName !== name) {
+    try { prevProfile = await loadProfile(repoRoot, activeName); } catch { /* ignore — treat as null */ }
+  } else if (activeName === name) {
+    prevProfile = profile;
+  }
+
+  if (!explicit) stdout.write(`Using active profile '${name}'.\n`);
+  stdout.write(`\nDiff for profile '${name}' (vs current state):\n\n`);
+
+  let anyChange = false;
+
+  // .mcp.json
+  const mcpPath = join(repoRoot, '.mcp.json');
+  const mcpExisting = await readJsonOrEmpty(mcpPath);
+  const mcpDiff = diffMcpKeys(mcpExisting, profile);
+  stdout.write('.mcp.json:\n');
+  if (mcpDiff.added.length + mcpDiff.removed.length + mcpDiff.changed.length === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const k of mcpDiff.added)   stdout.write(`  + mcpServers.${k}\n`);
+    for (const k of mcpDiff.removed) stdout.write(`  - mcpServers.${k}\n`);
+    for (const k of mcpDiff.changed) stdout.write(`  ~ mcpServers.${k}   (content differs)\n`);
+  }
+  stdout.write('\n');
+
+  // settings.local.json
+  const permsPath = join(repoRoot, '.claude', 'settings.local.json');
+  const permsExisting = await readJsonOrEmpty(permsPath);
+  const permsDiff = diffPermissionKeys(permsExisting, profile);
+  stdout.write('.claude/settings.local.json:\n');
+  const permsTotal = permsDiff.allowAdded.length + permsDiff.allowRemoved.length
+                   + permsDiff.denyAdded.length + permsDiff.denyRemoved.length;
+  if (permsTotal === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const x of permsDiff.allowAdded)   stdout.write(`  + permissions.allow: '${x}'\n`);
+    for (const x of permsDiff.allowRemoved) stdout.write(`  - permissions.allow: '${x}'\n`);
+    for (const x of permsDiff.denyAdded)    stdout.write(`  + permissions.deny: '${x}'\n`);
+    for (const x of permsDiff.denyRemoved)  stdout.write(`  - permissions.deny: '${x}'\n`);
+  }
+  stdout.write('\n');
+
+  // enabledPlugins
+  const settingsPath = join(homeClaudeDir, 'settings.json');
+  const settings = await readJsonOrEmpty(settingsPath);
+  const pluginDiff = diffPluginKeys(settings, prevProfile, profile);
+  stdout.write('~/.claude/settings.json (enabledPlugins):\n');
+  if (pluginDiff.added.length + pluginDiff.removed.length === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const k of pluginDiff.added)   stdout.write(`  + ${k}\n`);
+    for (const k of pluginDiff.removed) stdout.write(`  - ${k}\n`);
+  }
+  stdout.write('\n');
+
+  // symlinks
+  const reportSymlink = async (label, link, expectedTarget) => {
+    stdout.write(`${label}:\n`);
+    if (!expectedTarget) { stdout.write('  — (not in profile)\n\n'); return; }
+    try {
+      const st = await lstat(link);
+      if (!st.isSymbolicLink()) {
+        anyChange = true;
+        stdout.write(`  ✗ is not a symlink (cannot replace non-symlink at this path; remove manually)\n\n`);
+        return;
+      }
+      const t = await readlink(link);
+      if (t === expectedTarget) {
+        stdout.write('  ✓ matches\n\n');
+      } else {
+        anyChange = true;
+        stdout.write(`  ~ wrong target: was '${t}', expected '${expectedTarget}'\n\n`);
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        anyChange = true;
+        stdout.write(`  + would create symlink → ${expectedTarget}\n\n`);
+        return;
+      }
+      throw e;
+    }
+  };
+  await reportSymlink(
+    `~/.claude/skills/${name}`,
+    join(homeClaudeDir, 'skills', name),
+    profile.local_skills && join(repoRoot, profile.local_skills)
+  );
+  await reportSymlink(
+    `~/.claude/agents/${name}`,
+    join(homeClaudeDir, 'agents', name),
+    profile.local_agents && join(repoRoot, profile.local_agents)
+  );
+
+  // active-profile
+  const currActive = await readActiveProfileName(repoRoot);
+  stdout.write('.claude/active-profile:\n');
+  if (currActive === name) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    stdout.write(`  ~ was '${currActive ?? '(none)'}', expected '${name}'\n`);
+  }
+  stdout.write('\n');
+
+  if (anyChange) {
+    stdout.write(`Run /profile switch ${name} to apply.\n`);
+  } else {
+    stdout.write('No changes.\n');
+  }
+  return 0;
+}
+
+export async function writeActiveProfile(repoRoot, name) {
+  await writeFile(join(repoRoot, '.claude', 'active-profile'), name + '\n');
+}
+
+export async function applyAll({ repoRoot, homeClaudeDir, profile, prevProfile }) {
+  await applyMcp(repoRoot, profile);
+  await applySymlinks(homeClaudeDir, repoRoot, profile);
+  await applyPermissions(repoRoot, profile);
+  await applyPlugins(homeClaudeDir, prevProfile, profile);
+  await writeActiveProfile(repoRoot, profile.name);
+  return 0;
+}
+
+export async function cmdSwitch({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  const prevName = await readActiveProfileName(repoRoot);
+  let prevProfile = null;
+  if (prevName && prevName !== name) {
+    try {
+      prevProfile = await loadProfile(repoRoot, prevName);
+    } catch (e) {
+      stderr.write(`warning: previous profile '${prevName}' could not be loaded (${e.message}); plugin removals skipped\n`);
+    }
+  }
+
+  await applyAll({ repoRoot, homeClaudeDir, profile, prevProfile });
+  stdout.write(
+    `Profile '${name}' applied. Restart Claude Code (Ctrl-D, then \`claude\`) to load plugins/MCP.\n`
+  );
+  return 0;
+}
+
+export async function findRepoRoot(start) {
+  let dir = resolve(start);
+  while (true) {
+    try {
+      const st = await stat(join(dir, '.claude', 'profiles'));
+      if (st.isDirectory()) return dir;
+    } catch {}
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`no .claude/profiles/ found in any parent of ${start}`);
+    }
+    dir = parent;
+  }
+}
+
+const USAGE = `usage:
+  mr-profile switch <name>
+  mr-profile status
+  mr-profile validate [name]
+  mr-profile diff [name]
+  mr-profile session-start
+`;
+
+export async function main(argv, env, io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  const [sub, ...rest] = argv;
+
+  const knownSubs = new Set(['switch', 'status', 'validate', 'diff', 'session-start']);
+  if (!knownSubs.has(sub)) {
+    stderr.write(USAGE);
+    return 2;
+  }
+  if (sub === 'switch' && !rest[0]) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let repoRoot;
+  try {
+    repoRoot = await findRepoRoot(process.cwd());
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+  const home = (env && env.HOME) || homedir();
+  const homeClaudeDir = join(home, '.claude');
+
+  switch (sub) {
+    case 'switch':
+      return await cmdSwitch({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'status':
+      return await cmdStatus({ repoRoot, homeClaudeDir, stdout });
+    case 'validate':
+      return await cmdValidate({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'diff':
+      return await cmdDiff({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'session-start':
+      return await cmdSessionStart({ repoRoot, homeClaudeDir, stdout });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const code = await main(process.argv.slice(2), process.env);
+  process.exit(code);
+}

--- a/plugins/monorepo-profiles/commands/profile.md
+++ b/plugins/monorepo-profiles/commands/profile.md
@@ -1,0 +1,17 @@
+---
+description: Manage monorepo profiles. Subcommands: switch, status, validate, diff.
+argument-hint: switch <name> | status | validate [name] | diff [name]
+---
+
+You are dispatching the `/profile` slash command.
+
+The user invoked: `/profile $ARGUMENTS`
+
+Run the following bash command, then paste its full stdout/stderr to the user verbatim. Do not interpret or rewrite the output.
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/bin/mr-profile.mjs" $ARGUMENTS
+```
+
+If the command exits non-zero, surface the error message exactly as printed.
+After a successful `switch`, the script prints a restart instruction — show it to the user prominently.

--- a/plugins/monorepo-profiles/docs/superpowers/plans/2026-04-29-monorepo-profiles-v0.2.md
+++ b/plugins/monorepo-profiles/docs/superpowers/plans/2026-04-29-monorepo-profiles-v0.2.md
@@ -1,0 +1,1427 @@
+# monorepo-profiles v0.2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `/profile validate`, `/profile diff`, drift-count detail in `/profile status`, and a JSON Schema for profile authoring.
+
+**Architecture:** Three private key-diff helpers (mcp, permissions, plugins via state-projection) become the shared computation engine for the new `cmdValidate`, the new `cmdDiff`, and the existing `cmdStatus`'s drift count. Same single-file Node ESM script (`bin/mr-profile.mjs`); no new modules, no deps. JSON Schema ships in `.claude-plugin/` and is wired in via README guidance — no `$schema` field added to user profiles.
+
+**Tech Stack:** Node 20+ ESM, `node:test`, `node:assert`, `node:fs/promises`, `node:crypto`. Same as v0.1.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-monorepo-profiles-v0.2-design.md`
+**Predecessor plan:** `docs/superpowers/plans/2026-04-29-monorepo-profiles.md` (v0.1)
+
+---
+
+## File Structure
+
+```
+bin/mr-profile.mjs                          # +~120 LOC (helpers + cmdValidate + cmdDiff + status updates + main dispatch)
+test/mr-profile.test.mjs                    # +~150 LOC (10 new tests)
+.claude-plugin/profile.schema.json          # NEW (~50 LOC)
+README.md                                   # +1 section (Editor schema setup)
+commands/profile.md                         # tweak: argument-hint frontmatter mentions validate/diff
+```
+
+## Internal Function Inventory (additions)
+
+| Function | Inputs | Output / side effects | Visibility |
+|---|---|---|---|
+| `diffMcpKeys(existing, profile)` | parsed `.mcp.json` object, profile | `{added: string[], removed: string[], changed: string[]}` | private |
+| `diffPermissionKeys(existing, profile)` | parsed settings.local.json, profile | `{allowAdded, allowRemoved, denyAdded, denyRemoved}` | private |
+| `diffPluginKeys(currentSettings, prevProfile, newProfile)` | parsed ~/.claude/settings.json, profile-or-null, profile | `{added: string[], removed: string[]}` (state-projection) | private |
+| `validateProfileExtended(repoRoot, profile)` | repo path, loaded profile | `{level: 'error'|'warn', message: string}[]` | private |
+| `cmdValidate({repoRoot, homeClaudeDir, name, stdout, stderr})` | options | exit 0 / 1 / 2; report on stdout | exported |
+| `cmdDiff({repoRoot, homeClaudeDir, name, stdout, stderr})` | options | exit 0 / 1 / 2; report on stdout | exported |
+
+Shared utility (already exists, no change): `loadProfile`, `readActiveProfileName`, `readJsonOrEmpty`, `readOrEmpty`, `sha`, `renderMcpBytes`, `renderPermissionsBytes`.
+
+---
+
+## Phase A: Key-diff helpers (foundation)
+
+These three private helpers are reused by `cmdStatus` (count only), `cmdDiff` (full key list), and `cmdValidate` (none directly, but it uses the same data shapes for output). Building them first means later phases just call them.
+
+### Task A.1: `diffMcpKeys(existing, profile)`
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Write the failing tests (append to test file)**
+
+```js
+import { diffMcpKeys } from '../bin/mr-profile.mjs';
+
+test('diffMcpKeys: detects added, removed, changed', () => {
+  const existing = { mcpServers: { signoz: { command: 'old' }, github: { command: 'gh' } } };
+  const profile = { mcp_servers: { signoz: { command: 'new' }, playwright: { command: 'pw' } } };
+  const d = diffMcpKeys(existing, profile);
+  assert.deepEqual(d.added, ['playwright']);
+  assert.deepEqual(d.removed, ['github']);
+  assert.deepEqual(d.changed, ['signoz']);
+});
+
+test('diffMcpKeys: empty existing yields all profile keys as added', () => {
+  const d = diffMcpKeys({}, { mcp_servers: { signoz: { command: 'x' } } });
+  assert.deepEqual(d.added, ['signoz']);
+  assert.deepEqual(d.removed, []);
+  assert.deepEqual(d.changed, []);
+});
+
+test('diffMcpKeys: identical existing and profile yields all empty', () => {
+  const same = { mcpServers: { signoz: { command: 'x' } } };
+  const profile = { mcp_servers: { signoz: { command: 'x' } } };
+  const d = diffMcpKeys(same, profile);
+  assert.deepEqual(d.added, []);
+  assert.deepEqual(d.removed, []);
+  assert.deepEqual(d.changed, []);
+});
+```
+
+- [ ] **Step 2: Run tests, verify red**
+
+Run: `cd /Users/dmestas/projects/monorepo-profiles && npm test`
+Expected: failure mentioning `diffMcpKeys` not exported.
+
+- [ ] **Step 3: Implement helper in `bin/mr-profile.mjs`** (place near other render helpers)
+
+```js
+export function diffMcpKeys(existing, profile) {
+  const have = existing.mcpServers ?? {};
+  const want = profile.mcp_servers ?? {};
+  const haveKeys = Object.keys(have);
+  const wantKeys = Object.keys(want);
+  const added = wantKeys.filter(k => !(k in have));
+  const removed = haveKeys.filter(k => !(k in want));
+  const changed = wantKeys
+    .filter(k => k in have)
+    .filter(k => JSON.stringify(have[k]) !== JSON.stringify(want[k]));
+  return { added, removed, changed };
+}
+```
+
+The function is `export`ed (not private) so tests can import it. It's exported but not part of the user-facing CLI surface — that's fine for our single-file convention.
+
+- [ ] **Step 4: Run tests, verify green**
+
+Expected: 38 tests passing (35 prior + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(diff): diffMcpKeys helper for added/removed/changed servers"
+```
+
+---
+
+### Task A.2: `diffPermissionKeys(existing, profile)`
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import { diffPermissionKeys } from '../bin/mr-profile.mjs';
+
+test('diffPermissionKeys: returns set diffs over allow and deny arrays', () => {
+  const existing = { permissions: { allow: ['Bash(npm *)', 'Bash(go *)'], deny: ['Bash(rm -rf *)'] } };
+  const profile  = { permissions: { allow: ['Bash(go *)', 'Bash(docker *)'], deny: ['Bash(rm -rf *)', 'Bash(kubectl delete *)'] } };
+  const d = diffPermissionKeys(existing, profile);
+  assert.deepEqual(d.allowAdded.sort(), ['Bash(docker *)']);
+  assert.deepEqual(d.allowRemoved.sort(), ['Bash(npm *)']);
+  assert.deepEqual(d.denyAdded.sort(), ['Bash(kubectl delete *)']);
+  assert.deepEqual(d.denyRemoved, []);
+});
+
+test('diffPermissionKeys: tolerates missing fields', () => {
+  const d = diffPermissionKeys({}, { permissions: { allow: ['x'] } });
+  assert.deepEqual(d.allowAdded, ['x']);
+  assert.deepEqual(d.allowRemoved, []);
+  assert.deepEqual(d.denyAdded, []);
+  assert.deepEqual(d.denyRemoved, []);
+});
+```
+
+- [ ] **Step 2: Run tests, verify red**
+
+- [ ] **Step 3: Implement helper**
+
+```js
+export function diffPermissionKeys(existing, profile) {
+  const have = existing.permissions ?? {};
+  const want = profile.permissions ?? {};
+  const haveAllow = have.allow ?? [];
+  const wantAllow = want.allow ?? [];
+  const haveDeny = have.deny ?? [];
+  const wantDeny = want.deny ?? [];
+  return {
+    allowAdded:   wantAllow.filter(x => !haveAllow.includes(x)),
+    allowRemoved: haveAllow.filter(x => !wantAllow.includes(x)),
+    denyAdded:    wantDeny.filter(x => !haveDeny.includes(x)),
+    denyRemoved:  haveDeny.filter(x => !wantDeny.includes(x))
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify green** (40 tests passing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(diff): diffPermissionKeys helper over allow/deny arrays"
+```
+
+---
+
+### Task A.3: `diffPluginKeys(currentSettings, prevProfile, newProfile)` via state projection
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+This is the Ousterhout-fixed projection approach. Rather than profile-vs-profile diff, we project current `enabledPlugins` forward through apply and diff current vs projected. Re-applying the active profile correctly produces an empty diff.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import { diffPluginKeys } from '../bin/mr-profile.mjs';
+
+test('diffPluginKeys: first switch — current empty, prev null, new has 3', () => {
+  const current = {};
+  const newP = { plugins: ['a@m', 'b@m', 'c@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, null, newP);
+  assert.deepEqual(d.added.sort(), ['a@m', 'b@m', 'c@m']);
+  assert.deepEqual(d.removed, []);
+});
+
+test('diffPluginKeys: switch fe -> be with overlap', () => {
+  // current already reflects fe state, plus an unrelated plugin
+  const current = { 'fe-only@m': true, 'shared@m': true, 'unrelated@m': true };
+  const fe = { plugins: ['fe-only@m', 'shared@m'] };
+  const be = { plugins: ['shared@m', 'be-only@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, fe, be);
+  assert.deepEqual(d.added, ['be-only@m']);
+  assert.deepEqual(d.removed, ['fe-only@m']);
+  // 'shared@m' and 'unrelated@m' should not appear
+});
+
+test('diffPluginKeys: re-applying active profile yields empty diff', () => {
+  const current = { 'a@m': true, 'b@m': true };
+  const same = { plugins: ['a@m', 'b@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, same, same);
+  assert.deepEqual(d.added, []);
+  assert.deepEqual(d.removed, []);
+});
+
+test('diffPluginKeys: unrelated user-enabled plugin is preserved (not in diff)', () => {
+  const current = { 'unrelated@m': true };
+  const newP = { plugins: ['target@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, null, newP);
+  assert.deepEqual(d.added, ['target@m']);
+  assert.deepEqual(d.removed, []);
+});
+```
+
+- [ ] **Step 2: Run tests, verify red**
+
+- [ ] **Step 3: Implement helper**
+
+```js
+export function diffPluginKeys(currentSettings, prevProfile, newProfile) {
+  const current = { ...(currentSettings.enabledPlugins ?? {}) };
+  const projected = { ...current };
+  const newPlugins = newProfile.plugins ?? [];
+  const prevPlugins = prevProfile?.plugins ?? [];
+  for (const k of newPlugins) projected[k] = true;
+  for (const k of prevPlugins.filter(p => !newPlugins.includes(p))) delete projected[k];
+
+  const added = [];
+  const removed = [];
+  const allKeys = new Set([...Object.keys(current), ...Object.keys(projected)]);
+  for (const k of allKeys) {
+    const wasEnabled = current[k] === true;
+    const willBeEnabled = projected[k] === true;
+    if (wasEnabled && !willBeEnabled) removed.push(k);
+    else if (!wasEnabled && willBeEnabled) added.push(k);
+    // both true → no change; both falsy → no change
+  }
+  return { added, removed };
+}
+```
+
+- [ ] **Step 4: Run tests, verify green** (44 tests passing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(diff): diffPluginKeys via state projection (current vs post-apply)"
+```
+
+---
+
+## Phase B: `cmdValidate`
+
+### Task B.1: `cmdValidate` with valid summary output
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { cmdValidate } from '../bin/mr-profile.mjs';
+
+test('cmdValidate: valid backend profile prints summary and exits 0', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Profile 'backend': ✓ valid/);
+    assert.match(out, /2 plugins/);
+    assert.match(out, /1 mcp server/);
+    assert.match(out, /1 fragment/);
+    assert.match(out, /skills/);
+    assert.match(out, /agents/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+(Note: backend fixture has 2 plugins, 1 mcp server, 1 fragment, local_skills + local_agents.)
+
+- [ ] **Step 2: Run test, verify red**
+
+- [ ] **Step 3: Implement `validateProfileExtended` helper and `cmdValidate`**
+
+Add to `bin/mr-profile.mjs`. The helper produces an issue list; `cmdValidate` formats it. Place above `cmdValidate`.
+
+```js
+import { access } from 'node:fs/promises';
+
+async function pathExists(p) {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function validateProfileExtended(repoRoot, profile) {
+  const issues = [];
+  // mcp servers must have command or url
+  for (const [name, entry] of Object.entries(profile.mcp_servers ?? {})) {
+    const hasCommand = typeof entry?.command === 'string' && entry.command.length > 0;
+    const hasUrl = typeof entry?.url === 'string' && entry.url.length > 0;
+    if (!hasCommand && !hasUrl) {
+      issues.push({ level: 'error', message: `mcp_servers.${name}: missing 'command' or 'url'` });
+    }
+  }
+  // plugin id pattern
+  const pluginRe = /^[\w-]+@[\w-]+$/;
+  for (const [i, p] of (profile.plugins ?? []).entries()) {
+    if (typeof p !== 'string' || !pluginRe.test(p)) {
+      issues.push({ level: 'warn', message: `plugins[${i}]: '${p}' does not match 'name@marketplace' pattern` });
+    }
+  }
+  // fragment paths exist
+  for (const [i, frag] of (profile.instruction_fragments ?? []).entries()) {
+    if (!await pathExists(join(repoRoot, frag))) {
+      issues.push({ level: 'warn', message: `instruction_fragments[${i}]: '${frag}' does not exist` });
+    }
+  }
+  // local_skills / local_agents source dirs exist
+  for (const field of ['local_skills', 'local_agents']) {
+    const path = profile[field];
+    if (path && !await pathExists(join(repoRoot, path))) {
+      issues.push({ level: 'warn', message: `${field}: '${path}' does not exist` });
+    }
+  }
+  return issues;
+}
+
+function summarizeProfile(profile) {
+  const parts = [];
+  const numPlugins = (profile.plugins ?? []).length;
+  if (numPlugins) parts.push(`${numPlugins} plugin${numPlugins === 1 ? '' : 's'}`);
+  const numMcp = Object.keys(profile.mcp_servers ?? {}).length;
+  if (numMcp) parts.push(`${numMcp} mcp server${numMcp === 1 ? '' : 's'}`);
+  const numFrag = (profile.instruction_fragments ?? []).length;
+  if (numFrag) parts.push(`${numFrag} fragment${numFrag === 1 ? '' : 's'}`);
+  if (profile.local_skills) parts.push('skills');
+  if (profile.local_agents) parts.push('agents');
+  return parts.length ? `(${parts.join(', ')})` : '';
+}
+
+export async function cmdValidate({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  const explicit = !!name;
+  if (!name) name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  if (!explicit) stdout.write(`Using active profile '${name}'.\n`);
+
+  const issues = await validateProfileExtended(repoRoot, profile);
+  const errors = issues.filter(i => i.level === 'error');
+  const warnings = issues.filter(i => i.level === 'warn');
+
+  if (errors.length === 0 && warnings.length === 0) {
+    const summary = summarizeProfile(profile);
+    stdout.write(`Profile '${name}': ✓ valid${summary ? ' ' + summary : ''}\n`);
+    return 0;
+  }
+
+  const e = errors.length, w = warnings.length;
+  stdout.write(`Profile '${name}': ✗ ${e} error${e === 1 ? '' : 's'}, ${w} warning${w === 1 ? '' : 's'}\n`);
+  for (const issue of issues) {
+    const tag = issue.level === 'error' ? 'ERROR' : 'WARN ';
+    stdout.write(`  ${tag}  ${issue.message}\n`);
+  }
+  return errors.length > 0 ? 1 : 0;
+}
+```
+
+`USAGE` already exists in the file (defined for `main` in v0.1). It will need to be updated in Phase E.1 to mention validate/diff but for now `USAGE` is whatever it currently says.
+
+- [ ] **Step 4: Run test, verify green** (45 tests passing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(validate): cmdValidate with valid-summary output"
+```
+
+---
+
+### Task B.2: `cmdValidate` reports errors (mcp missing command/url)
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+test('cmdValidate: mcp server entry missing command and url is an ERROR (exit 1)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Create an ad-hoc profile with a broken mcp_servers entry
+    await writeFile(join(repo, '.claude', 'profiles', 'broken.json'), JSON.stringify({
+      name: 'broken',
+      mcp_servers: { dud: { args: ['nope'] } }
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'broken', stdout });
+    assert.equal(code, 1);
+    const out = lines.join('');
+    assert.match(out, /Profile 'broken': ✗ 1 error/);
+    assert.match(out, /ERROR\s+mcp_servers\.dud: missing 'command' or 'url'/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect green**
+
+Implementation in B.1 already covers this. If a test fails, fix in `validateProfileExtended`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(validate): mcp missing command/url reports ERROR"
+```
+
+---
+
+### Task B.3: `cmdValidate` reports warnings (bad plugin id, missing fragment, missing dirs)
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+test('cmdValidate: invalid plugin id is a WARN (exit 0)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'profiles', 'wonky.json'), JSON.stringify({
+      name: 'wonky',
+      plugins: ['gopls-lsp', 'good@m'] // first lacks @marketplace
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'wonky', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Profile 'wonky': ✗ 0 errors, 1 warning/);
+    assert.match(out, /WARN\s+plugins\[0\]: 'gopls-lsp' does not match/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: missing instruction_fragments and local_skills/agents dirs each WARN', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'profiles', 'paths.json'), JSON.stringify({
+      name: 'paths',
+      instruction_fragments: ['nope/never.md'],
+      local_skills: 'nonexistent/skills',
+      local_agents: 'nonexistent/agents'
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'paths', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /3 warnings/);
+    assert.match(out, /WARN\s+instruction_fragments\[0\]: 'nope\/never\.md' does not exist/);
+    assert.match(out, /WARN\s+local_skills: 'nonexistent\/skills' does not exist/);
+    assert.match(out, /WARN\s+local_agents: 'nonexistent\/agents' does not exist/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run tests, expect green** (B.1's implementation covers all warnings)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(validate): bad plugin id and missing paths report WARN"
+```
+
+---
+
+### Task B.4: `cmdValidate` name resolution + USAGE fallback
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+test('cmdValidate: defaults to active profile when name omitted', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Using active profile 'backend'\./);
+    assert.match(out, /Profile 'backend': ✓ valid/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: no name and no active-profile returns 2 with USAGE', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run tests, expect green** (B.1's implementation already handles both)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(validate): active-profile fallback and USAGE on missing name"
+```
+
+Acceptance check: v0.2-AC-1, v0.2-AC-2 covered by Tasks B.1–B.4.
+
+---
+
+## Phase C: `cmdDiff`
+
+### Task C.1: `cmdDiff` all-match output
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { cmdDiff } from '../bin/mr-profile.mjs';
+
+test('cmdDiff: after a clean apply, every managed file shows ✓ matches and footer says No changes', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+
+    const out = lines.join('');
+    assert.match(out, /Diff for profile 'backend' \(vs current state\):/);
+    assert.match(out, /\.mcp\.json:\s*\n\s*✓ matches/);
+    assert.match(out, /settings\.local\.json:\s*\n\s*✓ matches/);
+    assert.match(out, /enabledPlugins\):\s*\n\s*✓ matches/);
+    assert.match(out, /skills\/backend:\s*\n\s*✓ matches/);
+    assert.match(out, /agents\/backend:\s*\n\s*✓ matches/);
+    assert.match(out, /active-profile:\s*\n\s*✓ matches/);
+    assert.match(out, /No changes\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, verify red** (`cmdDiff` not exported)
+
+- [ ] **Step 3: Implement `cmdDiff`**
+
+Add to `bin/mr-profile.mjs`. Place after `cmdValidate`.
+
+```js
+export async function cmdDiff({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  const explicit = !!name;
+  if (!name) name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  // prev profile for plugin projection
+  const activeName = await readActiveProfileName(repoRoot);
+  let prevProfile = null;
+  if (activeName && activeName !== name) {
+    try { prevProfile = await loadProfile(repoRoot, activeName); } catch { /* ignore — treat as null */ }
+  } else if (activeName === name) {
+    prevProfile = profile;
+  }
+
+  if (!explicit) stdout.write(`Using active profile '${name}'.\n`);
+  stdout.write(`\nDiff for profile '${name}' (vs current state):\n\n`);
+
+  let anyChange = false;
+
+  // .mcp.json
+  const mcpPath = join(repoRoot, '.mcp.json');
+  const mcpExisting = await readJsonOrEmpty(mcpPath);
+  const mcpDiff = diffMcpKeys(mcpExisting, profile);
+  stdout.write('.mcp.json:\n');
+  if (mcpDiff.added.length + mcpDiff.removed.length + mcpDiff.changed.length === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const k of mcpDiff.added)   stdout.write(`  + mcpServers.${k}\n`);
+    for (const k of mcpDiff.removed) stdout.write(`  - mcpServers.${k}\n`);
+    for (const k of mcpDiff.changed) stdout.write(`  ~ mcpServers.${k}   (content differs)\n`);
+  }
+  stdout.write('\n');
+
+  // settings.local.json
+  const permsPath = join(repoRoot, '.claude', 'settings.local.json');
+  const permsExisting = await readJsonOrEmpty(permsPath);
+  const permsDiff = diffPermissionKeys(permsExisting, profile);
+  stdout.write('.claude/settings.local.json:\n');
+  const permsTotal = permsDiff.allowAdded.length + permsDiff.allowRemoved.length
+                   + permsDiff.denyAdded.length + permsDiff.denyRemoved.length;
+  if (permsTotal === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const x of permsDiff.allowAdded)   stdout.write(`  + permissions.allow: '${x}'\n`);
+    for (const x of permsDiff.allowRemoved) stdout.write(`  - permissions.allow: '${x}'\n`);
+    for (const x of permsDiff.denyAdded)    stdout.write(`  + permissions.deny: '${x}'\n`);
+    for (const x of permsDiff.denyRemoved)  stdout.write(`  - permissions.deny: '${x}'\n`);
+  }
+  stdout.write('\n');
+
+  // enabledPlugins
+  const settingsPath = join(homeClaudeDir, 'settings.json');
+  const settings = await readJsonOrEmpty(settingsPath);
+  const pluginDiff = diffPluginKeys(settings, prevProfile, profile);
+  stdout.write('~/.claude/settings.json (enabledPlugins):\n');
+  if (pluginDiff.added.length + pluginDiff.removed.length === 0) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    for (const k of pluginDiff.added)   stdout.write(`  + ${k}\n`);
+    for (const k of pluginDiff.removed) stdout.write(`  - ${k}\n`);
+  }
+  stdout.write('\n');
+
+  // symlinks
+  const reportSymlink = async (label, link, expectedTarget) => {
+    stdout.write(`${label}:\n`);
+    if (!expectedTarget) { stdout.write('  — (not in profile)\n\n'); return; }
+    try {
+      const st = await lstat(link);
+      if (!st.isSymbolicLink()) {
+        anyChange = true;
+        stdout.write(`  ✗ is not a symlink (would replace would fail; remove manually)\n\n`);
+        return;
+      }
+      const t = await readlink(link);
+      if (t === expectedTarget) {
+        stdout.write('  ✓ matches\n\n');
+      } else {
+        anyChange = true;
+        stdout.write(`  ~ wrong target: was '${t}', expected '${expectedTarget}'\n\n`);
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        anyChange = true;
+        stdout.write(`  + would create symlink → ${expectedTarget}\n\n`);
+        return;
+      }
+      throw e;
+    }
+  };
+  await reportSymlink(
+    `~/.claude/skills/${name}`,
+    join(homeClaudeDir, 'skills', name),
+    profile.local_skills && join(repoRoot, profile.local_skills)
+  );
+  await reportSymlink(
+    `~/.claude/agents/${name}`,
+    join(homeClaudeDir, 'agents', name),
+    profile.local_agents && join(repoRoot, profile.local_agents)
+  );
+
+  // active-profile
+  const currActive = await readActiveProfileName(repoRoot);
+  stdout.write('.claude/active-profile:\n');
+  if (currActive === name) {
+    stdout.write('  ✓ matches\n');
+  } else {
+    anyChange = true;
+    stdout.write(`  ~ was '${currActive ?? '(none)'}', expected '${name}'\n`);
+  }
+  stdout.write('\n');
+
+  if (anyChange) {
+    stdout.write(`Run /profile switch ${name} to apply.\n`);
+  } else {
+    stdout.write('No changes.\n');
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run test, verify green** (46 tests passing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(diff): cmdDiff with all-match output"
+```
+
+---
+
+### Task C.2: `cmdDiff` partial-diff output (state projection in action)
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+test('cmdDiff: from active=frontend, diffing backend shows expected +/-/~ entries', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Apply frontend first, mark active
+    const fe = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, fe);
+    await applyPermissions(repo, fe);
+    await applyPlugins(homeClaude, null, fe);
+    await applySymlinks(homeClaude, repo, fe);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'frontend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+
+    // mcp: backend has 'github', frontend has 'playwright'
+    assert.match(out, /\+ mcpServers\.github/);
+    assert.match(out, /- mcpServers\.playwright/);
+
+    // perms: backend has go/docker, frontend has npm/pnpm
+    assert.match(out, /\+ permissions\.allow: 'Bash\(go \*\)'/);
+    assert.match(out, /- permissions\.allow: 'Bash\(npm \*\)'/);
+
+    // plugins: state-projection should show fe-only removed, be-only added
+    assert.match(out, /\+ gopls-lsp@claude-plugins-official/);
+    assert.match(out, /- frontend-design@claude-plugins-official/);
+
+    // symlinks: backend has both local_skills and local_agents (frontend skill link must change target)
+    // skills link target points to apps/web (frontend), needs to point at services/api (backend)
+    assert.match(out, /skills\/backend:/);
+    assert.match(out, /agents\/backend:/);
+
+    // active-profile
+    assert.match(out, /~ was 'frontend', expected 'backend'/);
+
+    assert.match(out, /Run \/profile switch backend to apply\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdDiff: re-diffing the active profile shows No changes', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    const out = lines.join('');
+    assert.match(out, /No changes\./);
+    // Critical: state projection means re-diff doesn't show phantom plugin additions
+    assert.doesNotMatch(out, /\+ gopls-lsp@/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run tests, expect green** (Task C.1's implementation handles both cases)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(diff): partial-diff and re-apply-no-phantom-additions"
+```
+
+Acceptance check: v0.2-AC-3 covered by Tasks C.1, C.2.
+
+---
+
+## Phase D: drift count + footer in `cmdStatus`
+
+### Task D.1: `cmdStatus` uses key-diff helpers for count, adds footer
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add failing tests**
+
+```js
+test('cmdStatus: drifted .mcp.json line shows "(N keys differ)" when keys actually differ', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Add a rogue server (1 added key)
+    const data = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    data.mcpServers.rogue = { command: 'x' };
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(data, null, 2) + '\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted \(1 key differs\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: drifted .mcp.json line shows "(formatting only)" when bytes differ but keys match', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Re-serialize with non-canonical formatting (e.g. tabs) — same keys, different bytes
+    const data = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(data) /* no indent, no trailing newline */);
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted \(formatting only\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: footer "Run /profile diff for details." appears only when drifted', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Clean state — no footer expected
+    let lines = [];
+    let stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.doesNotMatch(lines.join(''), /Run \/profile diff/);
+
+    // Drift one file — footer expected
+    await writeFile(join(repo, '.mcp.json'), '{"mcpServers":{"x":{"command":"y"}}}\n');
+    lines = [];
+    stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /Run \/profile diff for details\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run tests, verify red**
+
+- [ ] **Step 3: Update `cmdStatus` to use key-diff helpers and emit count + footer**
+
+Replace the body of `cmdStatus`. The structure is similar to before but uses the helpers for drift detail.
+
+```js
+export async function cmdStatus({ repoRoot, homeClaudeDir, stdout = process.stdout }) {
+  const name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stdout.write('no active profile (run /profile switch <name>)\n');
+    return 0;
+  }
+  const profile = await loadProfile(repoRoot, name);
+
+  const lines = [`active profile: ${name}`];
+  let anyDrift = false;
+
+  const driftLabel = (sha1, sha2, keyCount) => {
+    if (sha1 === sha2) return '✓';
+    anyDrift = true;
+    if (keyCount === 0) return '✗ drifted (formatting only)';
+    return `✗ drifted (${keyCount} key${keyCount === 1 ? ' differs' : 's differ'})`;
+  };
+
+  // .mcp.json
+  const mcpPath = join(repoRoot, '.mcp.json');
+  const mcpOnDisk = await readOrEmpty(mcpPath);
+  const mcpExisting = await readJsonOrEmpty(mcpPath);
+  const mcpExpected = renderMcpBytes(mcpExisting, profile);
+  const mcpDiff = diffMcpKeys(mcpExisting, profile);
+  const mcpKeyCount = mcpDiff.added.length + mcpDiff.removed.length + mcpDiff.changed.length;
+  lines.push(`.mcp.json: ${driftLabel(sha(mcpOnDisk), sha(mcpExpected), mcpKeyCount)}`);
+
+  // settings.local.json
+  const permsPath = join(repoRoot, '.claude', 'settings.local.json');
+  const permsOnDisk = await readOrEmpty(permsPath);
+  const permsExisting = await readJsonOrEmpty(permsPath);
+  const permsExpected = renderPermissionsBytes(permsExisting, profile);
+  const permsDiff = diffPermissionKeys(permsExisting, profile);
+  const permsKeyCount = permsDiff.allowAdded.length + permsDiff.allowRemoved.length
+                      + permsDiff.denyAdded.length + permsDiff.denyRemoved.length;
+  lines.push(`settings.local.json: ${driftLabel(sha(permsOnDisk), sha(permsExpected), permsKeyCount)}`);
+
+  // enabledPlugins (presence-only check, unchanged label semantics from v0.1)
+  const settingsPath = join(homeClaudeDir, 'settings.json');
+  const settingsExisting = await readJsonOrEmpty(settingsPath);
+  const expectedKeys = profile.plugins ?? [];
+  const enabledOk = expectedKeys.every(k => settingsExisting.enabledPlugins?.[k] === true);
+  if (!enabledOk) anyDrift = true;
+  lines.push(`enabledPlugins: ${enabledOk ? '✓ all required present' : '✗ missing required'}`);
+
+  // symlinks
+  const checkSym = async (link, expectedTarget) => {
+    if (!expectedTarget) return '— (not in profile)';
+    try {
+      const st = await lstat(link);
+      if (!st.isSymbolicLink()) { anyDrift = true; return '✗ not a symlink'; }
+      const t = await readlink(link);
+      if (t === expectedTarget) return '✓';
+      anyDrift = true;
+      return '✗ wrong target';
+    } catch (e) {
+      if (e.code === 'ENOENT') { anyDrift = true; return '✗ missing'; }
+      throw e;
+    }
+  };
+  const skillLink = join(homeClaudeDir, 'skills', name);
+  const agentLink = join(homeClaudeDir, 'agents', name);
+  lines.push(`skills symlink: ${await checkSym(skillLink, profile.local_skills && join(repoRoot, profile.local_skills))}`);
+  lines.push(`agents symlink: ${await checkSym(agentLink, profile.local_agents && join(repoRoot, profile.local_agents))}`);
+
+  stdout.write(lines.join('\n') + '\n');
+  if (anyDrift) stdout.write('\nRun /profile diff for details.\n');
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run tests, verify green** (49 tests passing)
+
+The existing v0.1 status test (`cmdStatus: ✓ for each managed file after a clean apply`) should still pass — its assertions use `/.mcp\.json: ✓/` which matches `✓` whether or not the new tail is appended.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(status): drift count + formatting-only label + diff-pointer footer"
+```
+
+Acceptance check: v0.2-AC-4 covered by Task D.1.
+
+---
+
+## Phase E: CLI dispatch
+
+### Task E.1: `main` dispatches `validate` and `diff`
+
+**Files:**
+- Modify: `bin/mr-profile.mjs`
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+test('main: dispatches "validate <name>"', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['validate', 'backend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'backend': ✓ valid/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: dispatches "diff <name>"', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['diff', 'backend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Diff for profile 'backend'/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: validate and diff appear in USAGE on unknown subcommand', async () => {
+  const elsewhere = await mkdtemp(join(tmpdir(), 'mr-profile-elsewhere-'));
+  const origCwd = process.cwd();
+  try {
+    process.chdir(elsewhere);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['nope'], {}, { stderr });
+    assert.equal(code, 2);
+    const out = errs.join('');
+    assert.match(out, /validate/);
+    assert.match(out, /diff/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(elsewhere);
+  }
+});
+```
+
+- [ ] **Step 2: Run tests, verify red** (main doesn't dispatch new subcommands)
+
+- [ ] **Step 3: Update `main` and `USAGE`**
+
+Locate the `USAGE` constant and the validation list in `main`. Update both:
+
+```js
+const USAGE = `usage:
+  mr-profile switch <name>
+  mr-profile status
+  mr-profile validate [name]
+  mr-profile diff [name]
+  mr-profile session-start
+`;
+```
+
+In `main`, add `validate` and `diff` to the valid subcommand check, then add the dispatch cases:
+
+```js
+export async function main(argv, env, io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  const [sub, ...rest] = argv;
+
+  const knownSubs = new Set(['switch', 'status', 'validate', 'diff', 'session-start']);
+  if (!knownSubs.has(sub)) {
+    stderr.write(USAGE);
+    return 2;
+  }
+  if (sub === 'switch' && !rest[0]) {
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  let repoRoot;
+  try {
+    repoRoot = await findRepoRoot(process.cwd());
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+  const home = (env && env.HOME) || homedir();
+  const homeClaudeDir = join(home, '.claude');
+
+  switch (sub) {
+    case 'switch':
+      return await cmdSwitch({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'status':
+      return await cmdStatus({ repoRoot, homeClaudeDir, stdout });
+    case 'validate':
+      return await cmdValidate({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'diff':
+      return await cmdDiff({ repoRoot, homeClaudeDir, name: rest[0], stdout, stderr });
+    case 'session-start':
+      return await cmdSessionStart({ repoRoot, homeClaudeDir, stdout });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify green** (52 tests passing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(cli): dispatch validate and diff; update USAGE"
+```
+
+---
+
+### Task E.2: Update `commands/profile.md` argument hint
+
+**Files:**
+- Modify: `commands/profile.md`
+
+- [ ] **Step 1: Update the frontmatter**
+
+Open `commands/profile.md`. Locate the frontmatter:
+
+```yaml
+---
+description: Manage monorepo profiles (switch, status). Run `/profile switch <name>` or `/profile status`.
+argument-hint: switch <name> | status
+---
+```
+
+Replace with:
+
+```yaml
+---
+description: Manage monorepo profiles. Subcommands: switch, status, validate, diff.
+argument-hint: switch <name> | status | validate [name] | diff [name]
+---
+```
+
+The body of the file (the bash invocation that dispatches `$ARGUMENTS`) is unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add commands/profile.md
+git commit -m "docs(plugin): update /profile argument hint with validate and diff"
+```
+
+---
+
+## Phase F: JSON Schema + README
+
+### Task F.1: `profile.schema.json`
+
+**Files:**
+- Create: `.claude-plugin/profile.schema.json`
+
+- [ ] **Step 1: Write the schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://example.invalid/monorepo-profiles/profile.schema.json",
+  "title": "monorepo-profiles profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+$",
+      "description": "Must equal the JSON filename stem."
+    },
+    "description": { "type": "string" },
+    "mcp_servers": {
+      "type": "object",
+      "description": "Same shape as .mcp.json's mcpServers. Profile fully owns this key.",
+      "additionalProperties": {
+        "type": "object",
+        "anyOf": [
+          { "required": ["command"] },
+          { "required": ["url"] }
+        ],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "url": { "type": "string" }
+        }
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": { "type": "array", "items": { "type": "string" } },
+        "deny":  { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[\\w-]+@[\\w-]+$",
+        "description": "Plugin id in the form 'name@marketplace'."
+      }
+    },
+    "local_skills": {
+      "type": "string",
+      "description": "Path relative to repo root pointing to a directory of skills."
+    },
+    "local_agents": {
+      "type": "string",
+      "description": "Path relative to repo root pointing to a directory of agents."
+    },
+    "instruction_fragments": {
+      "type": "array",
+      "description": "Supplementary fragments not on the CLAUDE.md cwd cascade.",
+      "items": { "type": "string" }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Verify the schema is valid JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('/Users/dmestas/projects/monorepo-profiles/.claude-plugin/profile.schema.json'))"`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude-plugin/profile.schema.json
+git commit -m "feat(schema): JSON Schema Draft-07 for profile files"
+```
+
+---
+
+### Task F.2: README "Editor schema setup" section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Append the new section**
+
+Read the current `README.md`, then append the following at the bottom:
+
+```markdown
+
+## Editor schema setup (optional)
+
+The plugin ships a JSON Schema for profile files. To get autocomplete, hover docs,
+and typo detection in VS Code or Cursor, add to `.vscode/settings.json` in your
+monorepo:
+
+\`\`\`json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".claude/profiles/*.json"],
+      "url": "/absolute/path/to/monorepo-profiles/.claude-plugin/profile.schema.json"
+    }
+  ]
+}
+\`\`\`
+
+The plugin's install path is shown by `/plugin` in Claude Code. For team-shareable
+editor config, copy the schema into your repo (e.g. to `.claude/profile.schema.json`)
+and commit it.
+```
+
+(In the actual file, the inner triple-backtick fences should be regular triple backticks, not escaped.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): editor schema setup instructions"
+```
+
+---
+
+## Phase G: Manual verification (v0.2-AC-5)
+
+### Task G.1: Verify schema produces editor autocomplete
+
+**Files:** none — manual verification only.
+
+This is a one-time manual check that the JSON Schema produces useful behavior in at least one editor (VS Code or Cursor).
+
+- [ ] **Step 1: Configure editor**
+
+In any monorepo with `.claude/profiles/*.json` (the `/tmp/mr-profile-test` from v0.1's manual verification works fine), create `.vscode/settings.json`:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["**/.claude/profiles/*.json"],
+      "url": "/Users/dmestas/projects/monorepo-profiles/.claude-plugin/profile.schema.json"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Open a profile in the editor**
+
+Open `.claude/profiles/backend.json` in VS Code or Cursor with the JSON LSP enabled.
+
+- [ ] **Step 3: Test typo detection**
+
+Change `mcp_servers` to `mcp_serverz`. The editor should mark the field as unrecognized (red squiggle on the property name, or info diagnostic).
+
+- [ ] **Step 4: Test autocomplete**
+
+Add a new server entry: `"foo": { "" — autocomplete should offer `command`, `args`, `env`, `url`.
+
+- [ ] **Step 5: Test required-anyOf**
+
+Add `"foo": {}` (empty object). The schema should report the entry violates `anyOf` (missing both `command` and `url`).
+
+- [ ] **Step 6: Document outcome**
+
+Append to `README.md` under a "Verified" section: date + editor + result. Commit.
+
+```bash
+git add README.md
+git commit -m "docs: record schema editor verification"
+```
+
+If any step fails (the schema doesn't load, autocomplete doesn't fire), file as a v0.2 follow-up — don't block.
+
+---
+
+## Final acceptance check
+
+| AC | Verified by |
+|---|---|
+| v0.2-AC-1 (`cmdValidate` reports actionable errors and warnings without writing any file) | Tasks B.1–B.3 |
+| v0.2-AC-2 (`cmdValidate` defaults to active profile and exits 2 with USAGE) | Task B.4 |
+| v0.2-AC-3 (`cmdDiff` output matches spec'd format for all-match and partial-diff) | Tasks C.1, C.2 |
+| v0.2-AC-4 (`/profile status` includes `(N keys differ)` count and footer) | Task D.1 |
+| v0.2-AC-5 (Schema produces editor autocomplete in at least one editor) | Task G.1 (manual) |
+| v0.2-AC-6 (All v0.1 tests continue to pass) | every phase runs `npm test` and asserts the cumulative count |
+
+Total ≈ 13 tasks (12 code + 1 manual), 59 tests at end (35 v0.1 + 24 v0.2). `bin/mr-profile.mjs` ends at ~470 LOC.

--- a/plugins/monorepo-profiles/docs/superpowers/plans/2026-04-29-monorepo-profiles.md
+++ b/plugins/monorepo-profiles/docs/superpowers/plans/2026-04-29-monorepo-profiles.md
@@ -1,0 +1,1974 @@
+# monorepo-profiles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Claude Code plugin that lets a user define named profiles per monorepo and atomically swap MCP servers, permissions, plugins, skills, agents, and instruction-fragment context with a single `/profile switch <name>` command.
+
+**Architecture:** A single Node ESM script (`bin/mr-profile.mjs`) does all the work. Three subcommands: `switch`, `status`, `session-start`. A Claude Code plugin shell wraps it with one slash command (`/profile`) and one SessionStart hook. Every managed file follows the same rule: the profile owns specific keys it lists; everything else is preserved. Tests use `node --test` against fixture monorepos copied to `mkdtemp` dirs.
+
+**Tech Stack:** Node 20+ (ESM, `node:test`, `node:assert`, `node:fs/promises`, `node:crypto`, `node:os`, `node:path`), no third-party deps.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md`
+
+---
+
+## File Structure
+
+Plugin source repository (`/Users/dmestas/projects/monorepo-profiles/`):
+
+```
+.claude-plugin/plugin.json          # plugin manifest
+commands/profile.md                 # slash command body, dispatches to mr-profile
+hooks/hooks.json                    # SessionStart -> mr-profile session-start
+bin/mr-profile.mjs                  # all logic (~250 LOC); single ESM file
+test/
+  mr-profile.test.mjs               # all tests (~250 LOC)
+  helpers.mjs                       # fixture/tmp-dir helpers used by tests
+  fixtures/sample/                  # sample monorepo fixture
+    .claude/profiles/frontend.json
+    .claude/profiles/backend.json
+    AGENTS.md
+    services/api/AGENTS.md
+    apps/web/.claude/skills/dummy-skill/SKILL.md
+    services/api/.claude/skills/db-expert/SKILL.md
+package.json                        # type:module + test script
+.gitignore
+README.md
+docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md   (already exists)
+docs/superpowers/specs/hook-schema-verification.md              (created in Task 0.3)
+docs/superpowers/plans/2026-04-29-monorepo-profiles.md          (this file)
+```
+
+Per-monorepo files the plugin manages at runtime (NOT in this repo):
+- `<repo>/.mcp.json`
+- `<repo>/.claude/settings.local.json`
+- `~/.claude/settings.json` (`enabledPlugins` keys only)
+- `~/.claude/skills/<profile-name>/` (symlink)
+- `~/.claude/agents/<profile-name>/` (symlink)
+- `<repo>/.claude/active-profile`
+
+All file paths in `bin/mr-profile.mjs` are computed from two parameters: `repoRoot` (auto-detected by walking up from `process.cwd()` looking for `.claude/profiles/`) and `homeDir` (defaults to `os.homedir()`, but tests inject a tmp dir to avoid touching the real `~/.claude/`).
+
+---
+
+## Internal Function Inventory
+
+All in `bin/mr-profile.mjs`. Each function is independently testable by passing explicit `repoRoot` and `homeDir`.
+
+| Function | Inputs | Outputs / side effects |
+|---|---|---|
+| `findRepoRoot(cwd)` | string | string (repo root) or throws |
+| `validateProfile(obj, expectedName)` | parsed JSON, profile name | array of error strings ([] if valid) |
+| `loadProfile(repoRoot, name)` | strings | profile object or throws with actionable message |
+| `readActiveProfileName(repoRoot)` | string | string \| null |
+| `applyMcp(repoRoot, profile)` | strings, object | writes `<repo>/.mcp.json` |
+| `applyPermissions(repoRoot, profile)` | strings, object | writes `<repo>/.claude/settings.local.json` |
+| `applyPlugins(homeDir, prevProfile, newProfile)` | strings, objects | mutates `~/.claude/settings.json` `enabledPlugins` |
+| `applySymlinks(homeDir, repoRoot, profile)` | strings, object | creates/replaces symlinks under `~/.claude/skills/` and `~/.claude/agents/` |
+| `renderInstructions(repoRoot, profile)` | strings, object | string (concatenated fragments) |
+| `writeActiveProfile(repoRoot, name)` | strings | writes `<repo>/.claude/active-profile` |
+| `applyAll(opts)` | `{ repoRoot, homeDir, profile, prevProfile }` | orchestrates writes in fixed order |
+| `cmdSwitch(opts)` | `{ repoRoot, homeDir, name }` | full switch flow, prints restart prompt |
+| `cmdStatus(opts)` | `{ repoRoot, homeDir }` | prints active + per-file SHA check |
+| `cmdSessionStart(opts)` | `{ repoRoot, homeDir }` | prints hook JSON to stdout |
+| `main(argv, env)` | string[], object | dispatches subcommands; returns exit code |
+
+The `bin/mr-profile.mjs` entry point at the bottom is just:
+```js
+const code = await main(process.argv.slice(2), process.env);
+process.exit(code);
+```
+
+---
+
+## Phase 0: Scaffolding
+
+### Task 0.1: Initialize Node project
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/package.json`
+- Create: `/Users/dmestas/projects/monorepo-profiles/.gitignore`
+- Create: `/Users/dmestas/projects/monorepo-profiles/README.md`
+
+- [ ] **Step 1: Write `package.json`**
+
+```json
+{
+  "name": "monorepo-profiles",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test --test-reporter=spec test/"
+  }
+}
+```
+
+- [ ] **Step 2: Write `.gitignore`**
+
+```
+node_modules/
+.DS_Store
+test/.tmp/
+```
+
+- [ ] **Step 3: Write minimal `README.md`**
+
+```markdown
+# monorepo-profiles
+
+Atomic profile switching for Claude Code in monorepos. Define a profile per
+sub-stack (frontend, backend), commit it, and `/profile switch <name>` swaps
+MCP servers, permissions, plugins, skills, agents, and AGENTS.md fragments.
+
+See `docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md` for the
+full design.
+```
+
+- [ ] **Step 4: Initialize git and commit**
+
+```bash
+cd /Users/dmestas/projects/monorepo-profiles
+git init
+git add package.json .gitignore README.md docs/
+git commit -m "chore: scaffold monorepo-profiles plugin project"
+```
+
+Expected: clean commit on `main`.
+
+---
+
+### Task 0.2: Verify SessionStart hook output schema
+
+**This task is required by the spec ("Implementation step 1 must verify this schema"). It produces a small artifact that locks in the schema before any code is written against it.**
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/docs/superpowers/specs/hook-schema-verification.md`
+
+- [ ] **Step 1: Dispatch the claude-code-guide agent**
+
+Use the `Agent` tool with `subagent_type: claude-code-guide`. Prompt:
+
+> Confirm the exact JSON schema Claude Code expects on stdout from a SessionStart hook command in order to inject text into the model's session context. Specifically: what is the top-level key (`hookSpecificOutput`?), what fields are required inside it (`hookEventName`, `additionalContext`?), and what value of `hookEventName` does SessionStart use? Cite the official Claude Code hooks docs URL. If the hook can return additional fields (e.g., `decision`, `reason`, `suppressOutput`), list them. ≤200 words.
+
+- [ ] **Step 2: Capture findings to disk**
+
+Save the agent's report verbatim to `docs/superpowers/specs/hook-schema-verification.md` with a heading and the date.
+
+- [ ] **Step 3: Update the spec only if findings differ**
+
+If the verified schema does not match `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}`, edit `docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md` to use the corrected shape in the SessionStart section. Otherwise leave it alone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/hook-schema-verification.md docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md
+git commit -m "docs: verify SessionStart hook output schema"
+```
+
+---
+
+### Task 0.3: Stub the entry-point files
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/bin/mr-profile.mjs`
+- Create: `/Users/dmestas/projects/monorepo-profiles/test/mr-profile.test.mjs`
+- Create: `/Users/dmestas/projects/monorepo-profiles/test/helpers.mjs`
+
+- [ ] **Step 1: Stub `bin/mr-profile.mjs`**
+
+```js
+#!/usr/bin/env node
+// monorepo-profiles CLI. Subcommands: switch, status, session-start.
+
+export async function main(argv, env) {
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const code = await main(process.argv.slice(2), process.env);
+  process.exit(code);
+}
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x /Users/dmestas/projects/monorepo-profiles/bin/mr-profile.mjs
+```
+
+- [ ] **Step 3: Stub `test/helpers.mjs`**
+
+```js
+import { mkdtemp, rm, mkdir, writeFile, cp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, 'fixtures', 'sample');
+
+export async function makeRepoFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'mr-profile-repo-'));
+  await cp(FIXTURE_ROOT, dir, { recursive: true });
+  return dir;
+}
+
+export async function makeHomeFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'mr-profile-home-'));
+  await mkdir(join(dir, '.claude', 'skills'), { recursive: true });
+  await mkdir(join(dir, '.claude', 'agents'), { recursive: true });
+  await writeFile(join(dir, '.claude', 'settings.json'), '{}');
+  return join(dir, '.claude');
+}
+
+export async function cleanup(...dirs) {
+  for (const d of dirs) {
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+}
+```
+
+Note: `homeDir` returned by `makeHomeFixture` is the `.claude` dir directly, matching the convention used by `applyPlugins` and `applySymlinks` (they take `homeClaudeDir`, not `$HOME`). Adjust the function signatures to match: every function that touches user-global state takes `homeClaudeDir`, never raw `$HOME`.
+
+- [ ] **Step 4: Stub `test/mr-profile.test.mjs`**
+
+```js
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+```
+
+(Empty body for now; tests get added in subsequent tasks.)
+
+- [ ] **Step 5: Run tests to verify scaffolding**
+
+```bash
+cd /Users/dmestas/projects/monorepo-profiles
+npm test
+```
+
+Expected: passes with 0 tests run (no failure).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/ test/ package.json
+git commit -m "chore: stub mr-profile entry point and test scaffolding"
+```
+
+---
+
+### Task 0.4: Build the sample fixture monorepo
+
+**Files (all under `/Users/dmestas/projects/monorepo-profiles/test/fixtures/sample/`):**
+- Create: `.claude/profiles/frontend.json`
+- Create: `.claude/profiles/backend.json`
+- Create: `AGENTS.md`
+- Create: `services/api/AGENTS.md`
+- Create: `apps/web/.claude/skills/dummy-skill/SKILL.md`
+- Create: `services/api/.claude/skills/db-expert/SKILL.md`
+- Create: `services/api/.claude/agents/migration-runner.md`
+
+- [ ] **Step 1: Create `apps/web/.claude/skills/dummy-skill/SKILL.md`**
+
+```markdown
+---
+name: dummy-skill
+description: Used only as a fixture for monorepo-profiles tests.
+---
+This is a fixture skill. It does nothing.
+```
+
+- [ ] **Step 2: Create `services/api/.claude/skills/db-expert/SKILL.md`**
+
+```markdown
+---
+name: db-expert
+description: Used only as a fixture for monorepo-profiles tests.
+---
+This is a fixture skill. It does nothing.
+```
+
+- [ ] **Step 3: Create `services/api/.claude/agents/migration-runner.md`**
+
+```markdown
+---
+name: migration-runner
+description: Used only as a fixture for monorepo-profiles tests.
+---
+You are a fixture agent. Do nothing.
+```
+
+- [ ] **Step 4: Create `AGENTS.md` (repo-root preamble)**
+
+```markdown
+# Sample Monorepo
+
+Fixture used by monorepo-profiles tests.
+```
+
+- [ ] **Step 5: Create `services/api/AGENTS.md`**
+
+```markdown
+# services/api
+
+Backend service preamble fragment used by monorepo-profiles tests.
+```
+
+- [ ] **Step 6: Create `.claude/profiles/frontend.json`**
+
+```json
+{
+  "name": "frontend",
+  "description": "Web app stack",
+  "mcp_servers": {
+    "playwright": { "command": "npx", "args": ["@playwright/mcp"] }
+  },
+  "permissions": {
+    "allow": ["Bash(npm *)", "Bash(pnpm *)"],
+    "deny":  ["Bash(rm -rf *)"]
+  },
+  "plugins": [
+    "frontend-design@claude-plugins-official",
+    "agent-browser@claude-plugins-official"
+  ],
+  "local_skills": "apps/web/.claude/skills",
+  "instruction_fragments": ["AGENTS.md"]
+}
+```
+
+- [ ] **Step 7: Create `.claude/profiles/backend.json`**
+
+```json
+{
+  "name": "backend",
+  "description": "Go API services",
+  "mcp_servers": {
+    "github": { "command": "npx", "args": ["@modelcontextprotocol/server-github"] }
+  },
+  "permissions": {
+    "allow": ["Bash(go *)", "Bash(docker *)"],
+    "deny":  ["Bash(rm -rf *)", "Bash(kubectl delete *)"]
+  },
+  "plugins": [
+    "gopls-lsp@claude-plugins-official",
+    "code-review@claude-plugins-official"
+  ],
+  "local_skills": "services/api/.claude/skills",
+  "local_agents": "services/api/.claude/agents",
+  "instruction_fragments": ["AGENTS.md", "services/api/AGENTS.md"]
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add test/fixtures/
+git commit -m "test: add sample monorepo fixture"
+```
+
+---
+
+## Phase 1: Profile loader (AC-1)
+
+### Task 1.1: Test — profile rejects missing required fields
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs` (append)
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `test/mr-profile.test.mjs`:
+
+```js
+import { validateProfile } from '../bin/mr-profile.mjs';
+
+test('validateProfile: rejects missing name', () => {
+  const errors = validateProfile({}, 'frontend');
+  assert.ok(errors.some(e => e.includes("'name'")), `expected 'name' error, got: ${JSON.stringify(errors)}`);
+});
+
+test('validateProfile: rejects when name does not match filename', () => {
+  const errors = validateProfile({ name: 'foo' }, 'frontend');
+  assert.ok(errors.some(e => /name 'foo'.*does not match filename 'frontend'/.test(e)),
+    `expected filename mismatch error, got: ${JSON.stringify(errors)}`);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/dmestas/projects/monorepo-profiles && npm test
+```
+
+Expected: failure mentioning that `validateProfile` is not exported.
+
+- [ ] **Step 3: Implement `validateProfile`**
+
+Add to `bin/mr-profile.mjs` (above `main`):
+
+```js
+export function validateProfile(obj, expectedName) {
+  const errors = [];
+  if (typeof obj !== 'object' || obj === null) {
+    errors.push("profile must be a JSON object");
+    return errors;
+  }
+  if (typeof obj.name !== 'string') {
+    errors.push("missing or non-string 'name'");
+  } else if (obj.name !== expectedName) {
+    errors.push(`name '${obj.name}' does not match filename '${expectedName}'`);
+  }
+  return errors;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test
+```
+
+Expected: 2 passing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(profile): validate required name field"
+```
+
+---
+
+### Task 1.2: Test — profile loads a valid file
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `test/mr-profile.test.mjs`:
+
+```js
+import { loadProfile } from '../bin/mr-profile.mjs';
+import { makeRepoFixture, cleanup } from './helpers.mjs';
+
+test('loadProfile: loads a valid profile from fixture', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const p = await loadProfile(repo, 'frontend');
+    assert.equal(p.name, 'frontend');
+    assert.equal(p.description, 'Web app stack');
+    assert.equal(typeof p.mcp_servers.playwright.command, 'string');
+    assert.deepEqual(p.permissions.allow, ['Bash(npm *)', 'Bash(pnpm *)']);
+  } finally {
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test
+```
+
+Expected: failure (`loadProfile` not exported).
+
+- [ ] **Step 3: Implement `loadProfile`**
+
+Add to `bin/mr-profile.mjs`:
+
+```js
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function loadProfile(repoRoot, name) {
+  const path = join(repoRoot, '.claude', 'profiles', `${name}.json`);
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      throw new Error(`profile '${name}' not found at ${path}`);
+    }
+    throw e;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`profile '${name}' has invalid JSON at ${path}: ${e.message}`);
+  }
+  const errors = validateProfile(parsed, name);
+  if (errors.length > 0) {
+    throw new Error(`profile '${name}' invalid: ${errors.join('; ')}`);
+  }
+  return parsed;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test
+```
+
+Expected: all tests passing (3 total now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(profile): loadProfile reads and validates from disk"
+```
+
+---
+
+### Task 1.3: Test — malformed JSON gives file path + parse position
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append:
+
+```js
+import { writeFile } from 'node:fs/promises';
+
+test('loadProfile: malformed JSON error includes file path', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const path = join(repo, '.claude', 'profiles', 'frontend.json');
+    await writeFile(path, '{ "name": "frontend"  // not valid');
+    await assert.rejects(
+      loadProfile(repo, 'frontend'),
+      err => err.message.includes(path) && /invalid JSON/i.test(err.message)
+    );
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('loadProfile: missing profile lists path', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    await assert.rejects(
+      loadProfile(repo, 'nonexistent'),
+      err => err.message.includes('not found') && err.message.includes('nonexistent.json')
+    );
+  } finally {
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes already**
+
+```bash
+npm test
+```
+
+Expected: passes (the implementation in Task 1.2 already handles both cases). If a test fails, fix `loadProfile` until both pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(profile): error paths for missing and malformed profiles"
+```
+
+Acceptance check: AC-1 covered by tests in Tasks 1.1–1.3.
+
+---
+
+## Phase 2: applyMcp (AC-2 part)
+
+### Task 2.1: Test — apply writes `.mcp.json`
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { applyMcp } from '../bin/mr-profile.mjs';
+import { readFile } from 'node:fs/promises';
+
+test('applyMcp: writes mcpServers and preserves other top-level keys', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    // pre-existing .mcp.json with a non-mcpServers key
+    const existing = { mcpServers: { old: { command: 'old' } }, custom: { keep: true } };
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(existing));
+
+    const profile = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, profile);
+
+    const after = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    assert.deepEqual(after.mcpServers, profile.mcp_servers);
+    assert.deepEqual(after.custom, { keep: true });
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyMcp: idempotent — second apply yields identical bytes', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const profile = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, profile);
+    const a = await readFile(join(repo, '.mcp.json'), 'utf8');
+    await applyMcp(repo, profile);
+    const b = await readFile(join(repo, '.mcp.json'), 'utf8');
+    assert.equal(a, b);
+  } finally {
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test
+```
+
+Expected: failure (`applyMcp` not exported).
+
+- [ ] **Step 3: Implement `applyMcp`**
+
+Add to `bin/mr-profile.mjs`:
+
+```js
+import { writeFile } from 'node:fs/promises';
+
+async function readJsonOrEmpty(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') return {};
+    throw e;
+  }
+}
+
+export async function applyMcp(repoRoot, profile) {
+  const path = join(repoRoot, '.mcp.json');
+  const existing = await readJsonOrEmpty(path);
+  const next = { ...existing, mcpServers: profile.mcp_servers ?? {} };
+  await writeFile(path, JSON.stringify(next, null, 2) + '\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(apply): applyMcp owns mcpServers, preserves other keys"
+```
+
+---
+
+## Phase 3: applyPermissions (AC-2 part)
+
+### Task 3.1: Test — apply writes settings.local.json, preserves env
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { applyPermissions } from '../bin/mr-profile.mjs';
+import { mkdir } from 'node:fs/promises';
+
+test('applyPermissions: writes allow/deny, preserves env', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const settingsPath = join(repo, '.claude', 'settings.local.json');
+    await mkdir(join(repo, '.claude'), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      env: { DEBUG: 'true' },
+      permissions: { allow: ['stale'], deny: [] }
+    }));
+
+    const profile = await loadProfile(repo, 'backend');
+    await applyPermissions(repo, profile);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    assert.deepEqual(after.env, { DEBUG: 'true' });
+    assert.deepEqual(after.permissions.allow, profile.permissions.allow);
+    assert.deepEqual(after.permissions.deny, profile.permissions.deny);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyPermissions: idempotent', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    await mkdir(join(repo, '.claude'), { recursive: true });
+    const profile = await loadProfile(repo, 'backend');
+    await applyPermissions(repo, profile);
+    const a = await readFile(join(repo, '.claude', 'settings.local.json'), 'utf8');
+    await applyPermissions(repo, profile);
+    const b = await readFile(join(repo, '.claude', 'settings.local.json'), 'utf8');
+    assert.equal(a, b);
+  } finally {
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: not exported.
+
+- [ ] **Step 3: Implement `applyPermissions`**
+
+```js
+export async function applyPermissions(repoRoot, profile) {
+  const path = join(repoRoot, '.claude', 'settings.local.json');
+  const existing = await readJsonOrEmpty(path);
+  const next = {
+    ...existing,
+    permissions: {
+      ...(existing.permissions ?? {}),
+      allow: profile.permissions?.allow ?? [],
+      deny:  profile.permissions?.deny  ?? []
+    }
+  };
+  await writeFile(path, JSON.stringify(next, null, 2) + '\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(apply): applyPermissions owns allow/deny, preserves env/hooks"
+```
+
+---
+
+## Phase 4: applyPlugins (AC-3)
+
+### Task 4.1: Test — first switch enables, leaves unrelated alone
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { applyPlugins } from '../bin/mr-profile.mjs';
+import { makeHomeFixture } from './helpers.mjs';
+
+test('applyPlugins: first switch enables new plugins, preserves unrelated', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({
+      enabledPlugins: { 'unrelated@anyone': true }
+    }));
+
+    const profile = await loadProfile(repo, 'backend');
+    await applyPlugins(homeClaude, /* prev */ null, profile);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    assert.equal(after.enabledPlugins['unrelated@anyone'], true);
+    for (const key of profile.plugins) {
+      assert.equal(after.enabledPlugins[key], true, `expected ${key} enabled`);
+    }
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Implement `applyPlugins`**
+
+```js
+export async function applyPlugins(homeClaudeDir, prevProfile, newProfile) {
+  const path = join(homeClaudeDir, 'settings.json');
+  const settings = await readJsonOrEmpty(path);
+  const enabled = { ...(settings.enabledPlugins ?? {}) };
+
+  const toEnable  = newProfile.plugins ?? [];
+  const prevPlugins = prevProfile?.plugins ?? [];
+  const toDisable = prevPlugins.filter(p => !toEnable.includes(p));
+
+  for (const k of toEnable) enabled[k] = true;
+  for (const k of toDisable) delete enabled[k];
+
+  const next = { ...settings, enabledPlugins: enabled };
+  await writeFile(path, JSON.stringify(next, null, 2) + '\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(apply): applyPlugins enables new + preserves unrelated"
+```
+
+---
+
+### Task 4.2: Test — switch removes prior-only plugins (the diff)
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+test('applyPlugins: removes plugins from previous profile not in new profile', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({ enabledPlugins: { 'unrelated@x': true } }));
+
+    const fe = await loadProfile(repo, 'frontend');
+    const be = await loadProfile(repo, 'backend');
+
+    // simulate: frontend was active first
+    await applyPlugins(homeClaude, null, fe);
+    let after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    for (const k of fe.plugins) assert.equal(after.enabledPlugins[k], true);
+
+    // switch to backend
+    await applyPlugins(homeClaude, fe, be);
+    after = JSON.parse(await readFile(settingsPath, 'utf8'));
+
+    for (const k of be.plugins) assert.equal(after.enabledPlugins[k], true, `expected ${k} on`);
+    for (const k of fe.plugins) {
+      if (!be.plugins.includes(k)) {
+        assert.equal(after.enabledPlugins[k], undefined, `expected ${k} removed`);
+      }
+    }
+    assert.equal(after.enabledPlugins['unrelated@x'], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+(Implementation in Task 4.1 already handles this. If not, fix.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(apply): plugin diff removes prior-only on switch"
+```
+
+---
+
+### Task 4.3: Test — previous profile deleted: warn, do not orphan
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs` (only if needed)
+
+- [ ] **Step 1: Add the failing test**
+
+This is tested at the `cmdSwitch` level (since the warning happens when *loading* the previous profile fails). Add a placeholder test now and revisit it in Phase 8 after `cmdSwitch` exists. For Phase 4, just verify the function tolerates a `null` prevProfile and a prevProfile object whose plugins are empty.
+
+```js
+test('applyPlugins: prevProfile null is treated as empty plugin list', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({ enabledPlugins: {} }));
+
+    const be = await loadProfile(repo, 'backend');
+    await applyPlugins(homeClaude, null, be);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    for (const k of be.plugins) assert.equal(after.enabledPlugins[k], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect pass**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(apply): null prev profile is treated as empty plugin list"
+```
+
+---
+
+## Phase 5: applySymlinks (AC-2 part)
+
+### Task 5.1: Test — apply creates skills/agents symlinks
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { applySymlinks } from '../bin/mr-profile.mjs';
+import { lstat, readlink } from 'node:fs/promises';
+
+test('applySymlinks: creates skills and agents symlinks under home/.claude', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applySymlinks(homeClaude, repo, profile);
+
+    const skillLink = join(homeClaude, 'skills', 'backend');
+    const agentLink = join(homeClaude, 'agents', 'backend');
+
+    const skillStat = await lstat(skillLink);
+    assert.ok(skillStat.isSymbolicLink());
+    assert.equal(await readlink(skillLink), join(repo, 'services/api/.claude/skills'));
+
+    const agentStat = await lstat(agentLink);
+    assert.ok(agentStat.isSymbolicLink());
+    assert.equal(await readlink(agentLink), join(repo, 'services/api/.claude/agents'));
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `applySymlinks`**
+
+```js
+import { symlink, lstat, unlink } from 'node:fs/promises';
+
+async function safeSymlink(target, linkPath) {
+  try {
+    const st = await lstat(linkPath);
+    if (!st.isSymbolicLink()) {
+      throw new Error(`refusing to replace non-symlink at ${linkPath}; remove manually`);
+    }
+    await unlink(linkPath);
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  await symlink(target, linkPath);
+}
+
+export async function applySymlinks(homeClaudeDir, repoRoot, profile) {
+  if (profile.local_skills) {
+    await safeSymlink(
+      join(repoRoot, profile.local_skills),
+      join(homeClaudeDir, 'skills', profile.name)
+    );
+  }
+  if (profile.local_agents) {
+    await safeSymlink(
+      join(repoRoot, profile.local_agents),
+      join(homeClaudeDir, 'agents', profile.name)
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(apply): applySymlinks creates skills/agents symlinks per profile"
+```
+
+---
+
+### Task 5.2: Test — refuses to replace non-symlink
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+test('applySymlinks: refuses to replace a real directory at the symlink path', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // create a real dir where the symlink would go
+    const block = join(homeClaude, 'skills', 'backend');
+    await mkdir(block, { recursive: true });
+
+    const profile = await loadProfile(repo, 'backend');
+    await assert.rejects(
+      applySymlinks(homeClaude, repo, profile),
+      err => err.message.includes('refusing to replace non-symlink')
+    );
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect pass** (impl in 5.1 covers this).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(apply): refuse to clobber non-symlink directory"
+```
+
+---
+
+## Phase 6: renderInstructions + cmdSessionStart (AC-6)
+
+### Task 6.1: Test — renderInstructions concatenates fragments, skips missing
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { renderInstructions } from '../bin/mr-profile.mjs';
+
+test('renderInstructions: concatenates with separator, skips missing', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    // expect AGENTS.md + services/api/AGENTS.md, separated
+    const out = await renderInstructions(repo, profile);
+    assert.match(out, /Sample Monorepo/);
+    assert.match(out, /services\/api/);
+    assert.ok(out.includes('\n\n---\n\n'));
+
+    // Add a missing fragment, ensure it's skipped (warns to stderr, doesn't throw)
+    const augmented = { ...profile, instruction_fragments: [...profile.instruction_fragments, 'does/not/exist.md'] };
+    const out2 = await renderInstructions(repo, augmented);
+    // Output should still contain the existing pieces
+    assert.match(out2, /Sample Monorepo/);
+  } finally {
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `renderInstructions`**
+
+```js
+export async function renderInstructions(repoRoot, profile) {
+  const fragments = profile.instruction_fragments ?? [];
+  const parts = [];
+  for (const rel of fragments) {
+    const full = join(repoRoot, rel);
+    try {
+      parts.push(await readFile(full, 'utf8'));
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        process.stderr.write(`warning: instruction fragment not found, skipping: ${full}\n`);
+        continue;
+      }
+      throw e;
+    }
+  }
+  return parts.join('\n\n---\n\n');
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(instructions): concatenate fragments, skip-with-warn missing"
+```
+
+---
+
+### Task 6.2: Test — cmdSessionStart emits the verified hook JSON
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { cmdSessionStart } from '../bin/mr-profile.mjs';
+
+test('cmdSessionStart: emits Claude Code SessionStart hook JSON when active-profile set', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const captured = [];
+    const stdout = { write: chunk => captured.push(chunk) };
+    const code = await cmdSessionStart({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+
+    const out = JSON.parse(captured.join(''));
+    assert.equal(out.hookSpecificOutput.hookEventName, 'SessionStart');
+    assert.match(out.hookSpecificOutput.additionalContext, /Sample Monorepo/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSessionStart: silent exit 0 when no active-profile', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const captured = [];
+    const stdout = { write: chunk => captured.push(chunk) };
+    const code = await cmdSessionStart({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    assert.equal(captured.join(''), '');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `cmdSessionStart` and `readActiveProfileName`**
+
+```js
+export async function readActiveProfileName(repoRoot) {
+  try {
+    const txt = await readFile(join(repoRoot, '.claude', 'active-profile'), 'utf8');
+    const name = txt.trim();
+    return name || null;
+  } catch (e) {
+    if (e.code === 'ENOENT') return null;
+    throw e;
+  }
+}
+
+export async function cmdSessionStart({ repoRoot, homeClaudeDir, stdout = process.stdout }) {
+  const name = await readActiveProfileName(repoRoot);
+  if (!name) return 0;
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    process.stderr.write(`session-start: ${e.message}\n`);
+    return 0;
+  }
+  const text = await renderInstructions(repoRoot, profile);
+  if (!text) return 0;
+  const out = {
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: text }
+  };
+  stdout.write(JSON.stringify(out));
+  return 0;
+}
+```
+
+(Schema confirmed in Task 0.2; if Task 0.2 found a different schema, update this output here.)
+
+- [ ] **Step 4: Run tests, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(session-start): emit Claude Code hook JSON with concatenated fragments"
+```
+
+---
+
+## Phase 7: cmdStatus with SHA fingerprint (AC-4)
+
+### Task 7.1: Test — status reports ✓ when on-disk SHA matches profile-rendered SHA
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { cmdStatus } from '../bin/mr-profile.mjs';
+
+test('cmdStatus: ✓ for each managed file after a clean apply', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    const out = lines.join('');
+
+    assert.equal(code, 0);
+    assert.match(out, /active profile: backend/);
+    assert.match(out, /\.mcp\.json: ✓/);
+    assert.match(out, /settings\.local\.json: ✓/);
+    assert.match(out, /enabledPlugins: ✓/);
+    assert.match(out, /skills symlink: ✓/);
+    assert.match(out, /agents symlink: ✓/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement helpers and `cmdStatus`**
+
+```js
+import { createHash } from 'node:crypto';
+
+function sha(s) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+async function readOrEmpty(path) {
+  try { return await readFile(path, 'utf8'); }
+  catch (e) { if (e.code === 'ENOENT') return ''; throw e; }
+}
+
+function renderMcpBytes(existing, profile) {
+  const next = { ...existing, mcpServers: profile.mcp_servers ?? {} };
+  return JSON.stringify(next, null, 2) + '\n';
+}
+
+function renderPermissionsBytes(existing, profile) {
+  const next = {
+    ...existing,
+    permissions: {
+      ...(existing.permissions ?? {}),
+      allow: profile.permissions?.allow ?? [],
+      deny:  profile.permissions?.deny  ?? []
+    }
+  };
+  return JSON.stringify(next, null, 2) + '\n';
+}
+
+function renderPluginsBytes(existing, prevProfile, newProfile) {
+  const enabled = { ...(existing.enabledPlugins ?? {}) };
+  const toEnable = newProfile.plugins ?? [];
+  const prevPlugins = prevProfile?.plugins ?? [];
+  const toDisable = prevPlugins.filter(p => !toEnable.includes(p));
+  for (const k of toEnable) enabled[k] = true;
+  for (const k of toDisable) delete enabled[k];
+  return JSON.stringify({ ...existing, enabledPlugins: enabled }, null, 2) + '\n';
+}
+
+export async function cmdStatus({ repoRoot, homeClaudeDir, stdout = process.stdout }) {
+  const name = await readActiveProfileName(repoRoot);
+  if (!name) {
+    stdout.write('no active profile (run /profile switch <name>)\n');
+    return 0;
+  }
+  const profile = await loadProfile(repoRoot, name);
+
+  const lines = [`active profile: ${name}`];
+
+  // .mcp.json
+  const mcpPath = join(repoRoot, '.mcp.json');
+  const mcpOnDisk = await readOrEmpty(mcpPath);
+  const mcpExisting = await readJsonOrEmpty(mcpPath);
+  const mcpExpected = renderMcpBytes(mcpExisting, profile);
+  lines.push(`.mcp.json: ${sha(mcpOnDisk) === sha(mcpExpected) ? '✓' : '✗ drifted'}`);
+
+  // settings.local.json
+  const permsPath = join(repoRoot, '.claude', 'settings.local.json');
+  const permsOnDisk = await readOrEmpty(permsPath);
+  const permsExisting = await readJsonOrEmpty(permsPath);
+  const permsExpected = renderPermissionsBytes(permsExisting, profile);
+  lines.push(`settings.local.json: ${sha(permsOnDisk) === sha(permsExpected) ? '✓' : '✗ drifted'}`);
+
+  // enabledPlugins (compare just the enabledPlugins subset, since other keys aren't owned)
+  const settingsPath = join(homeClaudeDir, 'settings.json');
+  const settingsExisting = await readJsonOrEmpty(settingsPath);
+  // status compares "current state has all expected keys true and no prev-only keys present"
+  const expectedKeys = profile.plugins ?? [];
+  const enabledOk = expectedKeys.every(k => settingsExisting.enabledPlugins?.[k] === true);
+  lines.push(`enabledPlugins: ${enabledOk ? '✓' : '✗ drifted'}`);
+
+  // symlinks
+  const skillLink = join(homeClaudeDir, 'skills', name);
+  const agentLink = join(homeClaudeDir, 'agents', name);
+  const checkSym = async (link, expectedTarget) => {
+    if (!expectedTarget) return '— (not in profile)';
+    try {
+      const st = await lstat(link);
+      if (!st.isSymbolicLink()) return '✗ not a symlink';
+      const t = await readlink(link);
+      return t === expectedTarget ? '✓' : '✗ wrong target';
+    } catch (e) {
+      if (e.code === 'ENOENT') return '✗ missing';
+      throw e;
+    }
+  };
+  lines.push(`skills symlink: ${await checkSym(skillLink, profile.local_skills && join(repoRoot, profile.local_skills))}`);
+  lines.push(`agents symlink: ${await checkSym(agentLink, profile.local_agents && join(repoRoot, profile.local_agents))}`);
+
+  stdout.write(lines.join('\n') + '\n');
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(status): SHA fingerprint check for each managed file"
+```
+
+---
+
+### Task 7.2: Test — status reports ✗ drifted when file edited
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+test('cmdStatus: ✗ drifted when .mcp.json was edited after switch', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // user edits the file
+    const mcpPath = join(repo, '.mcp.json');
+    const data = JSON.parse(await readFile(mcpPath, 'utf8'));
+    data.mcpServers.added = { command: 'rogue' };
+    await writeFile(mcpPath, JSON.stringify(data, null, 2) + '\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect pass** (impl in 7.1 covers it)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(status): drift detection on hand-edited managed file"
+```
+
+---
+
+### Task 7.3: Test — partial-state detection when active-profile is missing
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+test('cmdStatus: reports no active profile when active-profile file is absent', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /no active profile/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect pass**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/mr-profile.test.mjs
+git commit -m "test(status): no-active-profile message"
+```
+
+Acceptance check: AC-4 covered by Tasks 7.1–7.3.
+
+---
+
+## Phase 8: applyAll + cmdSwitch (AC-5)
+
+### Task 8.1: Test — applyAll writes in the spec-defined order; active-profile last
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { applyAll } from '../bin/mr-profile.mjs';
+
+test('applyAll: writes managed files; active-profile written last', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    const code = await applyAll({
+      repoRoot: repo, homeClaudeDir: homeClaude, profile, prevProfile: null
+    });
+    assert.equal(code, 0);
+
+    // every managed file is present
+    await readFile(join(repo, '.mcp.json'));
+    await readFile(join(repo, '.claude', 'settings.local.json'));
+    await readFile(join(homeClaude, 'settings.json'));
+    await lstat(join(homeClaude, 'skills', 'backend'));
+    await lstat(join(homeClaude, 'agents', 'backend'));
+
+    const active = (await readFile(join(repo, '.claude', 'active-profile'), 'utf8')).trim();
+    assert.equal(active, 'backend');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `applyAll` and `writeActiveProfile`**
+
+```js
+export async function writeActiveProfile(repoRoot, name) {
+  await writeFile(join(repoRoot, '.claude', 'active-profile'), name + '\n');
+}
+
+export async function applyAll({ repoRoot, homeClaudeDir, profile, prevProfile }) {
+  await applyMcp(repoRoot, profile);
+  await applySymlinks(homeClaudeDir, repoRoot, profile);
+  await applyPermissions(repoRoot, profile);
+  await applyPlugins(homeClaudeDir, prevProfile, profile);
+  await writeActiveProfile(repoRoot, profile.name);
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(switch): applyAll orchestrates writes; active-profile last"
+```
+
+---
+
+### Task 8.2: Test — cmdSwitch loads previous profile and computes diff
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { cmdSwitch } from '../bin/mr-profile.mjs';
+
+test('cmdSwitch: switching frontend -> backend removes frontend-only plugins', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    let lines = [];
+    const stdout = { write: c => lines.push(c) };
+
+    let code = await cmdSwitch({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'frontend', stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'frontend' applied/);
+    assert.match(lines.join(''), /Restart Claude Code/);
+
+    lines = [];
+    code = await cmdSwitch({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+
+    const settings = JSON.parse(await readFile(join(homeClaude, 'settings.json'), 'utf8'));
+    // Frontend-only plugins should be gone
+    assert.equal(settings.enabledPlugins['frontend-design@claude-plugins-official'], undefined);
+    // Backend-only plugins should be present
+    assert.equal(settings.enabledPlugins['gopls-lsp@claude-plugins-official'], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSwitch: missing profile returns non-zero with actionable message', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const stdout = { write: () => {} };
+    const code = await cmdSwitch({
+      repoRoot: repo, homeClaudeDir: homeClaude, name: 'missing', stdout, stderr
+    });
+    assert.notEqual(code, 0);
+    assert.match(errs.join(''), /missing/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `cmdSwitch`**
+
+```js
+export async function cmdSwitch({
+  repoRoot, homeClaudeDir, name,
+  stdout = process.stdout, stderr = process.stderr
+}) {
+  let profile;
+  try {
+    profile = await loadProfile(repoRoot, name);
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+
+  const prevName = await readActiveProfileName(repoRoot);
+  let prevProfile = null;
+  if (prevName && prevName !== name) {
+    try {
+      prevProfile = await loadProfile(repoRoot, prevName);
+    } catch (e) {
+      stderr.write(`warning: previous profile '${prevName}' could not be loaded (${e.message}); plugin removals skipped\n`);
+    }
+  }
+
+  await applyAll({ repoRoot, homeClaudeDir, profile, prevProfile });
+  stdout.write(
+    `Profile '${name}' applied. Restart Claude Code (Ctrl-D, then \`claude\`) to load plugins/MCP.\n`
+  );
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(switch): cmdSwitch loads prev profile, applies diff, prints restart"
+```
+
+Acceptance check: AC-3 plus AC-5 covered by Tasks 4 and 8.
+
+---
+
+## Phase 9: CLI dispatch + repo-root resolution
+
+### Task 9.1: Test — findRepoRoot walks up from cwd
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { findRepoRoot } from '../bin/mr-profile.mjs';
+
+test('findRepoRoot: walks up to a directory containing .claude/profiles', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const deep = join(repo, 'services', 'api');
+    const found = await findRepoRoot(deep);
+    assert.equal(found, repo);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('findRepoRoot: throws actionable error when none found', async () => {
+  await assert.rejects(
+    findRepoRoot('/'),
+    err => /no .claude\/profiles\//.test(err.message)
+  );
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `findRepoRoot`**
+
+```js
+import { stat } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+
+export async function findRepoRoot(start) {
+  let dir = resolve(start);
+  while (true) {
+    try {
+      const st = await stat(join(dir, '.claude', 'profiles'));
+      if (st.isDirectory()) return dir;
+    } catch {}
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`no .claude/profiles/ found in any parent of ${start}`);
+    }
+    dir = parent;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(cli): findRepoRoot walks up to .claude/profiles"
+```
+
+---
+
+### Task 9.2: Test — main dispatches subcommands
+
+**Files:**
+- Modify: `test/mr-profile.test.mjs`
+- Modify: `bin/mr-profile.mjs`
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+import { main } from '../bin/mr-profile.mjs';
+
+test('main: dispatches "switch <name>" using cwd-derived repo root', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['switch', 'frontend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'frontend' applied/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: prints usage and returns 2 on unknown subcommand', async () => {
+  const repo = await makeRepoFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['nonsense'], {}, { stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+  }
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+- [ ] **Step 3: Implement `main`**
+
+Replace the stub `main` in `bin/mr-profile.mjs`:
+
+```js
+import { homedir } from 'node:os';
+
+const USAGE = `usage:
+  mr-profile switch <name>
+  mr-profile status
+  mr-profile session-start
+`;
+
+export async function main(argv, env, io = {}) {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  const [sub, ...rest] = argv;
+
+  let repoRoot;
+  try {
+    repoRoot = await findRepoRoot(process.cwd());
+  } catch (e) {
+    stderr.write(`error: ${e.message}\n`);
+    return 1;
+  }
+  const home = (env && env.HOME) || homedir();
+  const homeClaudeDir = join(home, '.claude');
+
+  switch (sub) {
+    case 'switch': {
+      const [name] = rest;
+      if (!name) { stderr.write(USAGE); return 2; }
+      return await cmdSwitch({ repoRoot, homeClaudeDir, name, stdout, stderr });
+    }
+    case 'status':
+      return await cmdStatus({ repoRoot, homeClaudeDir, stdout });
+    case 'session-start':
+      return await cmdSessionStart({ repoRoot, homeClaudeDir, stdout });
+    default:
+      stderr.write(USAGE);
+      return 2;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/mr-profile.mjs test/mr-profile.test.mjs
+git commit -m "feat(cli): main dispatches switch/status/session-start"
+```
+
+---
+
+## Phase 10: Plugin packaging
+
+### Task 10.1: Plugin manifest
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "monorepo-profiles",
+  "version": "0.1.0",
+  "description": "Atomic per-monorepo profile switching: MCP servers, permissions, plugins, skills, agents, AGENTS.md fragments.",
+  "author": { "name": "dmestas" }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "chore: add plugin manifest"
+```
+
+---
+
+### Task 10.2: Slash command
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/commands/profile.md`
+
+- [ ] **Step 1: Write the slash command**
+
+```markdown
+---
+description: Manage monorepo profiles (switch, status). Run `/profile switch <name>` or `/profile status`.
+argument-hint: switch <name> | status
+---
+
+You are dispatching the `/profile` slash command.
+
+The user invoked: `/profile $ARGUMENTS`
+
+Run the following bash command, then paste its full stdout/stderr to the user verbatim. Do not interpret or rewrite the output.
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/bin/mr-profile.mjs" $ARGUMENTS
+```
+
+If the command exits non-zero, surface the error message exactly as printed.
+After a successful `switch`, the script prints a restart instruction — show it to the user prominently.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add commands/profile.md
+git commit -m "feat(plugin): /profile slash command dispatches to mr-profile"
+```
+
+---
+
+### Task 10.3: SessionStart hook
+
+**Files:**
+- Create: `/Users/dmestas/projects/monorepo-profiles/hooks/hooks.json`
+
+- [ ] **Step 1: Write the hook config**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/mr-profile.mjs\" session-start",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add hooks/hooks.json
+git commit -m "feat(plugin): SessionStart hook injects active profile fragments"
+```
+
+---
+
+## Phase 11: Manual verification (AC-7)
+
+### Task 11.1: Install plugin locally and run the manual checklist
+
+This is a one-time manual verification that real Claude Code accepts the plugin and applies state correctly post-restart.
+
+- [ ] **Step 1: Add plugin to Claude Code**
+
+Use Claude Code's `/plugin` command (in a different session) to install from `file:///Users/dmestas/projects/monorepo-profiles`.
+
+Alternative: symlink into the cache:
+```bash
+ln -sf /Users/dmestas/projects/monorepo-profiles \
+       ~/.claude/plugins/cache/local-dev/monorepo-profiles/0.1.0
+```
+…and edit `~/.claude/settings.json` to mark it enabled.
+
+- [ ] **Step 2: Pick a real monorepo for the test**
+
+Use a scratch monorepo (or a copy of the fixture) somewhere outside the plugin source. Place `frontend.json` and `backend.json` profiles in `<repo>/.claude/profiles/`. Add `active-profile` to `.gitignore`.
+
+- [ ] **Step 3: Open Claude Code in the repo**
+
+```bash
+cd <repo> && claude
+```
+
+- [ ] **Step 4: Run `/profile switch frontend`**
+
+Expected: stdout includes "Profile 'frontend' applied. Restart Claude Code…".
+
+- [ ] **Step 5: Restart Claude Code; verify state**
+
+Exit, then `claude` again. Run `/profile status`. Confirm:
+- `active profile: frontend`
+- All managed files report ✓
+- The frontend MCP servers appear in this session
+- Frontend-listed plugins are enabled (use Claude Code's `/plugin` listing)
+
+- [ ] **Step 6: Switch to backend**
+
+`/profile switch backend` → restart → `/profile status`. Confirm backend MCP, permissions, plugins. Confirm frontend-only plugins are gone.
+
+- [ ] **Step 7: Confirm drift detection**
+
+Hand-edit `.mcp.json` (add a server). Run `/profile status`. Expected: `.mcp.json: ✗ drifted`.
+
+- [ ] **Step 8: Document outcome**
+
+Append a note to `README.md` under a "Verified" section: date + Claude Code version + result. Commit.
+
+```bash
+git add README.md
+git commit -m "docs: record manual end-to-end verification result"
+```
+
+---
+
+## Final acceptance check
+
+| AC | Verified by |
+|---|---|
+| AC-1 (profile loads or rejects with actionable error) | Tasks 1.1–1.3 |
+| AC-2 (per-key ownership across managed files) | Tasks 2.1, 3.1, 4.1, 5.1, 5.2 |
+| AC-3 (plugin diff with no spooky action) | Tasks 4.1–4.3 |
+| AC-4 (status SHA fingerprint check) | Tasks 7.1–7.3 |
+| AC-5 (idempotent atomic switch via applyAll/cmdSwitch) | Tasks 2.1, 3.1, 4.1, 8.1, 8.2 (each runs apply twice) |
+| AC-6 (SessionStart hook emits verified Claude Code schema) | Tasks 0.2 + 6.1–6.2 |
+| AC-7 (manual: real Claude Code session loads new state) | Task 11.1 |
+
+Total ≈ 28 tasks, ≈ 140 step checkboxes. Each green commit lands a verifiable behavior.

--- a/plugins/monorepo-profiles/docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md
+++ b/plugins/monorepo-profiles/docs/superpowers/specs/2026-04-29-monorepo-profiles-design.md
@@ -1,0 +1,322 @@
+# monorepo-profiles — Design Spec
+
+**Status:** Approved 2026-04-29
+**Owner:** dmestas
+**Audience:** v1 implementation
+**Predecessor:** `dx-audit-claude-code-monorepo.md` (problem motivation)
+
+## Problem
+
+Claude Code is project-scoped for almost every config layer except `CLAUDE.md`. In a monorepo where one engineer alternates between frontend (`apps/web/`) and backend (`services/api/`) work, switching context means manually toggling plugins, swapping `.mcp.json`, editing `settings.local.json`, and accepting that auto-memory mixes both contexts. The audit (`/Users/dmestas/projects/dx-audit-claude-code-monorepo.md`) scored this defining workflow 3/10.
+
+## Goal
+
+Ship a Claude Code plugin that lets the user define named **profiles** (one JSON file per profile in `<repo>/.claude/profiles/`) and atomically swap the managed config layers with a single slash command. Profiles are committed to the repo so the team shares them.
+
+## Non-goals (v1)
+
+- Cross-harness support (Codex, Gemini, Cursor, Copilot). Architecture leaves room for it but no adapters ship.
+- Mid-session swap of plugins or MCP servers. Switch requires a Claude Code restart — restart prompt is part of the UX.
+- Snapshot/rollback machinery. Files under git are recovered with `git restore`; `settings.local.json` is the user's responsibility (one-time backup).
+- Drift detection beyond a presence check.
+- Concurrency control. Solo dev, no lock file.
+- Per-skill or per-agent toggling within a plugin. Only plugin-level enable/disable is supported (harness limitation).
+
+## Approach
+
+A single Node script (`bin/mr-profile.mjs`) does all the work, invoked by a slash command and a SessionStart hook. Profiles overwrite the files they manage; manual edits to those files between switches are lost. This invariant — **the profile is the single source of truth for managed files** — keeps the implementation simple and the mental model clean.
+
+When the user wants a managed file to contain something the profile doesn't say, they edit the profile, not the file.
+
+## Architecture
+
+### Source repository
+
+```
+~/projects/monorepo-profiles/
+├── .claude-plugin/plugin.json     # Claude Code plugin manifest
+├── commands/profile.md            # /profile slash command body
+├── hooks/hooks.json               # SessionStart registration
+├── bin/mr-profile.mjs             # all logic, ~200 LOC, single file
+├── test/
+│   ├── mr-profile.test.mjs        # ~150 LOC, ~10 tests
+│   └── fixtures/sample/           # one fixture monorepo
+├── docs/superpowers/specs/        # this doc lives here
+└── README.md
+```
+
+### Per-monorepo files (created/managed by the plugin in user repos)
+
+```
+<repo>/.claude/
+├── profiles/
+│   ├── frontend.json              # committed
+│   └── backend.json               # committed
+└── active-profile                 # gitignored, one line: "backend"
+```
+
+User adds `active-profile` to `.gitignore` once during onboarding (mentioned in README).
+
+## Components
+
+### `/profile` slash command
+
+`commands/profile.md` defines a single dispatcher with two subcommands:
+
+| Subcommand | Effect |
+|---|---|
+| `/profile switch <name>` | Calls `mr-profile switch <name>`. Writes managed files. Prints restart prompt. |
+| `/profile status` | Calls `mr-profile status`. Prints active profile name + presence/absence of each managed file. |
+
+### SessionStart hook
+
+`hooks/hooks.json` registers `bin/mr-profile.mjs session-start` on the SessionStart event. The hook reads `<repo>/.claude/active-profile`, loads the named profile, concatenates the contents of `instruction_fragments`, and emits a JSON object to stdout in the schema Claude Code's hook system expects. The expected shape (per current Claude Code docs) is:
+
+```json
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+```
+
+**Implementation step 1 must verify this schema against the live Claude Code hook documentation before writing the hook.** If it has changed, update the schema in code. This is the only spec assumption that requires runtime verification.
+
+If no `active-profile` file exists, the hook exits 0 with no output.
+
+### `bin/mr-profile.mjs`
+
+Single Node ESM script. Subcommands:
+
+| Subcommand | Args | Output |
+|---|---|---|
+| `switch <name>` | profile name | applies profile, prints restart prompt to stdout, exit 0 on success |
+| `status` | none | prints active profile + managed-file checks, exit 0 |
+| `session-start` | none | emits JSON `additionalContext` for SessionStart hook, exit 0 |
+
+The script auto-detects repo root by walking up from `process.cwd()` looking for `.claude/profiles/`. If none is found, it exits 1 with an actionable message.
+
+## Profile schema
+
+Example `<repo>/.claude/profiles/backend.json`:
+
+```json
+{
+  "name": "backend",
+  "description": "Go API services + Postgres + observability",
+  "mcp_servers": {
+    "signoz": { "command": "npx", "args": ["@signoz/mcp"], "env": {} },
+    "github": { "command": "npx", "args": ["@modelcontextprotocol/server-github"] }
+  },
+  "permissions": {
+    "allow": ["Bash(go *)", "Bash(docker *)", "Bash(psql *)", "Bash(kubectl get *)"],
+    "deny":  ["Bash(rm -rf *)", "Bash(kubectl delete *)"]
+  },
+  "plugins": [
+    "software-philosophy@agent-plugins",
+    "gopls-lsp@claude-plugins-official",
+    "code-review@claude-plugins-official"
+  ],
+  "local_skills": "services/api/.claude/skills",
+  "local_agents": "services/api/.claude/agents",
+  "instruction_fragments": [
+    ".claude/profiles/backend.preamble.md"
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Must equal the JSON filename stem (e.g. `backend.json` → `"backend"`) |
+| `description` | string | no | Shown in `status` output |
+| `mcp_servers` | object | no | Same shape as `.mcp.json`'s `mcpServers`. Profile fully owns `.mcp.json`. |
+| `permissions.allow` | string[] | no | Replaces `settings.local.json` allow list |
+| `permissions.deny` | string[] | no | Replaces deny list |
+| `plugins` | string[] | no | `name@marketplace` keys. Profile fully owns the user-level `enabledPlugins` map for these names. (Plugins not listed by any profile are not touched.) |
+| `local_skills` | string | no | Path **relative to repo root** pointing to a directory of skills; symlinked to `~/.claude/skills/<profile-name>/` |
+| `local_agents` | string | no | Path **relative to repo root** pointing to a directory of agents; symlinked to `~/.claude/agents/<profile-name>/` |
+| `instruction_fragments` | string[] | no | Paths relative to repo root; concatenated into SessionStart `additionalContext`. Reserve this for supplementary content not picked up by Claude Code's CLAUDE.md cwd cascade — e.g., profile-specific preambles. Listing CLAUDE.md itself is allowed but redundant; the cascade already injects it. |
+
+### Managed files — uniform per-key ownership
+
+Every managed file follows the same rule: **the profile owns specific keys it lists; every other key in that file is preserved.** This single rule applies to all writes.
+
+| Path | Profile-owned key(s) | Preserved on the same file |
+|---|---|---|
+| `<repo>/.mcp.json` | `mcpServers` | any other top-level keys (none today; future-proofing) |
+| `<repo>/.claude/settings.local.json` | `permissions.allow`, `permissions.deny` | every other top-level key (`env`, `hooks`, etc.) |
+| `~/.claude/settings.json` | `enabledPlugins[<key>]` for each key in the previous profile's plugins ∪ the new profile's plugins | all other keys including `enabledPlugins` keys for non-managed plugins |
+| `~/.claude/skills/<profile-name>/` | the symlink itself | nothing else under `~/.claude/skills/` |
+| `~/.claude/agents/<profile-name>/` | the symlink itself | nothing else under `~/.claude/agents/` |
+| `<repo>/.claude/active-profile` | the entire file | n/a (single-purpose file) |
+
+### Write order
+
+Writes happen in this fixed order so that mid-write failure damages the most-recoverable files first and leaves the completion flag in a state the next `/profile status` can detect:
+
+1. `<repo>/.mcp.json` — git-tracked, trivial restore on failure
+2. `~/.claude/skills/<name>/` and `~/.claude/agents/<name>/` symlinks — idempotent, easy to delete
+3. `<repo>/.claude/settings.local.json` — gitignored; the user keeps a one-time backup per onboarding instructions
+4. `~/.claude/settings.json` `enabledPlugins` — user-global; manual recovery, hardest case
+5. `<repo>/.claude/active-profile` — written **last**, acts as the completion flag. If `active-profile` is missing or stale, `/profile status` will detect the partial state and report it.
+
+### Plugin-key tracking — previous→current diff
+
+Switching plugins requires knowing what to remove (last profile's plugins not in the new profile). The script computes this from local context only: the previous profile name comes from `<repo>/.claude/active-profile` (read before it is overwritten), and only the previous profile's `plugins` list is consulted. No "union of all profiles" — the apply behavior depends only on the two profiles directly involved.
+
+Algorithm on `switch <new>`:
+
+1. Read `active-profile` → previous name (may be absent).
+2. If previous exists and previous profile file exists, load it; otherwise treat its plugins as `[]`.
+3. Compute:
+   - `to_enable  = new.plugins`
+   - `to_disable = previous.plugins − new.plugins`
+4. In `~/.claude/settings.json.enabledPlugins`: set keys in `to_enable` to `true`; remove keys in `to_disable`. All other keys are untouched.
+
+Edge cases:
+- First-ever switch (no previous): `to_disable = []`, just enable.
+- Previous profile file deleted: warn to stderr, treat as `to_disable = []` (don't orphan plugins).
+- Same profile re-applied: `to_enable = new.plugins`, `to_disable = previous.plugins − new.plugins = []`. No-op for plugin keys.
+
+This replaces the earlier "union of all profiles" model — local reasoning only, no spooky action between unrelated profile files.
+
+## Data flow
+
+### Switch
+
+```
+/profile switch backend
+  └→ mr-profile switch backend
+      ├→ resolve repo root
+      ├→ load <repo>/.claude/profiles/backend.json, validate
+      ├→ load all profiles in <repo>/.claude/profiles/ (compute managed plugin set)
+      ├→ write .mcp.json
+      ├→ write .claude/settings.local.json (preserving non-permissions keys)
+      ├→ write ~/.claude/settings.json enabledPlugins (managed-set diff)
+      ├→ symlink ~/.claude/skills/<name>/ and ~/.claude/agents/<name>/
+      ├→ write .claude/active-profile
+      └→ print: "Profile 'backend' applied. Restart Claude Code to load plugins/MCP."
+```
+
+### Status
+
+```
+/profile status
+  └→ mr-profile status
+      ├→ read .claude/active-profile
+      ├→ for each managed file/symlink:
+      │     ├→ render what the active profile would write for that file (in memory)
+      │     ├→ compute SHA-256 of rendered bytes vs SHA-256 of on-disk bytes
+      │     └→ ✓ if equal, ✗ drifted (with a hint of which keys differ) if not
+      └→ print active name + per-file ✓/✗ list + last-switch timestamp (if known)
+```
+
+The drift check is intentionally a fingerprint comparison rather than a full diff — cheap, no extra deps, and accurate enough for the user to know whether to re-apply or investigate.
+
+### SessionStart
+
+```
+SessionStart event
+  └→ hooks/hooks.json invokes mr-profile session-start
+      ├→ read .claude/active-profile (skip if missing)
+      ├→ load profile, read instruction_fragments
+      ├→ concatenate (separator: "\n\n---\n\n")
+      └→ stdout: {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}
+```
+
+## Error handling
+
+| Failure | Detection | Response |
+|---|---|---|
+| Profile not found | `fs.access` | exit 1, message lists available profiles |
+| Profile JSON invalid | `JSON.parse` throws | exit 1, message includes file path and parse position |
+| Schema invalid (e.g. missing `name`) | manual validator | exit 1, lists each violation |
+| Repo root not found | walked to `/` | exit 1, "no .claude/profiles/ in any parent" |
+| Mid-write failure | try/catch around each write | exit 1 with the failed path; user runs `git restore` |
+| Symlink target missing | `fs.access` on source | warn to stderr, skip, continue |
+| Symlink slot occupied by non-symlink | `fs.lstat` | exit 1, "remove `~/.claude/skills/<name>/` manually" |
+| `active-profile` references missing profile | hook + status | hook exits 0 silently; status flags it |
+
+No transactions, no rollback. The user's recovery is: `git restore .mcp.json` and a backup of `settings.local.json`.
+
+## Testing
+
+### Test stack
+
+`node --test` (built-in to Node 20+, zero deps). Fixtures under `test/fixtures/sample/`. Each integration test copies the fixture to a `mkdtemp` directory and operates there.
+
+### Test list
+
+| # | Test | Category |
+|---|---|---|
+| 1 | profile rejects missing required fields with clear error | unit |
+| 2 | profile loads a valid file | unit |
+| 3 | malformed JSON gives file path + parse position | unit |
+| 4 | apply writes `.mcp.json` with profile servers | unit |
+| 5 | apply writes `settings.local.json`, preserves `env` key | unit |
+| 6a | apply enables new profile's plugins; keys not in either previous or new are untouched | unit |
+| 6b | apply removes plugins listed in previous profile but not in new profile | unit |
+| 6c | apply with no previous profile only enables (no removals); previous-profile-deleted warns and skips removals | unit |
+| 7 | apply creates skills/agents symlinks, refuses non-symlink target | unit |
+| 8 | apply concatenates `instruction_fragments`, skips missing with warning | unit |
+| 9a | status reports active profile + ✓ for each managed file when on-disk SHA matches profile-rendered SHA | unit |
+| 9b | status reports ✗ drifted for a managed file whose on-disk SHA differs from rendered | unit |
+| 9c | status detects partial state when `active-profile` is absent but managed files exist | unit |
+| 10 | session-start emits the verified Claude Code hook JSON schema with concatenated fragments | unit |
+
+### TDD discipline
+
+For each row:
+1. Write the test → run → **see red**.
+2. Implement minimum to make it pass → run → **see green**.
+3. Refactor if needed → run → still green.
+4. Commit.
+
+Commit cadence: ~one commit per green. Never commit without a green test.
+
+### Acceptance criteria
+
+| ID | Criterion | Verified by |
+|---|---|---|
+| AC-1 | Profile JSON loads or rejects with actionable error | tests 1-3 |
+| AC-2 | Each managed file follows the per-key ownership rule; non-owned keys preserved | tests 4-5, 6a, 7, 8 |
+| AC-3 | Plugin enable/remove follows previous→current diff with no spooky action between unrelated profiles | tests 6a, 6b, 6c |
+| AC-4 | `/profile status` reports active profile + per-file SHA-fingerprint match (✓ / ✗ drifted / partial-state) | tests 9a, 9b, 9c |
+| AC-5 | `/profile switch <name>` is idempotent: applying same profile twice yields same on-disk state | each of tests 4-8 runs apply twice and asserts identical output |
+| AC-6 | SessionStart hook emits the verified Claude Code JSON schema with concatenated fragments | test 10 |
+| AC-7 | Manual: real Claude Code session post-restart sees new MCP servers, permissions, enabled plugins | manual checklist (one-time) |
+
+### Manual checklist (one-time, post-implementation)
+
+1. Install plugin in Claude Code locally (file:// install or symlink into plugins cache).
+2. In a fixture monorepo, create `frontend.json` and `backend.json` profiles.
+3. `/profile switch frontend` → exit Claude Code → `claude` again → `/profile status` shows frontend active and Claude session has frontend MCP servers.
+4. `/profile switch backend` → restart → status shows backend, MCP and permissions reflect backend.
+5. Manually edit `.mcp.json` → `/profile switch backend` again → file is overwritten (confirms the invariant).
+
+## Out of scope, but acknowledged
+
+- **Cross-harness use.** v1 is Claude Code-only. The plugin shell (manifest, slash command, hook config) is Claude-specific. The core script `bin/mr-profile.mjs` is harness-agnostic — it reads JSON profiles and writes standard config files — so a future adapter for Cursor/Codex/Gemini could invoke it from their hook systems, but no such adapters ship in v1. Profile schema choices should not be driven by hypothetical adapters.
+- **Per-skill toggling.** Harness loads all skills in `~/.claude/skills/`. Symlinking a profile-bundled dir gives those skills; harness has no per-skill enable knob.
+- **Auto cwd-binding.** A profile does not declare `activates_when: <glob>`. Switching is always explicit.
+- **Symlinking `.mcp.json` into the profile (v2 candidate).** v1 keeps profile and `.mcp.json` as separate files; hand-edits to `.mcp.json` are lost on next switch. The proper "define error out of existence" answer is to make `.mcp.json` a symlink into a per-profile rendered file so editing it edits the active profile's data — but that requires restructuring profiles from single JSON files to directories. Logged for v2.
+
+## File creation/modification scope (v1 implementation)
+
+To avoid scope creep, the implementation creates exactly these files:
+
+```
+monorepo-profiles/.claude-plugin/plugin.json
+monorepo-profiles/commands/profile.md
+monorepo-profiles/hooks/hooks.json
+monorepo-profiles/bin/mr-profile.mjs
+monorepo-profiles/test/mr-profile.test.mjs
+monorepo-profiles/test/fixtures/sample/.claude/profiles/frontend.json
+monorepo-profiles/test/fixtures/sample/.claude/profiles/backend.json
+monorepo-profiles/test/fixtures/sample/AGENTS.md
+monorepo-profiles/README.md
+monorepo-profiles/.gitignore
+```
+
+Approximate sizes:
+- `bin/mr-profile.mjs` — ~200 LOC
+- `test/mr-profile.test.mjs` — ~150 LOC
+- everything else — small
+
+Total budget: ~400 LOC source + tests, plus configuration.

--- a/plugins/monorepo-profiles/docs/superpowers/specs/2026-04-29-monorepo-profiles-v0.2-design.md
+++ b/plugins/monorepo-profiles/docs/superpowers/specs/2026-04-29-monorepo-profiles-v0.2-design.md
@@ -1,0 +1,386 @@
+# monorepo-profiles v0.2 — Design Spec
+
+**Status:** Approved 2026-04-29
+**Owner:** dmestas
+**Audience:** v0.2 implementation
+**Predecessors:**
+- `dx-audit-claude-code-monorepo.md` (original problem)
+- `2026-04-29-monorepo-profiles-design.md` (v0.1 spec)
+- `dx-audit-monorepo-profiles.md` (v0.1 audit, motivation for this work)
+
+## Problem
+
+The v0.1 plugin scored 5/10 on the workflow audit, anchored by two pains:
+
+1. **Authoring is destructive.** The only way to test a profile is `/profile switch <name>`, which writes to live state and forces a Claude Code restart. Iterating on a new profile costs N restarts.
+2. **`/profile status` is too shallow.** "✗ drifted" tells the user they're out of sync but not what diverged. They have to `cat` files and compare by eye.
+
+A third pain — onboarding has no editor support — comes from the absence of a JSON Schema. Profiles are hand-written JSON with undiscoverable plugin IDs and field names; typos surface only after a destructive switch.
+
+## Goal
+
+Ship three additions in v0.2 that lift the audit score from 5/10 to ~7/10 without changing any v0.1 behavior:
+
+1. **`/profile validate <name>`** — non-destructive correctness check
+2. **`/profile diff <name>`** — preview what `/profile switch <name>` would change
+3. **JSON Schema** + a single status detail addition
+
+The fourth fix (drift detail in `/profile status`) is bundled here because it shares its key-diff machinery with `/profile diff`.
+
+## Non-goals (v0.2)
+
+- `/profile init` scaffolder — deferred to v0.3
+- `/profile rollback` — still no rollback in v0.2
+- Mid-session reload (no restart) — requires Claude Code harness investigation, deferred
+- Plugin installation precondition check (verify referenced plugins are actually installed on this machine) — deferred to v0.3
+- Backup `settings.local.json` on first switch — deferred to v0.3
+- `$schema` field in user profiles — schema is consumed via editor config, not embedded
+
+## Approach
+
+All three features extend the existing single-file Node script (`bin/mr-profile.mjs`). No new modules, no new dependencies. The render helpers introduced in v0.1 (`renderMcpBytes`, `renderPermissionsBytes`) become the shared computation engine for validate, diff, and status's drift count — reinforcing the "single source of truth" property already established for apply ↔ status.
+
+Both new subcommands take an **optional** profile name; when omitted, they default to the active profile (read from `<repo>/.claude/active-profile`). If neither is set, they exit 2 with USAGE.
+
+## Architecture
+
+### Source repository changes
+
+```
+bin/mr-profile.mjs                  # +~120 LOC: cmdValidate, cmdDiff, drift count, dispatch
+test/mr-profile.test.mjs            # +~150 LOC: 8 new tests
+.claude-plugin/profile.schema.json  # NEW (~50 lines, JSON Schema Draft-07)
+README.md                           # +"Editor schema setup" section
+```
+
+### Subcommand surface (new)
+
+| Subcommand | Args | Output | Exit |
+|---|---|---|---|
+| `validate [name]` | optional profile name; defaults to active | summary line + categorized issue list | 0 if no errors, 1 if any error |
+| `diff [name]` | optional profile name; defaults to active | per-file structured diff | 0 always (informational) |
+
+The existing `switch`, `status`, `session-start` subcommands are unchanged in semantics. `cmdStatus` gains the drift-count addition.
+
+## Component: `cmdValidate`
+
+```js
+export async function cmdValidate({
+  repoRoot, homeClaudeDir, name, stdout, stderr
+})
+```
+
+**Algorithm:**
+
+1. Resolve `name`: arg → falls back to `readActiveProfileName(repoRoot)` → if still null, write USAGE to stderr, return 2.
+2. Load profile via existing `loadProfile(repoRoot, name)`. If load throws, write `error: <msg>` to stderr, return 1. (loadProfile already covers JSON parse + schema-required-field errors.)
+3. Run extended checks (table below). Each check produces a list of `{level: 'error'|'warn', message: string}` entries.
+4. Format and write the report. Return 1 if any `error` entry, else 0.
+
+(The render functions `renderMcpBytes` / `renderPermissionsBytes` are pure JSON serialization with no realistic throw paths once `loadProfile` has succeeded; no need to wrap them.)
+
+### Extended checks
+
+| Check | Severity | Condition |
+|---|---|---|
+| `mcp_servers.<name>` missing both `command` and `url` | error | for each entry where neither field is a non-empty string |
+| `mcp_servers.<name>.command` is non-string when present | error | type check |
+| `plugins[i]` doesn't match `^[\w-]+@[\w-]+$` | warn | per item |
+| `local_skills` source dir doesn't exist on disk | error | `fs.access(join(repoRoot, profile.local_skills))`. Apply would create a silent dangling symlink. |
+| `local_agents` source dir doesn't exist on disk | error | same |
+| `instruction_fragments[i]` path doesn't exist on disk | warn | per item |
+
+**Why these severities:** errors describe states that would produce a useless `.mcp.json` after a switch (Claude Code would refuse to start the server), or render-function exceptions. Warnings describe states that won't break a switch but will silently fail at runtime — dangling symlinks, plugins that don't load, fragments that get skip-warned by the SessionStart hook.
+
+**Excluded check:** "is the plugin actually installed in `~/.claude/plugins/installed_plugins.json`?" — this couples validate to user-local state and creates false negatives for team-shareable validation. Belongs in a v0.3 precondition check.
+
+### Output (valid)
+
+```
+Profile 'backend': ✓ valid (3 plugins, 2 mcp servers, 1 fragment, skills, agents)
+```
+
+The summary lists count of plugins, mcp servers, instruction fragments, and yes/no for skills+agents (omitting fields that are absent).
+
+**When the name was resolved implicitly from `active-profile`** (no positional arg passed), prepend a single line so the user knows which profile they actually validated:
+
+```
+Using active profile 'backend'.
+Profile 'backend': ✓ valid (...)
+```
+
+### Output (issues)
+
+```
+Profile 'backend': ✗ 1 error, 2 warnings
+  ERROR  mcp_servers.signoz: missing 'command' or 'url'
+  WARN   instruction_fragments[0]: '.claude/profiles/backend.preamble.md' does not exist
+  WARN   plugins[1]: 'gopls-lsp_typo' does not match 'name@marketplace' pattern
+```
+
+Header line summarizes counts. Issue lines start with two-space indent + 5-char level tag + 2 spaces + message. All output goes to **stdout** (the report is the answer; stderr is reserved for unexpected exceptions).
+
+## Component: `cmdDiff`
+
+```js
+export async function cmdDiff({
+  repoRoot, homeClaudeDir, name, stdout, stderr
+})
+```
+
+**Algorithm:**
+
+1. Resolve `name` (same fallback chain as validate).
+2. Load profile. On error, write `error: <msg>` to stderr, return 1.
+3. For each managed file, compute the diff. Diff structure: `{ path: string, status: 'match'|'differ'|'missing'|'wrong-target', changes: Change[] }`.
+4. Format and write report. Return 0 (the report itself is the answer; differences are informational, not errors).
+
+### Per-file diff strategy
+
+| File | Owned namespace | Diff method |
+|---|---|---|
+| `<repo>/.mcp.json` | `mcpServers.*` | Set diff over keys; if both keys exist but values differ, mark `~ <key> (content differs)` (no deep recursion) |
+| `<repo>/.claude/settings.local.json` | `permissions.allow[]`, `permissions.deny[]` | Set diff over array elements |
+| `~/.claude/settings.json` | `enabledPlugins[<key>]` | **State projection.** Compute projected map: start from current `enabledPlugins`, set new profile's plugin keys to `true`, delete keys in `(prev.plugins − new.plugins)`. Diff current vs projected — only effective changes (false→true, or actually-deleted keys) appear. |
+| `~/.claude/skills/<name>/` | the symlink | lstat + readlink; report missing / wrong-target / matches |
+| `~/.claude/agents/<name>/` | same | same |
+| `<repo>/.claude/active-profile` | the entire string | exact equality; report `~ was 'X', expected 'Y'` |
+
+**Determining `prevProfile` for the plugin diff:** read `active-profile`. If the named profile differs from active, treat active as prev. If they match, prev = the same profile (so `to_disable = []` per the apply semantics).
+
+**Why state projection rather than profile-vs-profile diff:** if you ran `/profile diff backend` while backend is already active, a profile-vs-profile diff would either show every backend plugin as `+ added` (with prev=null) or nothing at all. Neither is honest. Projecting current state forward through the apply algorithm, then diffing current vs projected, shows only the effective changes the user would observe on disk. Re-applying the active profile produces an empty plugin diff, as it should.
+
+```js
+// Projection sketch
+const current = settings.enabledPlugins ?? {};
+const projected = { ...current };
+for (const k of newProfile.plugins) projected[k] = true;
+for (const k of (prev?.plugins ?? []).filter(p => !newProfile.plugins.includes(p))) {
+  delete projected[k];
+}
+// Diff current vs projected — effective changes only
+```
+
+### Output
+
+When name was resolved implicitly from `active-profile`, prepend `Using active profile 'X'.` (same convention as `cmdValidate`).
+
+Concrete example with the sample fixture, switching from active=frontend to backend:
+
+```
+Diff for profile 'backend' (vs current state):
+
+.mcp.json:
+  + mcpServers.signoz
+  ~ mcpServers.github   (content differs)
+
+.claude/settings.local.json:
+  + permissions.allow: 'Bash(go *)'
+  - permissions.allow: 'Bash(npm *)'
+
+~/.claude/settings.json (enabledPlugins):
+  + gopls-lsp@claude-plugins-official
+  - frontend-design@claude-plugins-official
+
+~/.claude/skills/backend:
+  + would create symlink → /Users/.../services/api/.claude/skills
+
+~/.claude/agents/backend:
+  ✓ matches
+
+.claude/active-profile:
+  ~ was 'frontend', expected 'backend'
+
+Run /profile switch backend to apply.
+```
+
+If a file is fully matched, it shows a single `✓ matches` line under its header. If everything matches across all files, the body is the headers + `✓ matches` per line, and a footer `No changes.` instead of the run-prompt.
+
+Output to **stdout**. Stderr only on exception.
+
+## Component: drift count in `cmdStatus`
+
+Single change. The line that today reads:
+```
+.mcp.json: ✗ drifted
+```
+becomes one of two forms:
+```
+.mcp.json: ✗ drifted (3 keys differ)
+.mcp.json: ✗ drifted (formatting only)
+```
+
+The two forms exist because `cmdStatus` already uses two layers of comparison:
+- **SHA-256** flags any byte difference, including whitespace or key-order changes.
+- **Key-diff** counts only key-level differences in the profile-owned namespace.
+
+When SHA mismatches AND key-diff is non-empty: `(N keys differ)`. When SHA mismatches but key-diff is empty (user reordered keys, ran a formatter, etc.): `(formatting only)` — honest about the situation without misleading the user with a `(0 keys differ)` count.
+
+For permissions, count = `len(allow_diff) + len(deny_diff)`. For enabledPlugins, the existing label `✗ missing required (<plugin>)` already names a specific plugin — keep it as-is, don't add a count.
+
+A footer line is appended when any file is drifted:
+
+```
+Run /profile diff for details.
+```
+
+When everything matches, the footer is absent.
+
+## Component: JSON Schema
+
+**Path:** `.claude-plugin/profile.schema.json`
+
+**Shape (Draft-07):**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://example.invalid/monorepo-profiles/profile.schema.json",
+  "title": "monorepo-profiles profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name"],
+  "properties": {
+    "name": { "type": "string", "pattern": "^[a-zA-Z0-9_-]+$" },
+    "description": { "type": "string" },
+    "mcp_servers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "anyOf": [
+          { "required": ["command"] },
+          { "required": ["url"] }
+        ],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "url": { "type": "string" }
+        }
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": { "type": "array", "items": { "type": "string" } },
+        "deny":  { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[\\w-]+@[\\w-]+$" }
+    },
+    "local_skills": { "type": "string" },
+    "local_agents": { "type": "string" },
+    "instruction_fragments": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}
+```
+
+**Why these constraints:**
+- `additionalProperties: false` at the top level catches typos like `mcpServers` (camelCase) instead of `mcp_servers`.
+- The `anyOf` on each MCP server entry mirrors the runtime check in `cmdValidate` so editors flag the same issue at edit-time.
+- The `plugins` regex catches `gopls-lsp` (missing marketplace) before a destructive switch.
+
+**Why no `$schema` field added to user profiles:** committing a `$schema` URL into every profile JSON either ties them to a non-existent public URL or to a fragile relative path. Editor users can wire the schema once via `json.schemas` config without polluting profile files.
+
+### README addition
+
+Append a short section to `README.md`:
+
+```markdown
+## Editor schema setup (optional)
+
+The plugin ships a JSON Schema for profile files. To get autocomplete, hover docs,
+and typo detection in VS Code or Cursor, add to `.vscode/settings.json` in your
+monorepo:
+
+\`\`\`json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".claude/profiles/*.json"],
+      "url": "/absolute/path/to/monorepo-profiles/.claude-plugin/profile.schema.json"
+    }
+  ]
+}
+\`\`\`
+
+The plugin's install path is shown by `/plugin` in Claude Code. Or, for team-
+shareable editor config, copy the schema into your repo (e.g. to
+`.claude/profile.schema.json`) and commit it.
+```
+
+## Error handling
+
+Inherits the existing model: `cmdValidate` and `cmdDiff` use the same `loadProfile` and `readActiveProfileName` helpers as the rest of the CLI, so behavior on missing/malformed profile files is consistent. The new error paths:
+
+| Failure | Detection | Response |
+|---|---|---|
+| Subcommand without name AND no active profile | combined check | exit 2, USAGE on stderr |
+| Diff: profile load fails | reuses loadProfile error | exit 1, `error: <msg>` on stderr |
+| Diff: filesystem read fails (e.g. permission denied on `settings.local.json`) | per-file try/catch | report `~ <path>: read failed (<errno>)`, exit 0 (informational) |
+
+## Testing
+
+### TDD increments (8 new tests + 2 to update)
+
+| # | Test | Phase |
+|---|---|---|
+| 1 | `cmdValidate`: valid backend profile → exit 0 with summary | Validate |
+| 2 | `cmdValidate`: mcp server missing command/url → exit 1, ERROR | Validate |
+| 3 | `cmdValidate`: invalid plugin id pattern → exit 0 with WARN | Validate |
+| 4 | `cmdValidate`: missing fragment path → exit 0 with WARN | Validate |
+| 5 | `cmdValidate`: defaults to active profile when name omitted | Validate |
+| 6 | `cmdValidate`: no name + no active-profile → exit 2 with USAGE | Validate |
+| 7 | `cmdDiff`: all-match shows `✓ matches` per file, no key list | Diff |
+| 8 | `cmdDiff`: prev=frontend, name=backend shows expected +/- key lines | Diff |
+| 9 | `cmdStatus`: drifted .mcp.json line shows `(N keys differ)` count | Status drift count |
+| 10 | `cmdStatus`: when drifted, footer `Run /profile diff for details.` appears | Status drift count |
+
+**Tests to update (existing):**
+- `cmdStatus: ✓ for each managed file after a clean apply` — must still pass; assertion on absence of footer when no drift.
+
+### Acceptance criteria (v0.2)
+
+| ID | Criterion | Verified by |
+|---|---|---|
+| v0.2-AC-1 | `cmdValidate` reports actionable errors and warnings without writing any file | tests 1–4 |
+| v0.2-AC-2 | `cmdValidate` defaults to active profile and exits 2 with USAGE if neither name nor active is set | tests 5, 6 |
+| v0.2-AC-3 | `cmdDiff` output matches the spec'd format for both all-match and partial-diff cases | tests 7, 8 |
+| v0.2-AC-4 | `/profile status` includes a `(N keys differ)` count and `Run /profile diff` footer when drifted | tests 9, 10 |
+| v0.2-AC-5 | Schema file exists, parses as valid JSON, and references the v0.1 profile shape (manual: open in editor with `json.schemas` configured, type `mcp_servers`, see autocomplete) | manual |
+| v0.2-AC-6 | All v0.1 tests continue to pass | full test suite |
+
+### Manual verification (v0.2-AC-5 only)
+
+After implementation, on the user's machine:
+
+1. Pick any monorepo with `.claude/profiles/*.json` (the scratch test repo from v0.1's manual verification works fine).
+2. Add `.vscode/settings.json` with the README's `json.schemas` snippet, pointing at the absolute path of `<plugin-install-dir>/.claude-plugin/profile.schema.json`.
+3. Open a profile JSON. Type a typo like `mcp_serverz` (not `mcp_servers`) — editor should flag it.
+4. Type a new key inside `mcp_servers.foo.` and observe autocomplete for `command`, `args`, `env`, `url`.
+
+If the schema works in one editor (VS Code), declare AC-5 met. Don't manually test every editor.
+
+## Out of scope, but acknowledged
+
+- **Onboarding scaffolder (`/profile init`).** Highest-leverage v0.3 candidate. Postponed to keep v0.2 small.
+- **Mid-session reload.** Requires investigation of Claude Code's hook/reload semantics. May not be feasible at all without harness changes.
+- **Pre-switch plugin install check.** Couples to user-local state. Belongs in a separate "team mode" feature with `/profile install-deps`.
+
+## File creation/modification scope (v0.2 implementation)
+
+```
+bin/mr-profile.mjs                          (modify, +~120 LOC)
+test/mr-profile.test.mjs                    (modify, +~150 LOC, ~10 new tests)
+.claude-plugin/profile.schema.json          (create, ~50 LOC)
+README.md                                   (modify, +1 section)
+docs/superpowers/specs/2026-04-29-monorepo-profiles-v0.2-design.md  (this doc)
+```
+
+End state: 35 + 10 = 45 tests; `bin/mr-profile.mjs` ≈ 470 LOC; new commands wired into `main` and `commands/profile.md`.

--- a/plugins/monorepo-profiles/docs/superpowers/specs/hook-schema-verification.md
+++ b/plugins/monorepo-profiles/docs/superpowers/specs/hook-schema-verification.md
@@ -1,0 +1,59 @@
+# SessionStart hook output schema verification
+
+**Date:** 2026-04-29
+**Source:** https://docs.claude.com/en/docs/claude-code/hooks (sections "Add context for Claude" and "SessionStart decision control")
+**Verdict:** Spec assumption matches the official schema. No spec changes required.
+
+## Verified schema
+
+To inject text into the model's session context from a SessionStart hook, the
+hook command writes the following JSON object to stdout:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "Current branch: feat/auth-refactor\nUncommitted changes: src/auth.ts, src/login.tsx\nActive issue: #4211 Migrate to OAuth2"
+  }
+}
+```
+
+- Top-level key: **`hookSpecificOutput`** (object).
+- Required nested fields:
+  - **`hookEventName`** — must equal `"SessionStart"` for the SessionStart event.
+  - **`additionalContext`** — string. Claude Code wraps it in a system reminder
+    and inserts it into the conversation at the start, before the first prompt.
+
+The docs also note: "Any text your hook script prints to stdout is added as
+context for Claude" for SessionStart specifically. The structured JSON form is
+preferred because it is explicit and survives format changes to plain stdout
+handling.
+
+## Other fields a SessionStart hook can return
+
+These come from the universal "JSON output" section and apply to every hook
+event, including SessionStart:
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `continue` | `true` | If `false`, Claude stops processing entirely after the hook runs. Takes precedence over event-specific decision fields. |
+| `stopReason` | none | Message shown to the user when `continue` is `false`. Not shown to Claude. |
+| `suppressOutput` | `false` | If `true`, omits stdout from the debug log. |
+| `systemMessage` | none | Warning message shown to the user. |
+
+SessionStart-specific decision-control fields are limited to
+`hookSpecificOutput.additionalContext` (per the SessionStart decision-control
+table in the docs). Top-level `decision`/`reason` are NOT used by SessionStart;
+the docs list `decision: "block"` only for `PreToolUse`, `UserPromptSubmit`,
+`PostToolUse`, `PostToolBatch`, `Stop`, `SubagentStop`, `ConfigChange`, and
+`PreCompact`.
+
+## Implication for this plugin
+
+`bin/mr-profile.mjs session-start` should:
+
+1. Read the active profile and concatenate `instruction_fragments`.
+2. Print a single JSON object to stdout matching the verified schema above.
+3. Exit 0. Use `continue: false` + `stopReason` only on a fatal error where the
+   user must intervene; otherwise print an empty `additionalContext` and exit 0
+   so a missing/broken profile never blocks session startup.

--- a/plugins/monorepo-profiles/hooks/hooks.json
+++ b/plugins/monorepo-profiles/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/mr-profile.mjs\" session-start",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/monorepo-profiles/package.json
+++ b/plugins/monorepo-profiles/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monorepo-profiles",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test --test-reporter=spec 'test/**/*.test.mjs'"
+  }
+}

--- a/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/backend.json
+++ b/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/backend.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "description": "Go API services",
+  "mcp_servers": {
+    "github": { "command": "npx", "args": ["@modelcontextprotocol/server-github"] }
+  },
+  "permissions": {
+    "allow": ["Bash(go *)", "Bash(docker *)"],
+    "deny":  ["Bash(rm -rf *)", "Bash(kubectl delete *)"]
+  },
+  "plugins": [
+    "gopls-lsp@claude-plugins-official",
+    "code-review@claude-plugins-official"
+  ],
+  "local_skills": "services/api/.claude/skills",
+  "local_agents": "services/api/.claude/agents",
+  "instruction_fragments": [".claude/profiles/backend.preamble.md"]
+}

--- a/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/backend.preamble.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/backend.preamble.md
@@ -1,0 +1,4 @@
+# Backend profile preamble
+
+You are working in the API service. Use Go conventions, prefer table-driven tests,
+and surface schema migrations carefully.

--- a/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/frontend.json
+++ b/plugins/monorepo-profiles/test/fixtures/sample/.claude/profiles/frontend.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "description": "Web app stack",
+  "mcp_servers": {
+    "playwright": { "command": "npx", "args": ["@playwright/mcp"] }
+  },
+  "permissions": {
+    "allow": ["Bash(npm *)", "Bash(pnpm *)"],
+    "deny":  ["Bash(rm -rf *)"]
+  },
+  "plugins": [
+    "frontend-design@claude-plugins-official",
+    "agent-browser@claude-plugins-official"
+  ],
+  "local_skills": "apps/web/.claude/skills"
+}

--- a/plugins/monorepo-profiles/test/fixtures/sample/CLAUDE.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/CLAUDE.md
@@ -1,0 +1,3 @@
+# Sample Monorepo
+
+Fixture used by monorepo-profiles tests.

--- a/plugins/monorepo-profiles/test/fixtures/sample/apps/web/.claude/skills/dummy-skill/SKILL.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/apps/web/.claude/skills/dummy-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: dummy-skill
+description: Used only as a fixture for monorepo-profiles tests.
+---
+This is a fixture skill. It does nothing.

--- a/plugins/monorepo-profiles/test/fixtures/sample/services/api/.claude/agents/migration-runner.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/services/api/.claude/agents/migration-runner.md
@@ -1,0 +1,5 @@
+---
+name: migration-runner
+description: Used only as a fixture for monorepo-profiles tests.
+---
+You are a fixture agent. Do nothing.

--- a/plugins/monorepo-profiles/test/fixtures/sample/services/api/.claude/skills/db-expert/SKILL.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/services/api/.claude/skills/db-expert/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: db-expert
+description: Used only as a fixture for monorepo-profiles tests.
+---
+This is a fixture skill. It does nothing.

--- a/plugins/monorepo-profiles/test/fixtures/sample/services/api/CLAUDE.md
+++ b/plugins/monorepo-profiles/test/fixtures/sample/services/api/CLAUDE.md
@@ -1,0 +1,3 @@
+# services/api
+
+Backend service preamble fragment used by monorepo-profiles tests.

--- a/plugins/monorepo-profiles/test/helpers.mjs
+++ b/plugins/monorepo-profiles/test/helpers.mjs
@@ -1,0 +1,27 @@
+import { mkdtemp, rm, mkdir, writeFile, cp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, 'fixtures', 'sample');
+
+export async function makeRepoFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'mr-profile-repo-'));
+  await cp(FIXTURE_ROOT, dir, { recursive: true });
+  return dir;
+}
+
+export async function makeHomeFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'mr-profile-home-'));
+  await mkdir(join(dir, '.claude', 'skills'), { recursive: true });
+  await mkdir(join(dir, '.claude', 'agents'), { recursive: true });
+  await writeFile(join(dir, '.claude', 'settings.json'), '{}');
+  return join(dir, '.claude');
+}
+
+export async function cleanup(...dirs) {
+  for (const d of dirs) {
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+}

--- a/plugins/monorepo-profiles/test/mr-profile.test.mjs
+++ b/plugins/monorepo-profiles/test/mr-profile.test.mjs
@@ -1,0 +1,1146 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { readFile, writeFile, mkdir, lstat, readlink, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validateProfile, loadProfile, applyMcp, applyPermissions, applyPlugins, applySymlinks, renderInstructions, cmdSessionStart, cmdStatus, applyAll, cmdSwitch, findRepoRoot, main, cmdDiff } from '../bin/mr-profile.mjs';
+import { makeRepoFixture, makeHomeFixture, cleanup } from './helpers.mjs';
+
+test('validateProfile: rejects missing name', () => {
+  const errors = validateProfile({}, 'frontend');
+  assert.ok(errors.some(e => e.includes("'name'")), `expected 'name' error, got: ${JSON.stringify(errors)}`);
+});
+
+test('validateProfile: rejects when name does not match filename', () => {
+  const errors = validateProfile({ name: 'foo' }, 'frontend');
+  assert.ok(errors.some(e => /name 'foo'.*does not match filename 'frontend'/.test(e)),
+    `expected filename mismatch error, got: ${JSON.stringify(errors)}`);
+});
+
+test('loadProfile: loads a valid profile from fixture', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const p = await loadProfile(repo, 'frontend');
+    assert.equal(p.name, 'frontend');
+    assert.equal(p.description, 'Web app stack');
+    assert.equal(typeof p.mcp_servers.playwright.command, 'string');
+    assert.deepEqual(p.permissions.allow, ['Bash(npm *)', 'Bash(pnpm *)']);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('loadProfile: malformed JSON error includes file path', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const path = join(repo, '.claude', 'profiles', 'frontend.json');
+    await writeFile(path, '{ "name": "frontend"  // not valid');
+    await assert.rejects(
+      loadProfile(repo, 'frontend'),
+      err => err.message.includes(path) && /invalid JSON/i.test(err.message)
+    );
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('loadProfile: missing profile lists path', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    await assert.rejects(
+      loadProfile(repo, 'nonexistent'),
+      err => err.message.includes('not found') && err.message.includes('nonexistent.json')
+    );
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyMcp: writes mcpServers and preserves other top-level keys', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    // pre-existing .mcp.json with a non-mcpServers key
+    const existing = { mcpServers: { old: { command: 'old' } }, custom: { keep: true } };
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(existing));
+
+    const profile = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, profile);
+
+    const after = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    assert.deepEqual(after.mcpServers, profile.mcp_servers);
+    assert.deepEqual(after.custom, { keep: true });
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyMcp: idempotent — second apply yields identical bytes', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const profile = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, profile);
+    const a = await readFile(join(repo, '.mcp.json'), 'utf8');
+    await applyMcp(repo, profile);
+    const b = await readFile(join(repo, '.mcp.json'), 'utf8');
+    assert.equal(a, b);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyPermissions: writes allow/deny, preserves env', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const settingsPath = join(repo, '.claude', 'settings.local.json');
+    await mkdir(join(repo, '.claude'), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      env: { DEBUG: 'true' },
+      permissions: { allow: ['stale'], deny: [] }
+    }));
+
+    const profile = await loadProfile(repo, 'backend');
+    await applyPermissions(repo, profile);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    assert.deepEqual(after.env, { DEBUG: 'true' });
+    assert.deepEqual(after.permissions.allow, profile.permissions.allow);
+    assert.deepEqual(after.permissions.deny, profile.permissions.deny);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyPermissions: idempotent', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    await mkdir(join(repo, '.claude'), { recursive: true });
+    const profile = await loadProfile(repo, 'backend');
+    await applyPermissions(repo, profile);
+    const a = await readFile(join(repo, '.claude', 'settings.local.json'), 'utf8');
+    await applyPermissions(repo, profile);
+    const b = await readFile(join(repo, '.claude', 'settings.local.json'), 'utf8');
+    assert.equal(a, b);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('applyPlugins: first switch enables new plugins, preserves unrelated', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({
+      enabledPlugins: { 'unrelated@anyone': true }
+    }));
+
+    const profile = await loadProfile(repo, 'backend');
+    await applyPlugins(homeClaude, /* prev */ null, profile);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    assert.equal(after.enabledPlugins['unrelated@anyone'], true);
+    for (const key of profile.plugins) {
+      assert.equal(after.enabledPlugins[key], true, `expected ${key} enabled`);
+    }
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applyPlugins: removes plugins from previous profile not in new profile', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({ enabledPlugins: { 'unrelated@x': true } }));
+
+    const fe = await loadProfile(repo, 'frontend');
+    const be = await loadProfile(repo, 'backend');
+
+    // simulate: frontend was active first
+    await applyPlugins(homeClaude, null, fe);
+    let after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    for (const k of fe.plugins) assert.equal(after.enabledPlugins[k], true);
+
+    // switch to backend
+    await applyPlugins(homeClaude, fe, be);
+    after = JSON.parse(await readFile(settingsPath, 'utf8'));
+
+    for (const k of be.plugins) assert.equal(after.enabledPlugins[k], true, `expected ${k} on`);
+    for (const k of fe.plugins) {
+      if (!be.plugins.includes(k)) {
+        assert.equal(after.enabledPlugins[k], undefined, `expected ${k} removed`);
+      }
+    }
+    assert.equal(after.enabledPlugins['unrelated@x'], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applyPlugins: prevProfile null is treated as empty plugin list', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({ enabledPlugins: {} }));
+
+    const be = await loadProfile(repo, 'backend');
+    await applyPlugins(homeClaude, null, be);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    for (const k of be.plugins) assert.equal(after.enabledPlugins[k], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applyPlugins: plugins shared between prev and new survive the switch', async () => {
+  const homeClaude = await makeHomeFixture();
+  try {
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({ enabledPlugins: {} }));
+
+    const prev = { name: 'a', plugins: ['shared@m', 'a-only@m'] };
+    const next = { name: 'b', plugins: ['shared@m', 'b-only@m'] };
+
+    await applyPlugins(homeClaude, null, prev);
+    await applyPlugins(homeClaude, prev, next);
+
+    const after = JSON.parse(await readFile(settingsPath, 'utf8'));
+    assert.equal(after.enabledPlugins['shared@m'], true, 'shared plugin must remain enabled');
+    assert.equal(after.enabledPlugins['b-only@m'], true, 'new-only plugin must be enabled');
+    assert.equal(after.enabledPlugins['a-only@m'], undefined, 'prev-only plugin must be removed');
+  } finally {
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applySymlinks: creates skills and agents symlinks under home/.claude', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applySymlinks(homeClaude, repo, profile);
+
+    const skillLink = join(homeClaude, 'skills', 'backend');
+    const agentLink = join(homeClaude, 'agents', 'backend');
+
+    const skillStat = await lstat(skillLink);
+    assert.ok(skillStat.isSymbolicLink());
+    assert.equal(await readlink(skillLink), join(repo, 'services/api/.claude/skills'));
+
+    const agentStat = await lstat(agentLink);
+    assert.ok(agentStat.isSymbolicLink());
+    assert.equal(await readlink(agentLink), join(repo, 'services/api/.claude/agents'));
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applySymlinks: refuses to replace a real directory at the symlink path', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // create a real dir where the symlink would go
+    const block = join(homeClaude, 'skills', 'backend');
+    await mkdir(block, { recursive: true });
+
+    const profile = await loadProfile(repo, 'backend');
+    await assert.rejects(
+      applySymlinks(homeClaude, repo, profile),
+      err => err.message.includes('refusing to replace non-symlink')
+    );
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applySymlinks: re-applying replaces an existing symlink (idempotent)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applySymlinks(homeClaude, repo, profile);
+    await applySymlinks(homeClaude, repo, profile);
+
+    const skillLink = join(homeClaude, 'skills', 'backend');
+    const agentLink = join(homeClaude, 'agents', 'backend');
+    assert.ok((await lstat(skillLink)).isSymbolicLink());
+    assert.equal(await readlink(skillLink), join(repo, 'services/api/.claude/skills'));
+    assert.ok((await lstat(agentLink)).isSymbolicLink());
+    assert.equal(await readlink(agentLink), join(repo, 'services/api/.claude/agents'));
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('renderInstructions: concatenates fragments with separator, skips missing', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    const out = await renderInstructions(repo, profile);
+    assert.match(out, /Backend profile preamble/);
+
+    // Ad-hoc profile with two fragments to exercise the separator
+    const twoFrag = {
+      ...profile,
+      instruction_fragments: ['CLAUDE.md', 'services/api/CLAUDE.md']
+    };
+    const both = await renderInstructions(repo, twoFrag);
+    assert.match(both, /Sample Monorepo/);
+    assert.match(both, /services\/api/);
+    assert.ok(both.includes('\n\n---\n\n'));
+
+    // Missing fragment is skipped (warns to stderr, doesn't throw)
+    const augmented = {
+      ...profile,
+      instruction_fragments: [...profile.instruction_fragments, 'does/not/exist.md']
+    };
+    const out2 = await renderInstructions(repo, augmented);
+    assert.match(out2, /Backend profile preamble/);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('cmdSessionStart: emits Claude Code SessionStart hook JSON when active-profile set', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const captured = [];
+    const stdout = { write: chunk => captured.push(chunk) };
+    const code = await cmdSessionStart({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+
+    const out = JSON.parse(captured.join(''));
+    assert.equal(out.hookSpecificOutput.hookEventName, 'SessionStart');
+    assert.match(out.hookSpecificOutput.additionalContext, /Backend profile preamble/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSessionStart: silent exit 0 when no active-profile', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const captured = [];
+    const stdout = { write: chunk => captured.push(chunk) };
+    const code = await cmdSessionStart({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    assert.equal(captured.join(''), '');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSessionStart: returns 0 even when a fragment is unreadable (e.g. is a directory)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // craft an ad-hoc profile pointing instruction_fragments at a directory
+    // (readFile will throw EISDIR — non-ENOENT)
+    const adhocPath = join(repo, '.claude', 'profiles', 'adhoc.json');
+    await writeFile(adhocPath, JSON.stringify({
+      name: 'adhoc',
+      instruction_fragments: ['services/api/.claude/skills']
+    }));
+    await writeFile(join(repo, '.claude', 'active-profile'), 'adhoc\n');
+
+    const captured = [];
+    const stdout = { write: c => captured.push(c) };
+    const code = await cmdSessionStart({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    // No stdout output: the hook must never block startup with bad output
+    assert.equal(captured.join(''), '');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: ✓ for each managed file after a clean apply', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    const out = lines.join('');
+
+    assert.equal(code, 0);
+    assert.match(out, /active profile: backend/);
+    assert.match(out, /\.mcp\.json: ✓/);
+    assert.match(out, /settings\.local\.json: ✓/);
+    assert.match(out, /enabledPlugins: ✓/);
+    assert.match(out, /skills symlink: ✓/);
+    assert.match(out, /agents symlink: ✓/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: ✗ drifted when .mcp.json was edited after switch', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // user edits the file
+    const mcpPath = join(repo, '.mcp.json');
+    const data = JSON.parse(await readFile(mcpPath, 'utf8'));
+    data.mcpServers.added = { command: 'rogue' };
+    await writeFile(mcpPath, JSON.stringify(data, null, 2) + '\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: enabledPlugins ✗ missing required when a required plugin is not enabled', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    // Enable only one of the two required plugins
+    const settingsPath = join(homeClaude, 'settings.json');
+    await writeFile(settingsPath, JSON.stringify({
+      enabledPlugins: { [profile.plugins[0]]: true }
+    }));
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /enabledPlugins: ✗ missing required/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: reports no active profile when active-profile file is absent', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /no active profile/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: drifted .mcp.json line shows "(N keys differ)" when keys actually differ', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Add a rogue server (1 added key)
+    const data = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    data.mcpServers.rogue = { command: 'x' };
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(data, null, 2) + '\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted \(1 key differs\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: drifted .mcp.json line shows "(formatting only)" when bytes differ but keys match', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Re-serialize with non-canonical formatting (e.g. tabs) — same keys, different bytes
+    const data = JSON.parse(await readFile(join(repo, '.mcp.json'), 'utf8'));
+    await writeFile(join(repo, '.mcp.json'), JSON.stringify(data) /* no indent, no trailing newline */);
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /\.mcp\.json: ✗ drifted \(formatting only\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdStatus: footer "Run /profile diff for details." appears only when drifted', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    // Clean state — no footer expected
+    let lines = [];
+    let stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.doesNotMatch(lines.join(''), /Run \/profile diff/);
+
+    // Drift one file — footer expected
+    await writeFile(join(repo, '.mcp.json'), '{"mcpServers":{"x":{"command":"y"}}}\n');
+    lines = [];
+    stdout = { write: c => lines.push(c) };
+    await cmdStatus({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.match(lines.join(''), /Run \/profile diff for details\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applyAll: writes managed files; active-profile written last', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    const code = await applyAll({
+      repoRoot: repo, homeClaudeDir: homeClaude, profile, prevProfile: null
+    });
+    assert.equal(code, 0);
+
+    // every managed file is present
+    await readFile(join(repo, '.mcp.json'));
+    await readFile(join(repo, '.claude', 'settings.local.json'));
+    await readFile(join(homeClaude, 'settings.json'));
+    await lstat(join(homeClaude, 'skills', 'backend'));
+    await lstat(join(homeClaude, 'agents', 'backend'));
+
+    const active = (await readFile(join(repo, '.claude', 'active-profile'), 'utf8')).trim();
+    assert.equal(active, 'backend');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSwitch: switching frontend -> backend removes frontend-only plugins', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    let lines = [];
+    const stdout = { write: c => lines.push(c) };
+
+    let code = await cmdSwitch({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'frontend', stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'frontend' applied/);
+    assert.match(lines.join(''), /Restart Claude Code/);
+
+    lines = [];
+    code = await cmdSwitch({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+
+    const settings = JSON.parse(await readFile(join(homeClaude, 'settings.json'), 'utf8'));
+    // Frontend-only plugins should be gone
+    assert.equal(settings.enabledPlugins['frontend-design@claude-plugins-official'], undefined);
+    // Backend-only plugins should be present
+    assert.equal(settings.enabledPlugins['gopls-lsp@claude-plugins-official'], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdSwitch: missing profile returns non-zero with actionable message', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const stdout = { write: () => {} };
+    const code = await cmdSwitch({
+      repoRoot: repo, homeClaudeDir: homeClaude, name: 'missing', stdout, stderr
+    });
+    assert.notEqual(code, 0);
+    assert.match(errs.join(''), /missing/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('applyAll: with non-null prevProfile, removes prev-only plugins', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const fe = await loadProfile(repo, 'frontend');
+    const be = await loadProfile(repo, 'backend');
+
+    // First apply with frontend as new and no prev
+    await applyAll({ repoRoot: repo, homeClaudeDir: homeClaude, profile: fe, prevProfile: null });
+    let settings = JSON.parse(await readFile(join(homeClaude, 'settings.json'), 'utf8'));
+    for (const k of fe.plugins) assert.equal(settings.enabledPlugins[k], true);
+
+    // Now apply backend with frontend as prev — fe-only plugins must go
+    await applyAll({ repoRoot: repo, homeClaudeDir: homeClaude, profile: be, prevProfile: fe });
+    settings = JSON.parse(await readFile(join(homeClaude, 'settings.json'), 'utf8'));
+    for (const k of be.plugins) assert.equal(settings.enabledPlugins[k], true);
+    for (const k of fe.plugins) {
+      if (!be.plugins.includes(k)) {
+        assert.equal(settings.enabledPlugins[k], undefined);
+      }
+    }
+    // active-profile points to backend (completion flag)
+    const active = (await readFile(join(repo, '.claude', 'active-profile'), 'utf8')).trim();
+    assert.equal(active, 'backend');
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: dispatches "switch <name>" using cwd-derived repo root', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['switch', 'frontend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'frontend' applied/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: prints usage and returns 2 on unknown subcommand', async () => {
+  const repo = await makeRepoFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['nonsense'], {}, { stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+  }
+});
+
+test('findRepoRoot: walks up to a directory containing .claude/profiles', async () => {
+  const repo = await makeRepoFixture();
+  try {
+    const deep = join(repo, 'services', 'api');
+    const found = await findRepoRoot(deep);
+    assert.equal(found, repo);
+  } finally {
+    await cleanup(repo);
+  }
+});
+
+test('findRepoRoot: throws actionable error when none found', async () => {
+  await assert.rejects(
+    findRepoRoot('/'),
+    err => /no .claude\/profiles\//.test(err.message)
+  );
+});
+
+test('cmdSwitch: warns and continues when previous profile fails to load', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Active-profile points to a profile that does not exist on disk
+    await writeFile(join(repo, '.claude', 'active-profile'), 'ghost\n');
+
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const stdout = { write: () => {} };
+
+    const code = await cmdSwitch({
+      repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout, stderr
+    });
+    assert.equal(code, 0);
+    assert.match(errs.join(''), /warning: previous profile 'ghost'/);
+    assert.match(errs.join(''), /plugin removals skipped/);
+
+    // The switch still succeeded — backend plugins enabled
+    const settings = JSON.parse(await readFile(join(homeClaude, 'settings.json'), 'utf8'));
+    const be = await loadProfile(repo, 'backend');
+    for (const k of be.plugins) assert.equal(settings.enabledPlugins[k], true);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: unknown subcommand from outside a repo prints USAGE (exit 2), not the no-repo error (exit 1)', async () => {
+  // tmp dir without .claude/profiles
+  const elsewhere = await mkdtemp(join(tmpdir(), 'mr-profile-elsewhere-'));
+  const origCwd = process.cwd();
+  try {
+    process.chdir(elsewhere);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['nonsense'], {}, { stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(elsewhere);
+  }
+});
+
+test('main: switch with no name returns 2 and prints USAGE', async () => {
+  const repo = await makeRepoFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['switch'], {}, { stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+  }
+});
+
+import { diffMcpKeys } from '../bin/mr-profile.mjs';
+
+test('diffMcpKeys: detects added, removed, changed', () => {
+  const existing = { mcpServers: { signoz: { command: 'old' }, github: { command: 'gh' } } };
+  const profile = { mcp_servers: { signoz: { command: 'new' }, playwright: { command: 'pw' } } };
+  const d = diffMcpKeys(existing, profile);
+  assert.deepEqual(d.added, ['playwright']);
+  assert.deepEqual(d.removed, ['github']);
+  assert.deepEqual(d.changed, ['signoz']);
+});
+
+test('diffMcpKeys: empty existing yields all profile keys as added', () => {
+  const d = diffMcpKeys({}, { mcp_servers: { signoz: { command: 'x' } } });
+  assert.deepEqual(d.added, ['signoz']);
+  assert.deepEqual(d.removed, []);
+  assert.deepEqual(d.changed, []);
+});
+
+test('diffMcpKeys: identical existing and profile yields all empty', () => {
+  const same = { mcpServers: { signoz: { command: 'x' } } };
+  const profile = { mcp_servers: { signoz: { command: 'x' } } };
+  const d = diffMcpKeys(same, profile);
+  assert.deepEqual(d.added, []);
+  assert.deepEqual(d.removed, []);
+  assert.deepEqual(d.changed, []);
+});
+
+import { diffPermissionKeys } from '../bin/mr-profile.mjs';
+
+test('diffPermissionKeys: returns set diffs over allow and deny arrays', () => {
+  const existing = { permissions: { allow: ['Bash(npm *)', 'Bash(go *)'], deny: ['Bash(rm -rf *)'] } };
+  const profile  = { permissions: { allow: ['Bash(go *)', 'Bash(docker *)'], deny: ['Bash(rm -rf *)', 'Bash(kubectl delete *)'] } };
+  const d = diffPermissionKeys(existing, profile);
+  assert.deepEqual(d.allowAdded.sort(), ['Bash(docker *)']);
+  assert.deepEqual(d.allowRemoved.sort(), ['Bash(npm *)']);
+  assert.deepEqual(d.denyAdded.sort(), ['Bash(kubectl delete *)']);
+  assert.deepEqual(d.denyRemoved, []);
+});
+
+test('diffPermissionKeys: tolerates missing fields', () => {
+  const d = diffPermissionKeys({}, { permissions: { allow: ['x'] } });
+  assert.deepEqual(d.allowAdded, ['x']);
+  assert.deepEqual(d.allowRemoved, []);
+  assert.deepEqual(d.denyAdded, []);
+  assert.deepEqual(d.denyRemoved, []);
+});
+
+import { diffPluginKeys } from '../bin/mr-profile.mjs';
+
+test('diffPluginKeys: first switch — current empty, prev null, new has 3', () => {
+  const current = {};
+  const newP = { plugins: ['a@m', 'b@m', 'c@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, null, newP);
+  assert.deepEqual(d.added.sort(), ['a@m', 'b@m', 'c@m']);
+  assert.deepEqual(d.removed, []);
+});
+
+test('diffPluginKeys: switch fe -> be with overlap', () => {
+  // current already reflects fe state, plus an unrelated plugin
+  const current = { 'fe-only@m': true, 'shared@m': true, 'unrelated@m': true };
+  const fe = { plugins: ['fe-only@m', 'shared@m'] };
+  const be = { plugins: ['shared@m', 'be-only@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, fe, be);
+  assert.deepEqual(d.added, ['be-only@m']);
+  assert.deepEqual(d.removed, ['fe-only@m']);
+  // 'shared@m' and 'unrelated@m' should not appear
+});
+
+test('diffPluginKeys: re-applying active profile yields empty diff', () => {
+  const current = { 'a@m': true, 'b@m': true };
+  const same = { plugins: ['a@m', 'b@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, same, same);
+  assert.deepEqual(d.added, []);
+  assert.deepEqual(d.removed, []);
+});
+
+test('diffPluginKeys: unrelated user-enabled plugin is preserved (not in diff)', () => {
+  const current = { 'unrelated@m': true };
+  const newP = { plugins: ['target@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, null, newP);
+  assert.deepEqual(d.added, ['target@m']);
+  assert.deepEqual(d.removed, []);
+});
+
+test('diffPluginKeys: explicit false in enabledPlugins is treated as not-enabled (transitions to true → added)', () => {
+  const current = { 'a@m': false };
+  const newP = { plugins: ['a@m'] };
+  const d = diffPluginKeys({ enabledPlugins: current }, null, newP);
+  assert.deepEqual(d.added, ['a@m']);
+  assert.deepEqual(d.removed, []);
+});
+
+import { cmdValidate } from '../bin/mr-profile.mjs';
+
+test('cmdValidate: valid backend profile prints summary and exits 0', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Profile 'backend': ✓ valid/);
+    assert.match(out, /2 plugins/);
+    assert.match(out, /1 mcp server/);
+    assert.match(out, /1 fragment/);
+    assert.match(out, /skills/);
+    assert.match(out, /agents/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: mcp server entry missing command and url is an ERROR (exit 1)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Create an ad-hoc profile with a broken mcp_servers entry
+    await writeFile(join(repo, '.claude', 'profiles', 'broken.json'), JSON.stringify({
+      name: 'broken',
+      mcp_servers: { dud: { args: ['nope'] } }
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'broken', stdout });
+    assert.equal(code, 1);
+    const out = lines.join('');
+    assert.match(out, /Profile 'broken': ✗ 1 error/);
+    assert.match(out, /ERROR\s+mcp_servers\.dud: missing 'command' or 'url'/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: invalid plugin id is a WARN (exit 0)', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'profiles', 'wonky.json'), JSON.stringify({
+      name: 'wonky',
+      plugins: ['gopls-lsp', 'good@m'] // first lacks @marketplace
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'wonky', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Profile 'wonky': ✗ 0 errors, 1 warning/);
+    assert.match(out, /WARN\s+plugins\[0\]: 'gopls-lsp' does not match/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: missing instruction_fragments WARN; missing local_skills/agents source dirs ERROR', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'profiles', 'paths.json'), JSON.stringify({
+      name: 'paths',
+      instruction_fragments: ['nope/never.md'],
+      local_skills: 'nonexistent/skills',
+      local_agents: 'nonexistent/agents'
+    }));
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'paths', stdout });
+    assert.equal(code, 1); // any error → exit 1
+    const out = lines.join('');
+    assert.match(out, /2 errors, 1 warning/);
+    assert.match(out, /WARN\s+instruction_fragments\[0\]: 'nope\/never\.md' does not exist/);
+    assert.match(out, /ERROR\s+local_skills: 'nonexistent\/skills' does not exist \(apply would create a dangling symlink\)/);
+    assert.match(out, /ERROR\s+local_agents: 'nonexistent\/agents' does not exist \(apply would create a dangling symlink\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: defaults to active profile when name omitted', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+    assert.match(out, /Using active profile 'backend'\./);
+    assert.match(out, /Profile 'backend': ✓ valid/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdValidate: no name and no active-profile returns 2 with USAGE', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await cmdValidate({ repoRoot: repo, homeClaudeDir: homeClaude, stderr });
+    assert.equal(code, 2);
+    assert.match(errs.join(''), /usage:/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdDiff: after a clean apply, every managed file shows ✓ matches and footer says No changes', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+
+    const out = lines.join('');
+    assert.match(out, /Diff for profile 'backend' \(vs current state\):/);
+    assert.match(out, /\.mcp\.json:\s*\n\s*✓ matches/);
+    assert.match(out, /settings\.local\.json:\s*\n\s*✓ matches/);
+    assert.match(out, /enabledPlugins\):\s*\n\s*✓ matches/);
+    assert.match(out, /skills\/backend:\s*\n\s*✓ matches/);
+    assert.match(out, /agents\/backend:\s*\n\s*✓ matches/);
+    assert.match(out, /active-profile:\s*\n\s*✓ matches/);
+    assert.match(out, /No changes\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdDiff: from active=frontend, diffing backend shows expected +/-/~ entries', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Apply frontend first, mark active
+    const fe = await loadProfile(repo, 'frontend');
+    await applyMcp(repo, fe);
+    await applyPermissions(repo, fe);
+    await applyPlugins(homeClaude, null, fe);
+    await applySymlinks(homeClaude, repo, fe);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'frontend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const code = await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    assert.equal(code, 0);
+    const out = lines.join('');
+
+    // mcp: backend has 'github', frontend has 'playwright'
+    assert.match(out, /\+ mcpServers\.github/);
+    assert.match(out, /- mcpServers\.playwright/);
+
+    // perms: backend has go/docker, frontend has npm/pnpm
+    assert.match(out, /\+ permissions\.allow: 'Bash\(go \*\)'/);
+    assert.match(out, /- permissions\.allow: 'Bash\(npm \*\)'/);
+
+    // plugins: state-projection should show fe-only removed, be-only added
+    assert.match(out, /\+ gopls-lsp@claude-plugins-official/);
+    assert.match(out, /- frontend-design@claude-plugins-official/);
+
+    // symlinks: backend has both local_skills and local_agents (frontend skill link must change target)
+    // skills link target points to apps/web (frontend), needs to point at services/api (backend)
+    assert.match(out, /skills\/backend:/);
+    assert.match(out, /agents\/backend:/);
+
+    // active-profile
+    assert.match(out, /~ was 'frontend', expected 'backend'/);
+
+    assert.match(out, /Run \/profile switch backend to apply\./);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdDiff: re-diffing the active profile shows No changes', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    const profile = await loadProfile(repo, 'backend');
+    await applyMcp(repo, profile);
+    await applyPermissions(repo, profile);
+    await applyPlugins(homeClaude, null, profile);
+    await applySymlinks(homeClaude, repo, profile);
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    const out = lines.join('');
+    assert.match(out, /No changes\./);
+    // Critical: state projection means re-diff doesn't show phantom plugin additions
+    assert.doesNotMatch(out, /\+ gopls-lsp@/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('cmdDiff: symlink slot occupied by real directory shows "is not a symlink" with corrected wording', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  try {
+    // Place a real directory where the skills symlink would go
+    await mkdir(join(homeClaude, 'skills', 'backend'), { recursive: true });
+    await writeFile(join(repo, '.claude', 'active-profile'), 'backend\n');
+
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    await cmdDiff({ repoRoot: repo, homeClaudeDir: homeClaude, name: 'backend', stdout });
+    const out = lines.join('');
+    assert.match(out, /✗ is not a symlink \(cannot replace non-symlink at this path; remove manually\)/);
+  } finally {
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: dispatches "validate <name>"', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['validate', 'backend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Profile 'backend': ✓ valid/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: dispatches "diff <name>"', async () => {
+  const repo = await makeRepoFixture();
+  const homeClaude = await makeHomeFixture();
+  const origCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const lines = [];
+    const stdout = { write: c => lines.push(c) };
+    const env = { HOME: join(homeClaude, '..') };
+    const code = await main(['diff', 'backend'], env, { stdout });
+    assert.equal(code, 0);
+    assert.match(lines.join(''), /Diff for profile 'backend'/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(repo);
+    await cleanup(join(homeClaude, '..'));
+  }
+});
+
+test('main: validate and diff appear in USAGE on unknown subcommand', async () => {
+  const elsewhere = await mkdtemp(join(tmpdir(), 'mr-profile-elsewhere-'));
+  const origCwd = process.cwd();
+  try {
+    process.chdir(elsewhere);
+    const errs = [];
+    const stderr = { write: c => errs.push(c) };
+    const code = await main(['nope'], {}, { stderr });
+    assert.equal(code, 2);
+    const out = errs.join('');
+    assert.match(out, /validate/);
+    assert.match(out, /diff/);
+  } finally {
+    process.chdir(origCwd);
+    await cleanup(elsewhere);
+  }
+});


### PR DESCRIPTION
## Summary

Vendors `monorepo-profiles` into `plugins/monorepo-profiles/`. A Claude Code plugin that lets users define named profiles per monorepo and atomically swap MCP servers, permissions, plugins, skills, agents, and supplementary instruction fragments via `/profile switch <name>`.

**Harness-specific by design.** No `SKILL.md`, not transpiled by `apm-builder`, Claude Code only. The core script (`bin/mr-profile.mjs`) is harness-agnostic Node ESM and could be invoked from a Cursor/Codex/Gemini hook in the future, but no such adapters ship today.

### Commands

- `/profile switch <name>` — atomic, restart-on-load, idempotent (v0.1, AC-5)
- `/profile status` — SHA fingerprint + drift count + footer (v0.2, AC-4)
- `/profile validate [name]` — non-destructive correctness check (v0.2, AC-1/AC-2)
- `/profile diff [name]` — preview with state-projected plugin diff (v0.2, AC-3)
- SessionStart hook — supplementary instruction fragment injection (v0.1, AC-6)
- JSON Schema — editor autocomplete + typo detection on profile JSON (v0.2, AC-5)

### Invariants

- **Per-key ownership** across all managed files (`.mcp.json`, `settings.local.json`, `~/.claude/settings.json` `enabledPlugins`, skills/agents symlinks, `active-profile`).
- **Previous→current diff** for plugin enablement — reasoning is local; no spooky action between unrelated profile files.
- **`active-profile` written last** — completion flag for partial-state detection.

### Spec and plan history

Under `plugins/monorepo-profiles/docs/superpowers/`:
- `specs/2026-04-29-monorepo-profiles-design.md` — v0.1 design
- `specs/2026-04-29-monorepo-profiles-v0.2-design.md` — v0.2 design
- `plans/2026-04-29-monorepo-profiles.md` — v0.1 plan
- `plans/2026-04-29-monorepo-profiles-v0.2.md` — v0.2 plan
- `specs/hook-schema-verification.md` — Claude Code hook output schema lookup

### apm-builder coexistence

`apm-builder/lib/discover.ts` walks `plugins/*/` looking for `SKILL.md`; directories without one are silently skipped. Verified: this plugin coexists with the existing canonical-source pipeline without modification.

## Test plan

- [x] `cd plugins/monorepo-profiles && npm test` — 61/61 passing (35 v0.1 + 26 v0.2)
- [x] `apm-builder` discovery is unaffected by this directory
- [ ] Manual: install in Claude Code, run `/profile switch frontend` in a fixture monorepo, restart, `/profile status` confirms ✓ (v0.1 AC-7)
- [ ] Manual: open `.claude/profiles/backend.json` in VS Code with the README's `json.schemas` snippet, confirm typo detection on `mcp_serverz` and autocomplete inside `mcp_servers.<name>.` (v0.2 AC-5)