### PR TITLE
feat(bones-powers): bones-native workflow plugin (forked from superpowers v5.0.7)

### DIFF
--- a/marketplace/plugins/bones-powers.json
+++ b/marketplace/plugins/bones-powers.json
@@ -1,0 +1,19 @@
+{
+  "name": "bones-powers",
+  "version": "0.1.0",
+  "description": "Bones-native workflow skills (forked from superpowers v5.0.7). Brainstorming → planning → execution → fan-in, expressed in slots, leaves, swarm sessions, and the persistent task graph.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-config/tree/main/plugins/bones-powers",
+  "release": "https://github.com/danmestas/agent-config/releases/tag/bones-powers@v0.1.0",
+  "categories": ["developer-tools", "workflows"],
+  "includes": [
+    "using-bones-powers",
+    "brainstorming",
+    "writing-plans",
+    "executing-plans",
+    "subagent-driven-development",
+    "dispatching-parallel-agents",
+    "using-bones-swarm",
+    "finishing-a-bones-leaf"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
         "yaml": "^2.6.0",
         "zod": "^3.23.8"
       },
+      "bin": {
+        "ac": "apm-builder/ac.ts",
+        "apm-builder": "apm-builder/cli.ts"
+      },
       "devDependencies": {
         "@types/archiver": "^6.0.3",
         "@types/node": "^22.0.0",

--- a/plugins/bones-powers/.claude-plugin/plugin.json
+++ b/plugins/bones-powers/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "bones-powers",
+  "version": "0.1.0",
+  "description": "Bones-native workflow skills (forked from superpowers v5.0.7). Brainstorming → planning → execution → fan-in, expressed in slots, leaves, swarm sessions, and the persistent task graph.",
+  "author": {
+    "name": "Daniel Mestas",
+    "email": "dan5446@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": ["bones", "workflows", "skills", "fossil", "swarm", "superpowers"]
+}

--- a/plugins/bones-powers/README.md
+++ b/plugins/bones-powers/README.md
@@ -1,0 +1,43 @@
+# bones-powers
+
+Bones-native workflow skills, forked from [superpowers](https://github.com/obra/superpowers) v5.0.7. Brainstorming → planning → execution → fan-in, expressed in bones primitives (slots, leaves, hub/trunk, swarm sessions, persistent task graph) instead of git worktrees + TodoWrite.
+
+## What's in the box
+
+8 skills:
+
+| Skill | Phase | What changed vs. upstream |
+|---|---|---|
+| `using-bones-powers` | Bootstrap meta | Renamed from `using-superpowers`; speaks bones vocabulary. |
+| `brainstorming` | Design | Spec output `docs/bones-powers/specs/`; commits via `bones repo ci`. |
+| `writing-plans` | Plan | Plans annotate `[slot: X]` per task; emit `bones tasks` graph at end. |
+| `executing-plans` | Single-session execution | TodoWrite plan-tracking replaced with `bones tasks list/claim/close`. |
+| `subagent-driven-development` | Parallel execution | Each implementer = `bones swarm join` (slot + claim + worktree atomic). |
+| `dispatching-parallel-agents` | Parallel debug | N concurrent slot sessions; `bones tasks aggregate` for rollup. |
+| `using-bones-swarm` | Workspace primitive | Full rewrite — `swarm join → cwd → work → commit → close`. Replaces `using-git-worktrees`. |
+| `finishing-a-bones-leaf` | Integration | `swarm fan-in` to trunk (with `--dry-run` preview), keep, or abandon. Replaces `finishing-a-development-branch`. |
+
+## Hybrid task model
+
+| Layer | Tool | Lifetime |
+|---|---|---|
+| Plan-level | `bones tasks` | Durable, cross-session, slot-routable, claimable |
+| In-session | TodoWrite | Ephemeral; one fresh list per claimed bones task |
+
+Plan steps go to `bones tasks`. Micro-steps inside a single agent's head go to TodoWrite. Never the reverse.
+
+## Activation
+
+The plugin's SessionStart hook auto-injects the `using-bones-powers` meta-skill **only when cwd contains `.bones/repo.fossil`**. Outside a bones workspace, the hook is silent.
+
+If you have both `superpowers` and `bones-powers` installed and you're in a bones workspace, both meta-skills bootstrap. Acceptable; gives you both vocabularies.
+
+## Out of v0
+
+- TDD / debugging / verification / code-review skills (use upstream `superpowers` for those)
+- Codex/Gemini/Cursor adapters
+- Automated test suite
+- Push-to-git-remote step in `finishing-a-bones-leaf`
+- Suppress-superpowers escape valve
+
+See `UPSTREAM.md` for provenance and the design spec at `docs/superpowers/specs/2026-04-29-bones-powers-design.md` for full rationale.

--- a/plugins/bones-powers/UPSTREAM.md
+++ b/plugins/bones-powers/UPSTREAM.md
@@ -30,7 +30,14 @@ Upstream license: MIT (Jesse Vincent / fsck.com).
 
 ## Resyncing from upstream (manual procedure)
 
-1. Identify the upstream version: `cat ~/.claude/plugins/cache/claude-plugins-official/superpowers/<version>/.claude-plugin/plugin.json | jq .version`
+1. Identify the latest installed upstream version:
+   ```
+   ls ~/.claude/plugins/cache/claude-plugins-official/superpowers/ | sort -V | tail -1
+   ```
+   Confirm by reading that path's manifest:
+   ```
+   cat ~/.claude/plugins/cache/claude-plugins-official/superpowers/<version>/.claude-plugin/plugin.json | jq .version
+   ```
 2. For each file in the table above marked "verbatim copy", overwrite with the upstream copy.
 3. For each "refactored" or "full rewrite" file, manually merge upstream changes into the bones-powers version.
 4. Update this file's "forked from v5.0.7 on 2026-04-29" header.

--- a/plugins/bones-powers/UPSTREAM.md
+++ b/plugins/bones-powers/UPSTREAM.md
@@ -14,7 +14,7 @@ This is a **one-time copy + diverge**. There is no automated resync from upstrea
 | `skills/using-bones-powers/SKILL.md` | `skills/using-superpowers/SKILL.md` | refactored — replaces "you have superpowers" with "you have bones-powers"; adds bones-primitives vocabulary section; drops codex/copilot tool-mapping refs |
 | `skills/brainstorming/SKILL.md` | `skills/brainstorming/SKILL.md` | refactored — spec output path → `docs/bones-powers/specs/`; commit mechanic → `bones repo add` + `bones repo ci` |
 | `skills/brainstorming/spec-document-reviewer-prompt.md` | same | verbatim copy |
-| `skills/brainstorming/visual-companion.md` | same | verbatim copy |
+| `skills/brainstorming/visual-companion.md` | same | refactored — replaced `.superpowers/brainstorm/` runtime paths with `.bones-powers/brainstorm/` |
 | `skills/writing-plans/SKILL.md` | `skills/writing-plans/SKILL.md` | refactored — adds `[slot: X]` annotation requirement; emits bones tasks per spec § 4.4 |
 | `skills/writing-plans/plan-document-reviewer-prompt.md` | same | verbatim copy |
 | `skills/executing-plans/SKILL.md` | `skills/executing-plans/SKILL.md` | refactored — replaces TodoWrite plan-tracking with `bones tasks list/claim/close` |

--- a/plugins/bones-powers/UPSTREAM.md
+++ b/plugins/bones-powers/UPSTREAM.md
@@ -1,0 +1,36 @@
+# Upstream Provenance
+
+`bones-powers` was forked from [superpowers](https://github.com/obra/superpowers) v5.0.7 on 2026-04-29.
+
+This is a **one-time copy + diverge**. There is no automated resync from upstream. Future upstream changes must be hand-merged.
+
+## Per-file provenance
+
+| `bones-powers` file | Upstream source (`superpowers v5.0.7`) | Treatment |
+|---|---|---|
+| `hooks/run-hook.cmd` | `hooks/run-hook.cmd` | verbatim copy |
+| `hooks/session-start` | `hooks/session-start` | rewritten — gated on `.bones/repo.fossil` marker, reads `using-bones-powers` instead of `using-superpowers` |
+| `hooks/hooks.json` | `hooks/hooks.json` | identical structure, identical schema |
+| `skills/using-bones-powers/SKILL.md` | `skills/using-superpowers/SKILL.md` | refactored — replaces "you have superpowers" with "you have bones-powers"; adds bones-primitives vocabulary section; drops codex/copilot tool-mapping refs |
+| `skills/brainstorming/SKILL.md` | `skills/brainstorming/SKILL.md` | refactored — spec output path → `docs/bones-powers/specs/`; commit mechanic → `bones repo add` + `bones repo ci` |
+| `skills/brainstorming/spec-document-reviewer-prompt.md` | same | verbatim copy |
+| `skills/brainstorming/visual-companion.md` | same | verbatim copy |
+| `skills/writing-plans/SKILL.md` | `skills/writing-plans/SKILL.md` | refactored — adds `[slot: X]` annotation requirement; emits bones tasks per spec § 4.4 |
+| `skills/writing-plans/plan-document-reviewer-prompt.md` | same | verbatim copy |
+| `skills/executing-plans/SKILL.md` | `skills/executing-plans/SKILL.md` | refactored — replaces TodoWrite plan-tracking with `bones tasks list/claim/close` |
+| `skills/subagent-driven-development/SKILL.md` | `skills/subagent-driven-development/SKILL.md` | refactored — implementer dispatch becomes `bones swarm join --slot --task-id` |
+| `skills/subagent-driven-development/implementer-prompt.md` | same | refactored — TodoWrite a fresh checklist after `swarm join` |
+| `skills/subagent-driven-development/spec-reviewer-prompt.md` | same | verbatim copy |
+| `skills/subagent-driven-development/code-quality-reviewer-prompt.md` | same | verbatim copy |
+| `skills/dispatching-parallel-agents/SKILL.md` | same | refactored — parallel = N concurrent slot sessions |
+| `skills/using-bones-swarm/SKILL.md` | `skills/using-git-worktrees/SKILL.md` | full rewrite — bones swarm flow (join/cwd/work/commit/close) |
+| `skills/finishing-a-bones-leaf/SKILL.md` | `skills/finishing-a-development-branch/SKILL.md` | full rewrite — fan-in/keep/abandon menu instead of merge/PR/keep/discard |
+
+Upstream license: MIT (Jesse Vincent / fsck.com).
+
+## Resyncing from upstream (manual procedure)
+
+1. Identify the upstream version: `cat ~/.claude/plugins/cache/claude-plugins-official/superpowers/<version>/.claude-plugin/plugin.json | jq .version`
+2. For each file in the table above marked "verbatim copy", overwrite with the upstream copy.
+3. For each "refactored" or "full rewrite" file, manually merge upstream changes into the bones-powers version.
+4. Update this file's "forked from v5.0.7 on 2026-04-29" header.

--- a/plugins/bones-powers/hooks/hooks.json
+++ b/plugins/bones-powers/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/bones-powers/hooks/run-hook.cmd
+++ b/plugins/bones-powers/hooks/run-hook.cmd
@@ -1,0 +1,46 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without SessionStart context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/plugins/bones-powers/hooks/session-start
+++ b/plugins/bones-powers/hooks/session-start
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# bones-powers SessionStart hook.
+# Injects skills/using-bones-powers/SKILL.md ONLY when cwd is a bones workspace
+# (marker: .bones/repo.fossil). Outside a bones workspace, exits silently with
+# empty additionalContext so other plugins/hooks are unaffected.
+
+set -u
+
+# Gate: bones workspace marker.
+if [[ ! -f .bones/repo.fossil ]]; then
+  if [[ -n "${CURSOR_PLUGIN_ROOT:-}" ]]; then
+    printf '{\n  "additional_context": ""\n}\n'
+  elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -z "${COPILOT_CLI:-}" ]]; then
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": ""\n  }\n}\n'
+  else
+    printf '{\n  "additionalContext": ""\n}\n'
+  fi
+  exit 0
+fi
+
+# Locate the using-bones-powers skill relative to this hook script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SKILL_FILE="${PLUGIN_ROOT}/skills/using-bones-powers/SKILL.md"
+
+if [[ ! -f "${SKILL_FILE}" ]]; then
+  # Skill missing — fail open with empty context rather than block the session.
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": ""\n  }\n}\n'
+  exit 0
+fi
+
+skill_content=$(cat "${SKILL_FILE}")
+
+# JSON-escape the skill content. Matches upstream superpowers approach: bash
+# parameter substitution rather than character-by-character loop. Each ${s//old/new}
+# is a single C-level pass.
+escape_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+session_context=$(escape_json "$skill_content")
+
+# Multi-platform output format (preserves upstream behavior; see
+# https://github.com/obra/superpowers/issues/571).
+if [[ -n "${CURSOR_PLUGIN_ROOT:-}" ]]; then
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -z "${COPILOT_CLI:-}" ]]; then
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
+else
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
+fi
+
+exit 0

--- a/plugins/bones-powers/skills/brainstorming/SKILL.md
+++ b/plugins/bones-powers/skills/brainstorming/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: brainstorming
+description: Help turn ideas into fully formed designs and specs through natural collaborative dialogue. Use when the user wants to design something, brainstorm a feature, or plan a project in a bones workspace.
+---
+
+# Brainstorming Ideas Into Designs
+
+Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
+
+Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## Checklist
+
+You MUST create a task for each of these items and complete them in order:
+
+1. **Explore project context** — check files, docs, recent commits
+2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
+3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+4. **Propose 2-3 approaches** — with trade-offs and your recommendation
+5. **Present design** — in sections scaled to their complexity, get user approval after each section
+6. **Write design doc** — save to `docs/bones-powers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+8. **User reviews written spec** — ask user to review the spec file before proceeding
+9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Explore project context" [shape=box];
+    "Visual questions ahead?" [shape=diamond];
+    "Offer Visual Companion\n(own message, no other content)" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design sections" [shape=box];
+    "User approves design?" [shape=diamond];
+    "Write design doc" [shape=box];
+    "Spec self-review\n(fix inline)" [shape=box];
+    "User reviews spec?" [shape=diamond];
+    "Invoke writing-plans skill" [shape=doublecircle];
+
+    "Explore project context" -> "Visual questions ahead?";
+    "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
+    "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
+    "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design sections";
+    "Present design sections" -> "User approves design?";
+    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Write design doc" [label="yes"];
+    "Write design doc" -> "Spec self-review\n(fix inline)";
+    "Spec self-review\n(fix inline)" -> "User reviews spec?";
+    "User reviews spec?" -> "Write design doc" [label="changes requested"];
+    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+}
+```
+
+**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+
+## The Process
+
+**Understanding the idea:**
+
+- Check out the current project state first (files, docs, recent commits)
+- Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
+- If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
+- For appropriately-scoped projects, ask questions one at a time to refine the idea
+- Prefer multiple choice questions when possible, but open-ended is fine too
+- Only one question per message - if a topic needs more exploration, break it into multiple questions
+- Focus on understanding: purpose, constraints, success criteria
+
+**Exploring approaches:**
+
+- Propose 2-3 different approaches with trade-offs
+- Present options conversationally with your recommendation and reasoning
+- Lead with your recommended option and explain why
+
+**Presenting the design:**
+
+- Once you believe you understand what you're building, present the design
+- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
+- Ask after each section whether it looks right so far
+- Cover: architecture, components, data flow, error handling, testing
+- Be ready to go back and clarify if something doesn't make sense
+
+**Design for isolation and clarity:**
+
+- Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently
+- For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?
+- Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.
+- Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.
+
+**Working in existing codebases:**
+
+- Explore the current structure before proposing changes. Follow existing patterns.
+- Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
+- Don't propose unrelated refactoring. Stay focused on what serves the current goal.
+
+## After the Design
+
+**Documentation:**
+
+- Write the validated design (spec) to `docs/bones-powers/specs/YYYY-MM-DD-<topic>-design.md`
+  - (User preferences for spec location override this default)
+- Use elements-of-style:writing-clearly-and-concisely skill if available
+- Commit the design document: `bones repo add <spec> && bones repo ci -m 'docs: add <topic> design spec' <spec>`
+
+**Spec Self-Review:**
+After writing the spec document, look at it with fresh eyes:
+
+1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
+2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
+3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
+4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+
+Fix any issues inline. No need to re-review — just fix and move on.
+
+**User Review Gate:**
+After the spec review loop passes, ask the user to review the written spec before proceeding:
+
+> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+
+Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+
+**Implementation:**
+
+- Invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other skill. writing-plans is the next step.
+
+## Key Principles
+
+- **One question at a time** - Don't overwhelm with multiple questions
+- **Multiple choice preferred** - Easier to answer than open-ended when possible
+- **YAGNI ruthlessly** - Remove unnecessary features from all designs
+- **Explore alternatives** - Always propose 2-3 approaches before settling
+- **Incremental validation** - Present design, get approval before moving on
+- **Be flexible** - Go back and clarify when something doesn't make sense
+
+## Visual Companion
+
+A browser-based companion for showing mockups, diagrams, and visual options during brainstorming. Available as a tool — not a mode. Accepting the companion means it's available for questions that benefit from visual treatment; it does NOT mean every question goes through the browser.
+
+**Offering the companion:** When you anticipate that upcoming questions will involve visual content (mockups, layouts, diagrams), offer it once for consent:
+> "Some of what we're working on might be easier to explain if I can show it to you in a web browser. I can put together mockups, diagrams, comparisons, and other visuals as we go. This feature is still new and can be token-intensive. Want to try it? (Requires opening a local URL)"
+
+**This offer MUST be its own message.** Do not combine it with clarifying questions, context summaries, or any other content. The message should contain ONLY the offer above and nothing else. Wait for the user's response before continuing. If they decline, proceed with text-only brainstorming.
+
+**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**
+
+- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
+- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions
+
+A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
+
+If they agree to the companion, read the detailed guide before proceeding:
+`skills/brainstorming/visual-companion.md`

--- a/plugins/bones-powers/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/plugins/bones-powers/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Spec Document Reviewer Prompt Template
+
+Use this template when dispatching a spec document reviewer subagent.
+
+**Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
+
+**Dispatch after:** Spec document is written to docs/superpowers/specs/
+
+```
+Task tool (general-purpose):
+  description: "Review spec document"
+  prompt: |
+    You are a spec document reviewer. Verify this spec is complete and ready for planning.
+
+    **Spec to review:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, "TBD", incomplete sections |
+    | Consistency | Internal contradictions, conflicting requirements |
+    | Clarity | Requirements ambiguous enough to cause someone to build the wrong thing |
+    | Scope | Focused enough for a single plan — not covering multiple independent subsystems |
+    | YAGNI | Unrequested features, over-engineering |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation planning.**
+    A missing section, a contradiction, or a requirement so ambiguous it could be
+    interpreted two different ways — those are issues. Minor wording improvements,
+    stylistic preferences, and "sections less detailed than others" are not.
+
+    Approve unless there are serious gaps that would lead to a flawed plan.
+
+    ## Output Format
+
+    ## Spec Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Section X]: [specific issue] - [why it matters for planning]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations

--- a/plugins/bones-powers/skills/brainstorming/visual-companion.md
+++ b/plugins/bones-powers/skills/brainstorming/visual-companion.md
@@ -1,0 +1,287 @@
+# Visual Companion Guide
+
+Browser-based visual brainstorming companion for showing mockups, diagrams, and options.
+
+## When to Use
+
+Decide per-question, not per-session. The test: **would the user understand this better by seeing it than reading it?**
+
+**Use the browser** when the content itself is visual:
+
+- **UI mockups** — wireframes, layouts, navigation structures, component designs
+- **Architecture diagrams** — system components, data flow, relationship maps
+- **Side-by-side visual comparisons** — comparing two layouts, two color schemes, two design directions
+- **Design polish** — when the question is about look and feel, spacing, visual hierarchy
+- **Spatial relationships** — state machines, flowcharts, entity relationships rendered as diagrams
+
+**Use the terminal** when the content is text or tabular:
+
+- **Requirements and scope questions** — "what does X mean?", "which features are in scope?"
+- **Conceptual A/B/C choices** — picking between approaches described in words
+- **Tradeoff lists** — pros/cons, comparison tables
+- **Technical decisions** — API design, data modeling, architectural approach selection
+- **Clarifying questions** — anything where the answer is words, not a visual preference
+
+A question *about* a UI topic is not automatically a visual question. "What kind of wizard do you want?" is conceptual — use the terminal. "Which of these wizard layouts feels right?" is visual — use the browser.
+
+## How It Works
+
+The server watches a directory for HTML files and serves the newest one to the browser. You write HTML content to `screen_dir`, the user sees it in their browser and can click to select options. Selections are recorded to `state_dir/events` that you read on your next turn.
+
+**Content fragments vs full documents:** If your HTML file starts with `<!DOCTYPE` or `<html`, the server serves it as-is (just injects the helper script). Otherwise, the server automatically wraps your content in the frame template — adding the header, CSS theme, selection indicator, and all interactive infrastructure. **Write content fragments by default.** Only write full documents when you need complete control over the page.
+
+## Starting a Session
+
+```bash
+# Start server with persistence (mockups saved to project)
+scripts/start-server.sh --project-dir /path/to/project
+
+# Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
+#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
+#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+```
+
+Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
+
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+
+**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+
+**Launching the server by platform:**
+
+**Claude Code (macOS / Linux):**
+```bash
+# Default mode works — the script backgrounds the server itself
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Claude Code (Windows):**
+```bash
+# Windows auto-detects and uses foreground mode, which blocks the tool call.
+# Use run_in_background: true on the Bash tool call so the server survives
+# across conversation turns.
+scripts/start-server.sh --project-dir /path/to/project
+```
+When calling this via the Bash tool, set `run_in_background: true`. Then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
+
+**Codex:**
+```bash
+# Codex reaps background processes. The script auto-detects CODEX_CI and
+# switches to foreground mode. Run it normally — no extra flags needed.
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Gemini CLI:**
+```bash
+# Use --foreground and set is_background: true on your shell tool call
+# so the process survives across turns
+scripts/start-server.sh --project-dir /path/to/project --foreground
+```
+
+**Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
+
+If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
+
+```bash
+scripts/start-server.sh \
+  --project-dir /path/to/project \
+  --host 0.0.0.0 \
+  --url-host localhost
+```
+
+Use `--url-host` to control what hostname is printed in the returned URL JSON.
+
+## The Loop
+
+1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:
+   - Before each write, check that `$STATE_DIR/server-info` exists. If it doesn't (or `$STATE_DIR/server-stopped` exists), the server has shut down — restart it with `start-server.sh` before continuing. The server auto-exits after 30 minutes of inactivity.
+   - Use semantic filenames: `platform.html`, `visual-style.html`, `layout.html`
+   - **Never reuse filenames** — each screen gets a fresh file
+   - Use Write tool — **never use cat/heredoc** (dumps noise into terminal)
+   - Server automatically serves the newest file
+
+2. **Tell user what to expect and end your turn:**
+   - Remind them of the URL (every step, not just first)
+   - Give a brief text summary of what's on screen (e.g., "Showing 3 layout options for the homepage")
+   - Ask them to respond in the terminal: "Take a look and let me know what you think. Click to select an option if you'd like."
+
+3. **On your next turn** — after the user responds in the terminal:
+   - Read `$STATE_DIR/events` if it exists — this contains the user's browser interactions (clicks, selections) as JSON lines
+   - Merge with the user's terminal text to get the full picture
+   - The terminal message is the primary feedback; `state_dir/events` provides structured interaction data
+
+4. **Iterate or advance** — if feedback changes current screen, write a new file (e.g., `layout-v2.html`). Only move to the next question when the current step is validated.
+
+5. **Unload when returning to terminal** — when the next step doesn't need the browser (e.g., a clarifying question, a tradeoff discussion), push a waiting screen to clear the stale content:
+
+   ```html
+   <!-- filename: waiting.html (or waiting-2.html, etc.) -->
+   <div style="display:flex;align-items:center;justify-content:center;min-height:60vh">
+     <p class="subtitle">Continuing in terminal...</p>
+   </div>
+   ```
+
+   This prevents the user from staring at a resolved choice while the conversation has moved on. When the next visual question comes up, push a new content file as usual.
+
+6. Repeat until done.
+
+## Writing Content Fragments
+
+Write just the content that goes inside the page. The server wraps it in the frame template automatically (header, theme CSS, selection indicator, and all interactive infrastructure).
+
+**Minimal example:**
+
+```html
+<h2>Which layout works better?</h2>
+<p class="subtitle">Consider readability and visual hierarchy</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Single Column</h3>
+      <p>Clean, focused reading experience</p>
+    </div>
+  </div>
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>Two Column</h3>
+      <p>Sidebar navigation with main content</p>
+    </div>
+  </div>
+</div>
+```
+
+That's it. No `<html>`, no CSS, no `<script>` tags needed. The server provides all of that.
+
+## CSS Classes Available
+
+The frame template provides these CSS classes for your content:
+
+### Options (A/B/C choices)
+
+```html
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Title</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+**Multi-select:** Add `data-multiselect` to the container to let users select multiple options. Each click toggles the item. The indicator bar shows the count.
+
+```html
+<div class="options" data-multiselect>
+  <!-- same option markup — users can select/deselect multiple -->
+</div>
+```
+
+### Cards (visual designs)
+
+```html
+<div class="cards">
+  <div class="card" data-choice="design1" onclick="toggleSelect(this)">
+    <div class="card-image"><!-- mockup content --></div>
+    <div class="card-body">
+      <h3>Name</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+### Mockup container
+
+```html
+<div class="mockup">
+  <div class="mockup-header">Preview: Dashboard Layout</div>
+  <div class="mockup-body"><!-- your mockup HTML --></div>
+</div>
+```
+
+### Split view (side-by-side)
+
+```html
+<div class="split">
+  <div class="mockup"><!-- left --></div>
+  <div class="mockup"><!-- right --></div>
+</div>
+```
+
+### Pros/Cons
+
+```html
+<div class="pros-cons">
+  <div class="pros"><h4>Pros</h4><ul><li>Benefit</li></ul></div>
+  <div class="cons"><h4>Cons</h4><ul><li>Drawback</li></ul></div>
+</div>
+```
+
+### Mock elements (wireframe building blocks)
+
+```html
+<div class="mock-nav">Logo | Home | About | Contact</div>
+<div style="display: flex;">
+  <div class="mock-sidebar">Navigation</div>
+  <div class="mock-content">Main content area</div>
+</div>
+<button class="mock-button">Action Button</button>
+<input class="mock-input" placeholder="Input field">
+<div class="placeholder">Placeholder area</div>
+```
+
+### Typography and sections
+
+- `h2` — page title
+- `h3` — section heading
+- `.subtitle` — secondary text below title
+- `.section` — content block with bottom margin
+- `.label` — small uppercase label text
+
+## Browser Events Format
+
+When the user clicks options in the browser, their interactions are recorded to `$STATE_DIR/events` (one JSON object per line). The file is cleared automatically when you push a new screen.
+
+```jsonl
+{"type":"click","choice":"a","text":"Option A - Simple Layout","timestamp":1706000101}
+{"type":"click","choice":"c","text":"Option C - Complex Grid","timestamp":1706000108}
+{"type":"click","choice":"b","text":"Option B - Hybrid","timestamp":1706000115}
+```
+
+The full event stream shows the user's exploration path — they may click multiple options before settling. The last `choice` event is typically the final selection, but the pattern of clicks can reveal hesitation or preferences worth asking about.
+
+If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser — use only their terminal text.
+
+## Design Tips
+
+- **Scale fidelity to the question** — wireframes for layout, polish for polish questions
+- **Explain the question on each page** — "Which layout feels more professional?" not just "Pick one"
+- **Iterate before advancing** — if feedback changes current screen, write a new version
+- **2-4 options max** per screen
+- **Use real content when it matters** — for a photography portfolio, use actual images (Unsplash). Placeholder content obscures design issues.
+- **Keep mockups simple** — focus on layout and structure, not pixel-perfect design
+
+## File Naming
+
+- Use semantic names: `platform.html`, `visual-style.html`, `layout.html`
+- Never reuse filenames — each screen must be a new file
+- For iterations: append version suffix like `layout-v2.html`, `layout-v3.html`
+- Server serves newest file by modification time
+
+## Cleaning Up
+
+```bash
+scripts/stop-server.sh $SESSION_DIR
+```
+
+If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+
+## Reference
+
+- Frame template (CSS reference): `scripts/frame-template.html`
+- Helper script (client-side): `scripts/helper.js`

--- a/plugins/bones-powers/skills/brainstorming/visual-companion.md
+++ b/plugins/bones-powers/skills/brainstorming/visual-companion.md
@@ -37,15 +37,15 @@ The server watches a directory for HTML files and serves the newest one to the b
 scripts/start-server.sh --project-dir /path/to/project
 
 # Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
-#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
-#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+#           "screen_dir":"/path/to/project/.bones-powers/brainstorm/12345-1706000000/content",
+#           "state_dir":"/path/to/project/.bones-powers/brainstorm/12345-1706000000/state"}
 ```
 
 Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
 
-**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.bones-powers/brainstorm/` for the session directory.
 
-**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+**Note:** Pass the project root as `--project-dir` so mockups persist in `.bones-powers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.bones-powers/` to `.gitignore` if it's not already there.
 
 **Launching the server by platform:**
 
@@ -279,7 +279,7 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 scripts/stop-server.sh $SESSION_DIR
 ```
 
-If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+If the session used `--project-dir`, mockup files persist in `.bones-powers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
 
 ## Reference
 

--- a/plugins/bones-powers/skills/dispatching-parallel-agents/SKILL.md
+++ b/plugins/bones-powers/skills/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: dispatching-parallel-agents
+description: Run N concurrent slot sessions in a bones workspace for parallel debugging or independent work. Discover ready work via bones swarm tasks --slot=X --json. Roll up cross-slot status via bones tasks aggregate. Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies.
+---
+
+# Dispatching Parallel Agents
+
+## Overview
+
+You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
+
+When you have multiple unrelated failures (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel.
+
+**Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Multiple failures?" [shape=diamond];
+    "Are they independent?" [shape=diamond];
+    "Single agent investigates all" [shape=box];
+    "One agent per problem domain" [shape=box];
+    "Can they work in parallel?" [shape=diamond];
+    "Sequential agents" [shape=box];
+    "Parallel dispatch" [shape=box];
+
+    "Multiple failures?" -> "Are they independent?" [label="yes"];
+    "Are they independent?" -> "Single agent investigates all" [label="no - related"];
+    "Are they independent?" -> "Can they work in parallel?" [label="yes"];
+    "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];
+    "Can they work in parallel?" -> "Sequential agents" [label="no - shared state"];
+}
+```
+
+**Use when:**
+- 3+ test files failing with different root causes
+- Multiple subsystems broken independently
+- Each problem can be understood without context from others
+- No shared state between investigations
+
+**Don't use when:**
+- Failures are related (fix one might fix others)
+- Need to understand full system state
+- Agents would interfere with each other
+
+## The Pattern
+
+### 1. Identify Independent Domains
+
+Group failures by what's broken:
+- File A tests: Tool approval flow
+- File B tests: Batch completion behavior
+- File C tests: Abort functionality
+
+Each domain is independent - fixing tool approval doesn't affect abort tests.
+
+### 2. Create Focused Agent Tasks
+
+Each agent gets:
+- **Specific scope:** One test file or subsystem
+- **Clear goal:** Make these tests pass
+- **Constraints:** Don't change other code
+- **Expected output:** Summary of what you found and fixed
+
+### 3. Dispatch in Parallel
+
+```typescript
+// In Claude Code / AI environment
+Task("Fix agent-tool-abort.test.ts failures")
+Task("Fix batch-completion-behavior.test.ts failures")
+Task("Fix tool-approval-race-conditions.test.ts failures")
+// All three run concurrently
+```
+
+### 4. Review and Integrate
+
+When agents return:
+- Read each summary
+- Verify fixes don't conflict
+- Run full test suite
+- Integrate all changes
+
+## Agent Prompt Structure
+
+Good agent prompts are:
+1. **Focused** - One clear problem domain
+2. **Self-contained** - All context needed to understand the problem
+3. **Specific about output** - What should the agent return?
+
+```markdown
+Fix the 3 failing tests in src/agents/agent-tool-abort.test.ts:
+
+1. "should abort tool with partial output capture" - expects 'interrupted at' in message
+2. "should handle mixed completed and aborted tools" - fast tool aborted instead of completed
+3. "should properly track pendingToolCount" - expects 3 results but gets 0
+
+These are timing/race condition issues. Your task:
+
+1. Read the test file and understand what each test verifies
+2. Identify root cause - timing issues or actual bugs?
+3. Fix by:
+   - Replacing arbitrary timeouts with event-based waiting
+   - Fixing bugs in abort implementation if found
+   - Adjusting test expectations if testing changed behavior
+
+Do NOT just increase timeouts - find the real issue.
+
+Return: Summary of what you found and what you fixed.
+```
+
+## Common Mistakes
+
+**❌ Too broad:** "Fix all the tests" - agent gets lost
+**✅ Specific:** "Fix agent-tool-abort.test.ts" - focused scope
+
+**❌ No context:** "Fix the race condition" - agent doesn't know where
+**✅ Context:** Paste the error messages and test names
+
+**❌ No constraints:** Agent might refactor everything
+**✅ Constraints:** "Do NOT change production code" or "Fix tests only"
+
+**❌ Vague output:** "Fix it" - you don't know what changed
+**✅ Specific:** "Return summary of root cause and changes"
+
+## Parallel = N concurrent slot sessions
+
+In bones, parallelism is expressed via slots. Each slot can hold one open swarm session (one leaf + one claimed task + one worktree). To run N agents in parallel:
+
+1. Pick N slot names (e.g. `alpha`, `beta`, `gamma`).
+2. For each slot, dispatch a fresh subagent that runs:
+   ```bash
+   READY_TASK=$(bones swarm tasks --slot="$SLOT" --json | jq -r '.[0].id')
+   bones swarm join --slot="$SLOT" --task-id="$READY_TASK"
+   # ... do the work ...
+   bones swarm close --result=success --summary='<note>'
+   ```
+
+The N sessions run independently, each in its own leaf/worktree.
+
+## Cross-slot status
+
+```bash
+bones tasks aggregate --json
+```
+
+Returns a per-slot summary: ready / claimed / closed counts. Use this to monitor parallel progress without polling each slot individually.
+
+## When NOT to Use
+
+**Related failures:** Fixing one might fix others - investigate together first
+**Need full context:** Understanding requires seeing entire system
+**Exploratory debugging:** You don't know what's broken yet
+**Shared state:** Agents would interfere (editing same files, using same resources)
+
+## Real Example from Session
+
+**Scenario:** 6 test failures across 3 files after major refactoring
+
+**Failures:**
+- agent-tool-abort.test.ts: 3 failures (timing issues)
+- batch-completion-behavior.test.ts: 2 failures (tools not executing)
+- tool-approval-race-conditions.test.ts: 1 failure (execution count = 0)
+
+**Decision:** Independent domains - abort logic separate from batch completion separate from race conditions
+
+**Dispatch:**
+```
+Agent 1 → Fix agent-tool-abort.test.ts
+Agent 2 → Fix batch-completion-behavior.test.ts
+Agent 3 → Fix tool-approval-race-conditions.test.ts
+```
+
+**Results:**
+- Agent 1: Replaced timeouts with event-based waiting
+- Agent 2: Fixed event structure bug (threadId in wrong place)
+- Agent 3: Added wait for async tool execution to complete
+
+**Integration:** All fixes independent, no conflicts, full suite green
+
+**Time saved:** 3 problems solved in parallel vs sequentially
+
+## Key Benefits
+
+1. **Parallelization** - Multiple investigations happen simultaneously
+2. **Focus** - Each agent has narrow scope, less context to track
+3. **Independence** - Agents don't interfere with each other
+4. **Speed** - 3 problems solved in time of 1
+
+## Verification
+
+After agents return:
+1. **Review each summary** - Understand what changed
+2. **Check for conflicts** - Did agents edit same code?
+3. **Run full suite** - Verify all fixes work together
+4. **Spot check** - Agents can make systematic errors
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- 6 failures across 3 files
+- 3 agents dispatched in parallel
+- All investigations completed concurrently
+- All fixes integrated successfully
+- Zero conflicts between agent changes

--- a/plugins/bones-powers/skills/executing-plans/SKILL.md
+++ b/plugins/bones-powers/skills/executing-plans/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: executing-plans
+description: Execute a plan task-by-task in a single session inside a bones workspace. Coordinator enumerates tasks via bones tasks list, claims one at a time, and closes with --reason on completion. Use when running a plan inline (single agent, single session); use subagent-driven-development instead for parallel slot work.
+---
+
+> **Execution mode**: this skill is for **single-session inline execution** — one agent runs the whole plan in one session. For parallel slot sessions, use `bones-powers:subagent-driven-development` instead. (Per spec § 5 boundary.)
+
+# Executing Plans
+
+## Overview
+
+Load plan, review critically, execute all tasks, report when complete.
+
+**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+
+**Note:** Tell your human partner that bones-powers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use bones-powers:subagent-driven-development instead of this skill.
+
+## Source of truth: the bones task graph
+
+The plan was materialized into bones tasks by `writing-plans` (per spec § 4.4). The coordinator's source of truth is **NOT** TodoWrite — it is `bones tasks list --parent=<root_id>`.
+
+```bash
+ROOT_ID=<paste from writing-plans output>
+bones tasks list --parent="$ROOT_ID" --json | jq '.[] | {id, title, slot, status}'
+```
+
+Loop through pending tasks; for each:
+
+```bash
+TASK_ID=<id from list>
+bones tasks claim "$TASK_ID"
+
+# (do the work — see hybrid task model § 6: TodoWrite the in-task micro-steps here)
+
+bones tasks close "$TASK_ID" --reason="<short result note>"
+```
+
+Heartbeat during long work via `bones swarm commit -m '…'`.
+
+**Hybrid task model**: per spec § 6, the coordinator keeps NO TodoWrite of its own. TodoWrite is the worker's tool, used only for micro-steps inside one currently-claimed bones task; it is discarded when the bones task closes.
+
+## The Process
+
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Enumerate tasks from `bones tasks list` and proceed
+
+### Step 2: Execute Tasks
+
+For each task from `bones tasks list --parent="$ROOT_ID"`:
+1. Claim via `bones tasks claim "$TASK_ID"`
+2. Follow each step exactly (plan has bite-sized steps)
+3. Run verifications as specified
+4. Close via `bones tasks close "$TASK_ID" --reason="<result>"`
+
+### Step 3: Complete Development
+
+After all tasks complete and verified:
+- Announce: "I'm using the finishing-a-bones-leaf skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use bones-powers:finishing-a-bones-leaf
+- Follow that skill to verify tests, present options, execute choice
+
+## When to Stop and Ask for Help
+
+**STOP executing immediately when:**
+- Hit a blocker (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- You don't understand an instruction
+- Verification fails repeatedly
+
+**Ask for clarification rather than guessing.**
+
+## When to Revisit Earlier Steps
+
+**Return to Review (Step 1) when:**
+- Partner updates the plan based on your feedback
+- Fundamental approach needs rethinking
+
+**Don't force through blockers** - stop and ask.
+
+## Remember
+- Review plan critically first
+- Follow plan steps exactly
+- Don't skip verifications
+- Reference skills when plan says to
+- Stop when blocked, don't guess
+- Never start implementation on main/master branch without explicit user consent
+
+## Integration
+
+**Required workflow skills:**
+- **bones-powers:using-bones-powers** - REQUIRED: Set up isolated workspace before starting
+- **bones-powers:writing-plans** - Creates the plan this skill executes
+- **bones-powers:finishing-a-bones-leaf** - Complete development after all tasks

--- a/plugins/bones-powers/skills/finishing-a-bones-leaf/SKILL.md
+++ b/plugins/bones-powers/skills/finishing-a-bones-leaf/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: finishing-a-bones-leaf
+description: After a bones swarm session closes, decide what to do with the open leaf — fan-in to trunk, keep open, or abandon. Use when implementation is complete, all tests pass, and you need to integrate the work back into the bones hub trunk.
+---
+
+# Finishing a bones leaf
+
+Your swarm session has closed (`bones swarm close --result=success`), but the leaf is still open in the hub. This skill walks you through the integration decision.
+
+**Prerequisite**: at least one closed-success swarm session has produced commits on a leaf in the hub.
+
+## Pre-flight: review what's about to integrate
+
+Before any integration step:
+
+```bash
+bones swarm status                # which leaves are open?
+bones repo timeline --limit 20    # recent activity on the hub
+bones repo diff <trunk-rev>       # diff vs. trunk for context
+```
+
+## Three options
+
+### Option 1: Fan-in to trunk (the merge path)
+
+Merges open hub leaves back into trunk. **Always preview first.**
+
+```bash
+# 1. Preview — see what would be merged, no changes
+bones swarm fan-in --dry-run -m "merge <leaves> to trunk"
+
+# 2. If preview looks right, execute
+bones swarm fan-in -m "merge <leaves> to trunk"
+```
+
+**On conflict** (semantics not yet empirically verified — see spec § 11 — but the defensive flow is canonical given fossil's conflict model):
+
+If `fan-in` reports a non-zero exit code, conflicts likely exist. Enumerate and resolve:
+
+```bash
+bones repo conflicts ls
+bones repo conflicts show <file>
+# Choose ONE resolution strategy per conflicted file:
+bones repo conflicts pick <file>           # pick one version wholesale
+bones repo conflicts merge <file>          # re-merge with a different strategy
+bones repo conflicts extract <file>        # extract all versions to disk for manual edit
+
+# After resolving each file:
+bones repo mark-resolved <file>
+
+# Once all conflicts marked resolved, re-run fan-in:
+bones swarm fan-in -m '<original message>'
+```
+
+### Option 2: Keep leaf open
+
+No-op. The leaf stays open in the hub for later work. Useful when:
+- Work is complete but you want trunk integration to happen later (e.g., as part of a release batch)
+- You need the leaf for another swarm session (rare)
+
+```bash
+echo "leaf left open; integrate later via 'bones swarm fan-in'"
+```
+
+### Option 3: Abandon
+
+Discard the work. Closes the swarm session as failed (releasing the claim) without fan-in. The commits remain on the leaf in the hub but are never integrated.
+
+```bash
+bones swarm close --result=fail --summary="<why abandoned>"
+```
+
+(Note: this only applies if a session is still open. If you've already cleanly closed a successful session and want to throw away the work, you'd need to manually close the leaf branch via `bones repo branch close <leaf>`.)
+
+## Decision flow
+
+```
+Is the work done and good?
+├── Yes, ready to integrate         → Option 1 (Fan-in)
+├── Yes, but defer integration       → Option 2 (Keep open)
+└── No, throw it away                → Option 3 (Abandon)
+```
+
+## What this skill does NOT cover (v0)
+
+- **Pushing trunk to a git remote**: if your bones workspace is over a git-cloned repo, push manually after fan-in via `git push`. Spec § 5.8 lists this as out of scope for v0.
+- **GitHub PR creation**: bones is hub-trunk, not git PR-flow. If you need a PR for human review, that's a manual workflow on top of the integrated trunk.

--- a/plugins/bones-powers/skills/subagent-driven-development/SKILL.md
+++ b/plugins/bones-powers/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: subagent-driven-development
+description: Execute a plan in parallel slot sessions. Each implementer subagent runs in its own bones swarm session (slot + claim + worktree atomic via bones swarm join). Two-stage review (spec compliance + code quality) per task. Use when the plan has independent tasks that can run concurrently; use executing-plans instead for single-session inline runs.
+---
+
+> **Execution mode**: this skill is for **parallel slot sessions** — multiple subagents claim and run plan steps concurrently, each in its own slot/leaf. For single-session inline runs, use `bones-powers:executing-plans` instead. (Per spec § 5 boundary.)
+
+# Subagent-Driven Development
+
+Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review. Each implementer runs in its own bones swarm session — isolated leaf, claimed task, dedicated worktree.
+
+**Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
+
+**Core principle:** Fresh subagent per task + bones swarm session (atomic claim) + two-stage review (spec then quality) = high quality, fast iteration
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Have implementation plan?" [shape=diamond];
+    "Tasks mostly independent?" [shape=diamond];
+    "Stay in this session?" [shape=diamond];
+    "subagent-driven-development" [shape=box];
+    "executing-plans" [shape=box];
+    "Manual execution or brainstorm first" [shape=box];
+
+    "Have implementation plan?" -> "Tasks mostly independent?" [label="yes"];
+    "Have implementation plan?" -> "Manual execution or brainstorm first" [label="no"];
+    "Tasks mostly independent?" -> "Stay in this session?" [label="yes"];
+    "Tasks mostly independent?" -> "Manual execution or brainstorm first" [label="no - tightly coupled"];
+    "Stay in this session?" -> "subagent-driven-development" [label="yes"];
+    "Stay in this session?" -> "executing-plans" [label="no - parallel session"];
+}
+```
+
+**vs. Executing Plans (parallel session):**
+- Same session (no context switch)
+- Fresh subagent per task (no context pollution)
+- Two-stage review after each task: spec compliance first, then code quality
+- Faster iteration (no human-in-loop between tasks)
+
+## Coordinator Setup
+
+```bash
+ROOT_ID=<paste from writing-plans output>
+bones tasks list --parent="$ROOT_ID" --json | jq '.[] | {id, title, slot, status}'
+```
+
+This is the source of truth. The coordinator does NOT mirror tasks into TodoWrite (per spec § 6). Tasks are claimed and closed atomically through the swarm session of each implementer subagent.
+
+## The Process
+
+```dot
+digraph process {
+    rankdir=TB;
+
+    subgraph cluster_per_task {
+        label="Per Task";
+        "Dispatch implementer subagent (./implementer-prompt.md)" [shape=box];
+        "Implementer subagent asks questions?" [shape=diamond];
+        "Answer questions, provide context" [shape=box];
+        "Implementer: swarm join + TodoWrite + implement + swarm close" [shape=box];
+        "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [shape=box];
+        "Spec reviewer subagent confirms code matches spec?" [shape=diamond];
+        "Re-dispatch on spec failure (swarm close fail + fresh join)" [shape=box];
+        "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
+        "Code quality reviewer subagent approves?" [shape=diamond];
+        "Re-dispatch on quality failure (swarm close fail + fresh join)" [shape=box];
+        "Task closed success in bones tasks" [shape=box];
+    }
+
+    "bones tasks list --parent=ROOT_ID (source of truth)" [shape=box];
+    "More tasks remain?" [shape=diamond];
+    "Dispatch final code reviewer subagent for entire implementation" [shape=box];
+    "Use bones-powers:finishing-a-bones-leaf" [shape=box style=filled fillcolor=lightgreen];
+
+    "bones tasks list --parent=ROOT_ID (source of truth)" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
+    "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
+    "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Implementer subagent asks questions?" -> "Implementer: swarm join + TodoWrite + implement + swarm close" [label="no"];
+    "Implementer: swarm join + TodoWrite + implement + swarm close" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
+    "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
+    "Spec reviewer subagent confirms code matches spec?" -> "Re-dispatch on spec failure (swarm close fail + fresh join)" [label="no"];
+    "Re-dispatch on spec failure (swarm close fail + fresh join)" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
+    "Spec reviewer subagent confirms code matches spec?" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
+    "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
+    "Code quality reviewer subagent approves?" -> "Re-dispatch on quality failure (swarm close fail + fresh join)" [label="no"];
+    "Re-dispatch on quality failure (swarm close fail + fresh join)" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
+    "Code quality reviewer subagent approves?" -> "Task closed success in bones tasks" [label="yes"];
+    "Task closed success in bones tasks" -> "More tasks remain?";
+    "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
+    "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
+    "Dispatch final code reviewer subagent for entire implementation" -> "Use bones-powers:finishing-a-bones-leaf";
+}
+```
+
+## For Each Task: Implementer Dispatch
+
+For each task in the bones task graph:
+
+1. **Coordinator dispatches a fresh implementer subagent** with:
+   - Task `id`, `slot`, full task title and body from `bones tasks show $TASK_ID`
+   - The plan path (from `--files`)
+   - Brief feedback context if this is a re-dispatch after review
+
+2. **Implementer's first action** (per spec § 5.5):
+   ```bash
+   bones swarm join --slot="$SLOT" --task-id="$TASK_ID"
+   ```
+   This atomically: opens a leaf, claims the task, prepares a worktree.
+
+3. **Implementer's second action**: TodoWrite a fresh checklist of the in-task micro-steps (per hybrid task model § 6).
+
+4. **Implementer does the work**, heartbeating via `bones swarm commit -m '…'`.
+
+5. **Implementer closes the swarm session**:
+   ```bash
+   bones swarm close --result=success --summary='<one-line result>'
+   ```
+
+## Re-dispatch on Review Issues
+
+If the spec-compliance reviewer or code-quality reviewer reports issues:
+
+1. **Implementer closes the swarm session as failed**:
+   ```bash
+   bones swarm close --result=fail --summary='<feedback summary>'
+   ```
+   This releases the claim. The task returns to the pending pool with the failure summary attached to its thread.
+
+2. **Coordinator dispatches a fresh implementer** with the original task + the review feedback as additional context.
+
+3. **New implementer joins via `bones swarm join`** (re-claims the same task), addresses the feedback, and re-runs the review loops.
+
+This loop continues until both reviews pass.
+
+## Reviewer Dispatch
+
+Spec-compliance and code-quality reviewers are read-only — they inspect the implementer's leaf directly without claiming a slot of their own. Dispatch them as fresh subagents with:
+- The task text
+- The implementer's report
+- The path to the implementer's worktree (from `bones swarm cwd --slot=$SLOT`)
+
+If a reviewer needs write access (e.g., to annotate or commit a finding), open a sibling slot session (e.g., `--slot=spec-review`, `--slot=code-review`) via a separate `bones swarm join`.
+
+## Model Selection
+
+Use the least powerful model that can handle each role to conserve cost and increase speed.
+
+**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+
+**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+
+**Architecture, design, and review tasks**: use the most capable available model.
+
+**Task complexity signals:**
+- Touches 1-2 files with a complete spec → cheap model
+- Touches multiple files with integration concerns → standard model
+- Requires design judgment or broad codebase understanding → most capable model
+
+## Handling Implementer Status
+
+Implementer subagents report one of four statuses. Handle each appropriately:
+
+**DONE:** Proceed to spec compliance review.
+
+**DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts. Read the concerns before proceeding. If the concerns are about correctness or scope, address them before review. If they're observations (e.g., "this file is getting large"), note them and proceed to review.
+
+**NEEDS_CONTEXT:** The implementer needs information that wasn't provided. Provide the missing context and re-dispatch.
+
+**BLOCKED:** The implementer cannot complete the task. Assess the blocker:
+1. If it's a context problem, provide more context and re-dispatch with the same model
+2. If the task requires more reasoning, re-dispatch with a more capable model
+3. If the task is too large, break it into smaller pieces
+4. If the plan itself is wrong, escalate to the human
+
+**Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
+
+## Prompt Templates
+
+- `./implementer-prompt.md` - Dispatch implementer subagent
+- `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
+- `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
+
+## Example Workflow
+
+```
+You: I'm using Subagent-Driven Development to execute this plan.
+
+[bones tasks list --parent=ROOT_ID]
+→ [T1: Hook installation script | slot=alpha | status=pending]
+→ [T2: Recovery modes | slot=beta | status=pending]
+...
+
+Task 1: Hook installation script
+
+[bones tasks show T1_ID → full task text]
+[Dispatch implementation subagent with task text + context]
+  Implementer first: bones swarm join --slot=alpha --task-id=T1_ID
+  Implementer second: TodoWrite [setup, tests, commit, self-review]
+
+Implementer: "Before I begin - should the hook be installed at user or system level?"
+
+You: "User level (~/.config/bones-powers/hooks/)"
+
+Implementer: "Got it. Implementing now..."
+[Later] Implementer:
+  - Implemented install-hook command
+  - Added tests, 5/5 passing
+  - Self-review: Found I missed --force flag, added it
+  - bones swarm close --result=success --summary='install-hook with --force, 5/5 tests'
+
+[Dispatch spec compliance reviewer with implementer's worktree path]
+Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
+
+[bones tasks show T1_ID — confirms closed:success]
+
+Task 2: Recovery modes
+
+[bones tasks show T2_ID → full task text]
+[Dispatch implementation subagent with task text + context]
+  Implementer first: bones swarm join --slot=beta --task-id=T2_ID
+  Implementer second: TodoWrite [verify mode, repair mode, tests, commit]
+
+Implementer: [No questions, proceeds]
+Implementer:
+  - Added verify/repair modes
+  - 8/8 tests passing
+  - Self-review: All good
+  - bones swarm close --result=success --summary='verify+repair modes, 8/8 tests'
+
+[Dispatch spec compliance reviewer]
+Spec reviewer: ❌ Issues:
+  - Missing: Progress reporting (spec says "report every 100 items")
+  - Extra: Added --json flag (not requested)
+
+[Coordinator dispatches fresh implementer with original task + review feedback]
+  New implementer: bones swarm close --result=fail --summary='missing progress reporting, extra --json flag'
+  New implementer: bones swarm join --slot=beta --task-id=T2_ID  (re-claim)
+  New implementer: TodoWrite [remove --json, add progress reporting, re-test]
+
+[Implementer fixes issues]
+Implementer: Removed --json flag, added progress reporting
+  bones swarm close --result=success --summary='progress reporting added, --json removed'
+
+[Spec reviewer reviews again]
+Spec reviewer: ✅ Spec compliant now
+
+[Dispatch code quality reviewer]
+Code reviewer: Strengths: Solid. Issues (Important): Magic number (100)
+
+[Re-dispatch implementer with quality feedback]
+  bones swarm close --result=fail --summary='magic number 100 needs PROGRESS_INTERVAL constant'
+  bones swarm join --slot=beta --task-id=T2_ID
+  Implementer: Extracted PROGRESS_INTERVAL constant
+  bones swarm close --result=success --summary='PROGRESS_INTERVAL constant extracted'
+
+[Code reviewer reviews again]
+Code reviewer: ✅ Approved
+
+...
+
+[After all tasks]
+[Dispatch final code-reviewer]
+Final reviewer: All requirements met, ready to merge
+
+Done!
+```
+
+## Advantages
+
+**vs. Manual execution:**
+- Subagents follow TDD naturally
+- Fresh context per task (no confusion)
+- Parallel-safe (subagents each hold their own slot)
+- Subagent can ask questions (before AND during work)
+
+**vs. Executing Plans:**
+- Same session (no handoff)
+- Continuous progress (no waiting)
+- Review checkpoints automatic
+
+**Efficiency gains:**
+- Coordinator queries bones tasks list (no file reading overhead)
+- Controller curates exactly what context is needed via `bones tasks show`
+- Subagent gets complete information upfront
+- Questions surfaced before work begins (not after)
+- Atomic claim via `bones swarm join` prevents double-work
+
+**Quality gates:**
+- Self-review catches issues before handoff
+- Two-stage review: spec compliance, then code quality
+- Review loops ensure fixes actually work
+- Spec compliance prevents over/under-building
+- Code quality ensures implementation is well-built
+
+**Cost:**
+- More subagent invocations (implementer + 2 reviewers per task)
+- Controller does more prep work (querying bones task graph)
+- Review loops add iterations
+- But catches issues early (cheaper than debugging later)
+
+## Red Flags
+
+**Never:**
+- Start implementation on main/master branch without explicit user consent
+- Skip reviews (spec compliance OR code quality)
+- Proceed with unfixed issues
+- Dispatch multiple implementation subagents for the same slot (conflicts)
+- Make subagent read plan file (provide full text via `bones tasks show` instead)
+- Skip scene-setting context (subagent needs to understand where task fits)
+- Ignore subagent questions (answer before letting them proceed)
+- Accept "close enough" on spec compliance (spec reviewer found issues = not done)
+- Skip review loops (reviewer found issues = implementer closes fail + fresh join = review again)
+- Let implementer self-review replace actual review (both are needed)
+- **Start code quality review before spec compliance is ✅** (wrong order)
+- Move to next task while either review has open issues
+- **Mirror bones tasks into TodoWrite at coordinator level** (source of truth is bones tasks, not TodoWrite)
+
+**If subagent asks questions:**
+- Answer clearly and completely
+- Provide additional context if needed
+- Don't rush them into implementation
+
+**If reviewer finds issues:**
+- Implementer closes swarm session as failed (`bones swarm close --result=fail`)
+- Coordinator dispatches fresh implementer with feedback
+- New implementer re-joins via `bones swarm join`
+- Reviewer reviews again
+- Repeat until approved
+- Don't skip the re-review
+
+**If subagent fails task:**
+- Dispatch fix subagent with specific instructions
+- Don't try to fix manually (context pollution)
+
+## Integration
+
+**Required workflow skills:**
+- **bones-powers:using-bones-swarm** - REQUIRED: understand slot sessions before starting
+- **bones-powers:writing-plans** - Creates the plan this skill executes
+- **bones-powers:requesting-code-review** - Code review template for reviewer subagents
+- **bones-powers:finishing-a-bones-leaf** - Complete development after all tasks
+
+**Subagents should use:**
+- **bones-powers:test-driven-development** - Subagents follow TDD for each task
+
+**Alternative workflow:**
+- **bones-powers:executing-plans** - Use for single-session inline execution instead of parallel slot sessions

--- a/plugins/bones-powers/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/plugins/bones-powers/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -1,0 +1,26 @@
+# Code Quality Reviewer Prompt Template
+
+Use this template when dispatching a code quality reviewer subagent.
+
+**Purpose:** Verify implementation is well-built (clean, tested, maintainable)
+
+**Only dispatch after spec compliance review passes.**
+
+```
+Task tool (bones-powers:code-reviewer):
+  Use template at requesting-code-review/code-reviewer.md
+
+  WHAT_WAS_IMPLEMENTED: [from implementer's report]
+  PLAN_OR_REQUIREMENTS: Task N from [plan-file]
+  BASE_SHA: [commit before task]
+  HEAD_SHA: [current commit]
+  DESCRIPTION: [task summary]
+```
+
+**In addition to standard code quality concerns, the reviewer should check:**
+- Does each file have one clear responsibility with a well-defined interface?
+- Are units decomposed so they can be understood and tested independently?
+- Is the implementation following the file structure from the plan?
+- Did this implementation create new files that are already large, or significantly grow existing files? (Don't flag pre-existing file sizes — focus on what this change contributed.)
+
+**Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment

--- a/plugins/bones-powers/skills/subagent-driven-development/implementer-prompt.md
+++ b/plugins/bones-powers/skills/subagent-driven-development/implementer-prompt.md
@@ -1,0 +1,145 @@
+# Implementer Subagent Prompt Template
+
+Use this template when dispatching an implementer subagent.
+
+```
+Task tool (general-purpose):
+  description: "Implement Task N: [task name]"
+  prompt: |
+    You are a bones-powers implementer subagent. Your task and slot have been provided.
+
+    Your first action MUST be:
+    ```bash
+    bones swarm join --slot="$SLOT" --task-id="$TASK_ID"
+    ```
+
+    This opens your leaf, claims your task, and prepares your worktree atomically.
+
+    Your second action MUST be a fresh TodoWrite checklist of the in-task micro-steps. Per spec § 6 (hybrid task model), you maintain TodoWrite for ephemeral in-session steps; the coordinator owns the bones task graph.
+
+    When work is complete:
+    ```bash
+    bones swarm close --result=success --summary='<one-line summary>'
+    ```
+
+    If you must abandon (review failure, blocked, etc.):
+    ```bash
+    bones swarm close --result=fail --summary='<reason>'
+    ```
+
+    Heartbeat during long work:
+    ```bash
+    bones swarm commit -m '<progress note>'
+    ```
+
+    ---
+
+    You are implementing Task N: [task name]
+
+    ## Task Description
+
+    [FULL TEXT of task from plan - paste it here, don't make subagent read file]
+
+    ## Context
+
+    [Scene-setting: where this fits, dependencies, architectural context]
+
+    ## Before You Begin
+
+    If you have questions about:
+    - The requirements or acceptance criteria
+    - The approach or implementation strategy
+    - Dependencies or assumptions
+    - Anything unclear in the task description
+
+    **Ask them now.** Raise any concerns before starting work.
+
+    ## Your Job
+
+    Once you're clear on requirements:
+    1. Run `bones swarm join --slot="$SLOT" --task-id="$TASK_ID"` (first action)
+    2. TodoWrite a checklist of in-task micro-steps (second action)
+    3. Implement exactly what the task specifies
+    4. Write tests (following TDD if task says to)
+    5. Verify implementation works
+    6. Heartbeat via `bones swarm commit -m '<progress note>'` as you go
+    7. Self-review (see below)
+    8. Close: `bones swarm close --result=success --summary='<one-line summary>'`
+    9. Report back
+
+    Work from: the worktree prepared by `bones swarm join`
+
+    **While you work:** If you encounter something unexpected or unclear, **ask questions**.
+    It's always OK to pause and clarify. Don't guess or make assumptions.
+
+    ## Code Organization
+
+    You reason best about code you can hold in context at once, and your edits are more
+    reliable when files are focused. Keep this in mind:
+    - Follow the file structure defined in the plan
+    - Each file should have one clear responsibility with a well-defined interface
+    - If a file you're creating is growing beyond the plan's intent, stop and report
+      it as DONE_WITH_CONCERNS — don't split files on your own without plan guidance
+    - If an existing file you're modifying is already large or tangled, work carefully
+      and note it as a concern in your report
+    - In existing codebases, follow established patterns. Improve code you're touching
+      the way a good developer would, but don't restructure things outside your task.
+
+    ## When You're in Over Your Head
+
+    It is always OK to stop and say "this is too hard for me." Bad work is worse than
+    no work. You will not be penalized for escalating.
+
+    **STOP and escalate when:**
+    - The task requires architectural decisions with multiple valid approaches
+    - You need to understand code beyond what was provided and can't find clarity
+    - You feel uncertain about whether your approach is correct
+    - The task involves restructuring existing code in ways the plan didn't anticipate
+    - You've been reading file after file trying to understand the system without progress
+
+    **How to escalate:** Run `bones swarm close --result=fail --summary='<reason>'` then
+    report back with status BLOCKED or NEEDS_CONTEXT. Describe specifically what you're
+    stuck on, what you've tried, and what kind of help you need. The controller can
+    provide more context, re-dispatch with a more capable model, or break the task into
+    smaller pieces.
+
+    ## Before Reporting Back: Self-Review
+
+    Review your work with fresh eyes. Ask yourself:
+
+    **Completeness:**
+    - Did I fully implement everything in the spec?
+    - Did I miss any requirements?
+    - Are there edge cases I didn't handle?
+
+    **Quality:**
+    - Is this my best work?
+    - Are names clear and accurate (match what things do, not how they work)?
+    - Is the code clean and maintainable?
+
+    **Discipline:**
+    - Did I avoid overbuilding (YAGNI)?
+    - Did I only build what was requested?
+    - Did I follow existing patterns in the codebase?
+
+    **Testing:**
+    - Do tests actually verify behavior (not just mock behavior)?
+    - Did I follow TDD if required?
+    - Are tests comprehensive?
+
+    If you find issues during self-review, fix them now before reporting.
+
+    ## Report Format
+
+    When done, report:
+    - **Status:** DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What you implemented (or what you attempted, if blocked)
+    - What you tested and test results
+    - Files changed
+    - Self-review findings (if any)
+    - Any issues or concerns
+
+    Use DONE_WITH_CONCERNS if you completed the work but have doubts about correctness.
+    Use BLOCKED if you cannot complete the task. Use NEEDS_CONTEXT if you need
+    information that wasn't provided. Never silently produce work you're unsure about.
+```

--- a/plugins/bones-powers/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/plugins/bones-powers/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -1,0 +1,61 @@
+# Spec Compliance Reviewer Prompt Template
+
+Use this template when dispatching a spec compliance reviewer subagent.
+
+**Purpose:** Verify implementer built what was requested (nothing more, nothing less)
+
+```
+Task tool (general-purpose):
+  description: "Review spec compliance for Task N"
+  prompt: |
+    You are reviewing whether an implementation matches its specification.
+
+    ## What Was Requested
+
+    [FULL TEXT of task requirements]
+
+    ## What Implementer Claims They Built
+
+    [From implementer's report]
+
+    ## CRITICAL: Do Not Trust the Report
+
+    The implementer finished suspiciously quickly. Their report may be incomplete,
+    inaccurate, or optimistic. You MUST verify everything independently.
+
+    **DO NOT:**
+    - Take their word for what they implemented
+    - Trust their claims about completeness
+    - Accept their interpretation of requirements
+
+    **DO:**
+    - Read the actual code they wrote
+    - Compare actual implementation to requirements line by line
+    - Check for missing pieces they claimed to implement
+    - Look for extra features they didn't mention
+
+    ## Your Job
+
+    Read the implementation code and verify:
+
+    **Missing requirements:**
+    - Did they implement everything that was requested?
+    - Are there requirements they skipped or missed?
+    - Did they claim something works but didn't actually implement it?
+
+    **Extra/unneeded work:**
+    - Did they build things that weren't requested?
+    - Did they over-engineer or add unnecessary features?
+    - Did they add "nice to haves" that weren't in spec?
+
+    **Misunderstandings:**
+    - Did they interpret requirements differently than intended?
+    - Did they solve the wrong problem?
+    - Did they implement the right feature but wrong way?
+
+    **Verify by reading code, not by trusting report.**
+
+    Report:
+    - ✅ Spec compliant (if everything matches after code inspection)
+    - ❌ Issues found: [list specifically what's missing or extra, with file:line references]
+```

--- a/plugins/bones-powers/skills/using-bones-powers/SKILL.md
+++ b/plugins/bones-powers/skills/using-bones-powers/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: using-bones-powers
+description: Use when starting any conversation in a bones workspace - establishes how to find and use bones-powers skills, requiring Skill tool invocation before ANY response including clarifying questions
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+bones-powers skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, direct requests) — highest priority
+2. **bones-powers skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Bones primitives
+
+bones-powers skills assume you understand these concepts. If any are unfamiliar, run `bones --help` and `bones <subcommand> --help`.
+
+| Term | Meaning |
+|---|---|
+| **workspace** | A directory bootstrapped by `bones up`. Marker: `.bones/repo.fossil`. |
+| **hub** | The Fossil repo at the center of the workspace. Holds trunk and all leaves. |
+| **trunk** | The mainline branch in the hub. Equivalent to git's `main`. |
+| **slot** | A named worker role (e.g. `alpha`, `frontend`, `infra`). Tasks are routed by slot. |
+| **leaf** | A slot's working session — a worktree + claimed task + open hub branch. Created by `bones swarm join`. |
+| **swarm session** | The lifecycle of one slot's leaf, from `swarm join` to `swarm close`. |
+| **fan-in** | `bones swarm fan-in` — merge open hub leaves back into trunk. |
+| **task** | A unit of work in `bones tasks`. Has `id`, `slot`, `parent`, `files`, `status` (pending/claimed/closed), `result` (success/fail/fork). |
+| **task graph** | Per spec § 4.4: one root task per plan, one child task per plan step, all sharing `--files=<plan-path>`. |
+
+| Tool you'd reach for | bones equivalent |
+|---|---|
+| `git worktree add` | `bones swarm join --slot=X --task-id=Y` |
+| `git commit` | `bones repo ci -m '…'` (free-form) or `bones swarm commit -m '…'` (heartbeats the active slot) |
+| `git merge`, "open a PR" | `bones swarm fan-in -m '…'` (preview with `--dry-run` first) |
+| TodoWrite (for plan tracking) | `bones tasks create/list/claim/close` |
+| TodoWrite (for in-session steps) | TodoWrite (still — see hybrid task model in § 6 of the spec) |
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/plugins/bones-powers/skills/using-bones-swarm/SKILL.md
+++ b/plugins/bones-powers/skills/using-bones-swarm/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: using-bones-swarm
+description: Open, work in, and close a bones swarm session — the slot-shaped lane that bundles a worktree, a claimed task, and an open hub branch. Use when starting feature work that needs isolation from current workspace, before executing implementation plans, or when you need a worktree for parallel work in a bones workspace.
+---
+
+# Using bones swarm
+
+`bones swarm` is the slot-scoped session primitive. One swarm session = one leaf = one worktree + one claimed task + one open hub branch. This skill walks you through the 5-step lifecycle.
+
+**Prerequisite**: a bones workspace (`.bones/repo.fossil` exists in cwd or a parent). If missing, run `bones up` first.
+
+## The lifecycle
+
+```
+1. swarm join    →  open a leaf, claim a task, prepare a worktree (atomic)
+2. swarm cwd     →  navigate to the worktree
+3. work          →  edit files; make changes
+4. swarm commit  →  heartbeat the session + commit (repeat as needed)
+5. swarm close   →  release claim, post result, stop the leaf
+```
+
+## Step 1: Join
+
+```bash
+bones swarm join --slot=<slot-name> --task-id=<task-id>
+```
+
+What this does (atomically):
+- Opens a new leaf in the hub for the given slot.
+- Claims the named task in `bones tasks` (fails if already claimed or closed).
+- Prepares a worktree on disk for that leaf.
+- Registers the swarm session so `swarm status` and `swarm cwd` can find it.
+
+**Recovery**: if a previous swarm session is stuck (crashed agent, stale lock):
+```bash
+bones swarm join --slot=<slot> --task-id=<id> --force
+```
+This clobbers the existing slot session. Use only when you're sure nothing else is using that slot.
+
+## Step 2: Navigate
+
+```bash
+cd "$(bones swarm cwd --slot=<slot-name>)"
+```
+
+Or capture the path once:
+```bash
+WORKTREE=$(bones swarm cwd --slot=<slot-name>)
+cd "$WORKTREE"
+```
+
+## Step 3: Work
+
+Edit files. The worktree is a normal filesystem checkout — your editor and tools work as usual.
+
+If you need to verify the workspace is clean:
+```bash
+bones repo status
+```
+
+## Step 4: Commit and heartbeat
+
+Every meaningful save during the session:
+
+```bash
+bones swarm commit -m "<message>" [files...]
+```
+
+This commits and emits a heartbeat. The hub knows the session is alive. Repeat as often as you'd commit normally.
+
+If you only want to commit (not heartbeat — rare), use `bones repo ci -m "…" <files>` directly. Prefer `swarm commit` while inside a session.
+
+## Step 5: Close
+
+When work is done:
+
+```bash
+bones swarm close --result=success --summary="<one-line result>"
+```
+
+This releases the claim, posts the result to the task's thread, and stops the leaf. The leaf remains in the hub (open for fan-in).
+
+If the work is incomplete or failed:
+```bash
+bones swarm close --result=fail --summary="<reason>"
+```
+
+Releases the claim so another worker (or another attempt) can pick the task back up.
+
+## Composition
+
+This skill is a primitive used by other bones-powers skills:
+- `bones-powers:executing-plans` (single-session inline) — invokes the lifecycle once per task.
+- `bones-powers:subagent-driven-development` — invokes the lifecycle per implementer subagent (one per slot, in parallel).
+- `bones-powers:dispatching-parallel-agents` — N concurrent invocations across N slots.
+- `bones-powers:finishing-a-bones-leaf` — what happens AFTER `swarm close`: fan-in, keep, or abandon.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `swarm join` errors "slot busy" | Previous session not cleanly closed | `swarm join --force` (recovery) or `swarm close` the stale session first |
+| `swarm cwd` returns nothing | No active session for that slot | Run `bones swarm status` to see what's open |
+| Heartbeat stops being sent | Agent crashed mid-task | The hub will eventually time the leaf out; recover with `--force` |
+| `swarm close` errors "no active session" | Already closed, or never joined | `bones swarm status` to confirm |

--- a/plugins/bones-powers/skills/writing-plans/SKILL.md
+++ b/plugins/bones-powers/skills/writing-plans/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+
+**Save plans to:** `docs/bones-powers/plans/YYYY-MM-DD-<feature-name>.md`
+- (User preferences for plan location override this default)
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- You reason best about code you can hold in context at once, and your edits are more reliable when files are focused. Prefer smaller, focused files over large ones that do too much.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, don't unilaterally restructure - but if a file you're modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use bones-powers:subagent-driven-development (recommended) or bones-powers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]  `[slot: <slot-name>]`
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+bones repo add tests/path/test.py src/path/file.py && bones repo ci -m "feat: add specific feature" tests/path/test.py src/path/file.py
+```
+````
+
+### Slot annotation
+
+Each task carries a `[slot: <name>]` tag matching the bones swarm slot that should claim it. Slots group tasks by worker type (e.g. `infra`, `frontend`, `data`). One slot per task; tasks without a natural slot use `[slot: any]`.
+
+Slot names become `--slot=<name>` arguments when the plan is materialized into bones tasks at the end of this skill (see "## Plan → bones tasks" below).
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
+- Steps that describe what to do without showing how (code blocks required for code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Self-Review
+
+After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## Plan → bones tasks
+
+After the plan is saved AND user-reviewed, materialize it into the bones task graph (per spec § 4.4 of `docs/superpowers/specs/2026-04-29-bones-powers-design.md`):
+
+```bash
+PLAN=docs/bones-powers/plans/<filename>.md
+bones repo add "$PLAN"
+bones repo ci -m "add <feature> plan" "$PLAN"
+
+# Root task (no slot, no parent)
+ROOT_ID=$(bones tasks create "<feature>" --files="$PLAN" --json | jq -r .id)
+echo "Root task: $ROOT_ID"
+
+# One child per plan task — repeat for each [slot: X] task in the plan
+bones tasks create "<task-1-title>" --parent="$ROOT_ID" --slot="<slot>" --files="$PLAN"
+bones tasks create "<task-2-title>" --parent="$ROOT_ID" --slot="<slot>" --files="$PLAN"
+# ... (one per task in the plan)
+```
+
+Children inherit no fields automatically — be explicit. Reuse `--files="$PLAN"` on every child so `bones tasks show <id>` always surfaces the source-of-truth plan.
+
+## Execution Handoff
+
+After tasks are emitted, offer execution choice:
+
+> "Plan materialized. Root task `<ROOT_ID>` with N children. Two execution modes (per spec § 5):
+>
+> 1. **`subagent-driven-development` (recommended for parallel work)** — dispatches a fresh implementer subagent per child task, each in its own slot/leaf via `bones swarm join`. Two-stage review between tasks.
+>
+> 2. **`executing-plans` (single-session inline)** — coordinator loops through `bones tasks list --parent=<ROOT_ID>`, claiming and closing each task in this session.
+>
+> Which mode?"
+
+If `subagent-driven-development` chosen:
+- **REQUIRED SUB-SKILL:** Use `bones-powers:subagent-driven-development`.
+
+If `executing-plans` chosen:
+- **REQUIRED SUB-SKILL:** Use `bones-powers:executing-plans`.

--- a/plugins/bones-powers/skills/writing-plans/SKILL.md
+++ b/plugins/bones-powers/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when you have a spec or requirements for a multi-step task, before touching code
+description: Use when you have a spec or requirements for a multi-step task in a bones workspace, before touching code — produces a bones task graph plan with slot assignments and leaf-level steps
 ---
 
 # Writing Plans

--- a/plugins/bones-powers/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/plugins/bones-powers/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Plan Document Reviewer Prompt Template
+
+Use this template when dispatching a plan document reviewer subagent.
+
+**Purpose:** Verify the plan is complete, matches the spec, and has proper task decomposition.
+
+**Dispatch after:** The complete plan is written.
+
+```
+Task tool (general-purpose):
+  description: "Review plan document"
+  prompt: |
+    You are a plan document reviewer. Verify this plan is complete and ready for implementation.
+
+    **Plan to review:** [PLAN_FILE_PATH]
+    **Spec for reference:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
+    | Spec Alignment | Plan covers spec requirements, no major scope creep |
+    | Task Decomposition | Tasks have clear boundaries, steps are actionable |
+    | Buildability | Could an engineer follow this plan without getting stuck? |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation.**
+    An implementer building the wrong thing or getting stuck is an issue.
+    Minor wording, stylistic preferences, and "nice to have" suggestions are not.
+
+    Approve unless there are serious gaps — missing requirements from the spec,
+    contradictory steps, placeholder content, or tasks so vague they can't be acted on.
+
+    ## Output Format
+
+    ## Plan Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Task X, Step Y]: [specific issue] - [why it matters for implementation]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations


### PR DESCRIPTION
## Summary

- New plugin `plugins/bones-powers/` — 8 workflow skills forked from superpowers v5.0.7 and refactored to use bones primitives (slots, leaves, hub/trunk, swarm sessions, persistent task graph).
- Hybrid task model: bones tasks for plan-level work, TodoWrite for in-session micro-steps. Bridge rules canonical in spec § 6.
- Gated SessionStart hook auto-injects `using-bones-powers` only inside bones workspaces (marker: `.bones/repo.fossil`).

## Spec

`docs/superpowers/specs/2026-04-29-bones-powers-design.md` (gitignored — exists locally only)

## Plan

`docs/superpowers/plans/2026-04-29-bones-powers.md` (gitignored — exists locally only)

## Test plan

- [x] All 8 SKILL.md frontmatter valid (name + description)
- [x] All 3 JSON files (plugin.json, hooks.json, marketplace registration) parse
- [x] SessionStart hook gate: empty injection outside bones workspace (negative path)
- [x] SessionStart hook gate: full skill injection inside bones workspace (positive path)
- [x] No leftover `superpowers:` cross-references (only upstream provenance prose remains)
- [x] No leftover git mechanics inside skill bodies (other than the intentional mapping table in `using-bones-powers` showing git→bones translations)
- [ ] Manual: load plugin in fresh Claude Code session, confirm 8 skills discoverable, hook fires only in bones workspace
- [ ] Manual: dry-run `bones swarm fan-in` end-to-end against a real plan

## Out of v0 (deferred)

See spec § 12: TDD/debugging/verification/code-review skills, multi-harness adapters, automated tests, push-to-git-remote step in `finishing-a-bones-leaf`, suppress-superpowers escape valve.