### PR TITLE
ci: skip on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSES/**'
   push:
     branches: [main]
 

--- a/.github/workflows/docker-test-matrix.yml
+++ b/.github/workflows/docker-test-matrix.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSES/**'
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
## Summary

Skip CI workflows (`ci.yml` typecheck/test/validate/build, `docker-test-matrix.yml`) on PRs that touch only documentation. Both workflows already gate on `branches: [main]`; this adds `paths-ignore` so doc-only changes don't burn CI minutes.

## Patterns ignored

```yaml
paths-ignore:
  - '*.md'        # root-level: README, CHANGELOG, CONTRIBUTING, CONVENTIONS, TAXONOMY, AGENTS, SUPERPOWERS_ARCHITECTURE, GH_PROJECT_SETUP_GUIDE, EVOLUTION
  - 'docs/**'     # specs, plans, USING-AC.md
  - 'LICENSES/**' # vendor license attribution
```

`*.md` (single-star) only matches root-level markdown — `**/*.md` would be needed to match recursively. So `skills/<name>/SKILL.md`, `plugins/<name>/README.md`, and similar nested markdown still trigger CI (correct — those are content the validator runs against).

## What still triggers CI

- Any change under `skills/`, `plugins/`, `agents/`, `hooks/`, `mcp/`, `personas/`, `modes/`, `apm-builder/`, `marketplace/`, `dist/`
- `package.json`, `package-lock.json`, `tsconfig.json`, `vitest.config.*`
- Any `.github/workflows/**` change (so this PR itself runs CI)

## Test plan

- [x] This PR's CI runs (workflow files changed)
- [ ] After merge: open a docs-only PR (e.g., README tweak) and confirm `test` and `matrix` are skipped
- [ ] After merge: open a code PR and confirm both still run