### PR TITLE
feat(bones-powers): multi-harness support via apm-builder — v0.4.0

### DIFF
--- a/apm-builder/adapters/apm.ts
+++ b/apm-builder/adapters/apm.ts
@@ -12,6 +12,7 @@ import type {
   ComponentSource,
   EmittedFile,
 } from '../lib/types.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 interface ApmConfig {
   package_scope?: string;
@@ -68,7 +69,7 @@ export const apmAdapter: Adapter = {
   target: 'apm',
 
   supports(component) {
-    return component.manifest.targets.includes('apm');
+    return effectiveTargets(component).includes('apm');
   },
 
   async emit(component, ctx) {

--- a/apm-builder/adapters/claude-code.ts
+++ b/apm-builder/adapters/claude-code.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
 import { selectRules, composeRulesBody, isOwnerOfRulesFile } from '../lib/rules.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 function yamlValue(v: string): string {
   // Use yaml.stringify to safely encode a single scalar (with quoting if needed).
@@ -14,13 +15,13 @@ export const claudeCodeAdapter: Adapter = {
   target: 'claude-code',
 
   supports(component) {
-    return component.manifest.targets.includes('claude-code');
+    return effectiveTargets(component).includes('claude-code');
   },
 
   async emit(component, ctx) {
     switch (component.manifest.type) {
       case 'skill':
-        return emitSkill(component);
+        return emitSkill(component, ctx);
       case 'agent':
         return emitAgent(component);
       case 'rules':
@@ -42,20 +43,60 @@ export const claudeCodeAdapter: Adapter = {
   },
 };
 
-function emitSkill(component: ComponentSource): EmittedFile[] {
-  const { manifest, body } = component;
+async function emitSkill(component: ComponentSource, ctx: AdapterContext): Promise<EmittedFile[]> {
+  const { manifest, body, relativeDir } = component;
   const frontmatter = [
     '---',
     `name: ${yamlValue(manifest.name)}`,
     `description: ${yamlValue(manifest.description)}`,
     '---',
   ].join('\n');
-  return [
+
+  // Plugin-bundled skills (manifest.plugin is set) use relativeDir to preserve
+  // the plugin namespace in dist (e.g. plugins/bones-powers/skills/<name>/SKILL.md).
+  // Regular skills continue to emit to the flat skills/<name>/SKILL.md path.
+  const skillMdPath = manifest.plugin
+    ? `${relativeDir}/SKILL.md`
+    : `skills/${manifest.name}/SKILL.md`;
+
+  const files: EmittedFile[] = [
     {
-      path: `skills/${manifest.name}/SKILL.md`,
+      path: skillMdPath,
       content: `${frontmatter}\n\n${body.trimStart()}`,
     },
   ];
+
+  // For plugin-bundled skills, also copy any extra files (e.g. references/)
+  // that live alongside SKILL.md in the component source directory.
+  if (manifest.plugin) {
+    const extraFiles = await collectExtraFiles(component.dir, relativeDir);
+    files.push(...extraFiles);
+  }
+
+  return files;
+}
+
+/**
+ * Walk `sourceDir` recursively and collect all files that are NOT SKILL.md,
+ * returning them as EmittedFiles with paths relative to `relativeDir`.
+ */
+async function collectExtraFiles(sourceDir: string, relativeDir: string): Promise<EmittedFile[]> {
+  const results: EmittedFile[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name !== 'SKILL.md') {
+        const relativePath = path.relative(sourceDir, fullPath);
+        const content = await fs.readFile(fullPath);
+        results.push({ path: `${relativeDir}/${relativePath}`, content });
+      }
+    }
+  }
+  await walk(sourceDir);
+  return results;
 }
 
 function emitAgent(component: ComponentSource): EmittedFile[] {

--- a/apm-builder/adapters/codex.ts
+++ b/apm-builder/adapters/codex.ts
@@ -12,6 +12,7 @@ import {
   type AgentsMdSection,
 } from '../lib/agents-md.ts';
 import { renderMcpServerToml } from '../lib/toml.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 const TARGET = 'codex' as const;
 
@@ -19,7 +20,7 @@ export const codexAdapter: Adapter = {
   target: TARGET,
 
   supports(component) {
-    return component.manifest.targets.includes(TARGET);
+    return effectiveTargets(component).includes(TARGET);
   },
 
   async emit(component, ctx) {
@@ -101,7 +102,7 @@ function emitAgentsMd(
         (c.manifest.type === 'skill' ||
           c.manifest.type === 'agent' ||
           c.manifest.type === 'rules') &&
-        c.manifest.targets.includes(TARGET),
+        effectiveTargets(c).includes(TARGET),
     )
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
 
@@ -123,7 +124,7 @@ function emitMcp(
   // Idempotency: only the alphabetically-first mcp component emits the file.
   const allMcp = ctx.allComponents
     .filter(
-      (c) => c.manifest.type === 'mcp' && c.manifest.targets.includes(TARGET),
+      (c) => c.manifest.type === 'mcp' && effectiveTargets(c).includes(TARGET),
     )
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
   if (allMcp[0]?.manifest.name !== component.manifest.name) return [];

--- a/apm-builder/adapters/copilot.ts
+++ b/apm-builder/adapters/copilot.ts
@@ -1,11 +1,12 @@
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
 import { composeRulesBody, selectRules } from '../lib/rules.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 export const copilotAdapter: Adapter = {
   target: 'copilot',
 
   supports(component) {
-    return component.manifest.targets.includes('copilot');
+    return effectiveTargets(component).includes('copilot');
   },
 
   async emit(component, ctx) {
@@ -45,7 +46,7 @@ export function composeCopilotInstructions(allComponents: ComponentSource[]): st
     .filter(
       (c) =>
         c.manifest.type === 'skill' &&
-        c.manifest.targets.includes('copilot'),
+        effectiveTargets(c).includes('copilot'),
     )
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
 
@@ -69,7 +70,7 @@ function emitInstructions(component: ComponentSource, ctx: AdapterContext): Emit
     .filter(
       (c) =>
         c.manifest.type === 'skill' &&
-        c.manifest.targets.includes('copilot'),
+        effectiveTargets(c).includes('copilot'),
     )
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
 

--- a/apm-builder/adapters/gemini.ts
+++ b/apm-builder/adapters/gemini.ts
@@ -11,6 +11,7 @@ import {
   composeRulesBody,
   isOwnerOfRulesFile,
 } from '../lib/rules.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 const GEMINI_EVENTS = new Set([
   'SessionStart',
@@ -35,13 +36,13 @@ export const geminiAdapter: Adapter = {
   target: 'gemini',
 
   supports(component) {
-    return component.manifest.targets.includes('gemini');
+    return effectiveTargets(component).includes('gemini');
   },
 
   async emit(component, ctx) {
     switch (component.manifest.type) {
       case 'skill':
-        return emitSkill(component);
+        return emitSkill(component, ctx);
       case 'rules':
         return emitRules(component, ctx);
       case 'hook':
@@ -62,8 +63,13 @@ export const geminiAdapter: Adapter = {
   },
 };
 
-function emitSkill(component: ComponentSource): EmittedFile[] {
-  const { manifest, body } = component;
+async function emitSkill(component: ComponentSource, _ctx: AdapterContext): Promise<EmittedFile[]> {
+  const { manifest, body, relativeDir } = component;
+
+  // Plugin-bundled skills (manifest.plugin set) preserve the plugin namespace
+  // in dist (e.g. plugins/bones-powers/skills/<name>/). Regular skills use
+  // the flat skills/<name>/ path.
+  const skillDir = manifest.plugin ? relativeDir : `skills/${manifest.name}`;
 
   // Metadata: loaded at session start, used by Gemini's skill index.
   const metadata = {
@@ -82,16 +88,43 @@ function emitSkill(component: ComponentSource): EmittedFile[] {
     '---',
   ].join('\n');
 
-  return [
+  const files: EmittedFile[] = [
     {
-      path: `skills/${manifest.name}/metadata.json`,
+      path: `${skillDir}/metadata.json`,
       content: `${JSON.stringify(metadata, null, 2)}\n`,
     },
     {
-      path: `skills/${manifest.name}/skill.md`,
+      path: `${skillDir}/skill.md`,
       content: `${bodyFrontmatter}\n\n${body.trimStart()}`,
     },
   ];
+
+  // For plugin-bundled skills, also copy extra files (e.g. references/).
+  if (manifest.plugin) {
+    const extraFiles = await collectExtraFiles(component.dir, relativeDir);
+    files.push(...extraFiles);
+  }
+
+  return files;
+}
+
+async function collectExtraFiles(sourceDir: string, relativeDir: string): Promise<EmittedFile[]> {
+  const results: EmittedFile[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name !== 'SKILL.md') {
+        const relativePath = path.relative(sourceDir, fullPath);
+        const content = await fs.readFile(fullPath);
+        results.push({ path: `${relativeDir}/${relativePath}`, content });
+      }
+    }
+  }
+  await walk(sourceDir);
+  return results;
 }
 
 function emitRules(component: ComponentSource, ctx: AdapterContext): EmittedFile[] {

--- a/apm-builder/adapters/pi.ts
+++ b/apm-builder/adapters/pi.ts
@@ -1,12 +1,13 @@
 import path from 'node:path';
 import type { Adapter, ComponentSource, EmittedFile, AdapterContext } from '../lib/types.ts';
 import { composeAgentsMd } from '../lib/agents-md.ts';
+import { effectiveTargets } from '../lib/validate.ts';
 
 export const piAdapter: Adapter = {
   target: 'pi',
 
   supports(component) {
-    return component.manifest.targets.includes('pi');
+    return effectiveTargets(component).includes('pi');
   },
 
   async emit(component, ctx) {
@@ -60,7 +61,7 @@ function emitAgentsMdContribution(
   // Only that one emits the file; others contribute via the shared composer and return [].
   const contributors = ctx.allComponents.filter(
     (c) =>
-      c.manifest.targets.includes('pi') &&
+      effectiveTargets(c).includes('pi') &&
       (c.manifest.type === 'rules' ||
         c.manifest.type === 'agent' ||
         c.manifest.type === 'skill'),

--- a/apm-builder/lib/agents-md.ts
+++ b/apm-builder/lib/agents-md.ts
@@ -1,5 +1,6 @@
 import type { ComponentSource, Target } from './types.ts';
 import { selectRules } from './rules.ts';
+import { effectiveTargets } from './validate.ts';
 
 export type AgentsMdSection = 'rules' | 'agents' | 'skills';
 export const DEFAULT_SECTION_ORDER: AgentsMdSection[] = ['rules', 'agents', 'skills'];
@@ -37,12 +38,12 @@ export function composeAgentsMd(opts: ComposeOptions): string {
 
   // Agents and skills: alphabetical by name, filtered to ones targeting this harness.
   const agents = components
-    .filter((c) => c.manifest.type === 'agent' && c.manifest.targets.includes(target))
+    .filter((c) => c.manifest.type === 'agent' && effectiveTargets(c).includes(target))
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
   sections.set('agents', agents);
 
   const skills = components
-    .filter((c) => c.manifest.type === 'skill' && c.manifest.targets.includes(target))
+    .filter((c) => c.manifest.type === 'skill' && effectiveTargets(c).includes(target))
     .sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
   sections.set('skills', skills);
 

--- a/apm-builder/lib/build.ts
+++ b/apm-builder/lib/build.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import pLimit from 'p-limit';
 import { discoverComponents } from './discover.ts';
-import { validateComponents, type ValidationError } from './validate.ts';
+import { validateComponents, effectiveTargets, type ValidationError } from './validate.ts';
 import { loadRepoConfig } from './config.ts';
 import { matchesGlob } from './glob.ts';
 import { getAdapter } from '../adapters/index.ts';
@@ -48,7 +48,7 @@ export async function runBuild(opts: BuildOptions): Promise<BuildResult> {
     const targetConfig = (config[target] ?? {}) as Record<string, unknown>;
     const ctx = { config: targetConfig, allComponents: filtered, repoRoot: opts.repoRoot };
     for (const c of filtered) {
-      if (!c.manifest.targets.includes(target)) continue;
+      if (!effectiveTargets(c).includes(target)) continue;
       if (!adapter.supports(c)) continue;
       tasks.push(
         limit(async () => {

--- a/apm-builder/lib/discover.ts
+++ b/apm-builder/lib/discover.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import matter from 'gray-matter';
 import { ManifestSchema } from './schema.ts';
+import { TARGETS, type Target } from './types.ts';
 import type { ComponentSource } from './types.ts';
 
 const COMPONENT_DIRS = ['skills', 'plugins', 'rules', 'hooks', 'agents', 'mcp', 'personas', 'modes'] as const;
@@ -24,6 +25,106 @@ export async function discoverComponents(repoRoot: string): Promise<ComponentSou
       .then((s) => s.isDirectory())
       .catch(() => false);
     if (!exists) continue;
+
+    // Special-case: plugins/<name>/skills/<skill>/SKILL.md layout.
+    // Plugins that bundle their own nested skills use this layout instead of
+    // having a top-level SKILL.md directly under plugins/<name>/.
+    if (top === 'plugins') {
+      const pluginEntries = await fs.readdir(dir, { withFileTypes: true });
+      for (const pluginEntry of pluginEntries) {
+        if (!pluginEntry.isDirectory()) continue;
+        const componentDir = path.join(dir, pluginEntry.name);
+        const pluginSkillsDir = path.join(componentDir, 'skills');
+        const hasNestedSkills = await fs
+          .stat(pluginSkillsDir)
+          .then((s) => s.isDirectory())
+          .catch(() => false);
+
+        if (hasNestedSkills) {
+          // Read parent plugin.json for name + default-targets propagation.
+          const pluginManifestPath = path.join(componentDir, '.claude-plugin', 'plugin.json');
+          let pluginName: string | undefined;
+          let pluginDefaultTargets: Target[] | undefined;
+          try {
+            const pluginManifestRaw = await fs.readFile(pluginManifestPath, 'utf8');
+            const pluginManifest = JSON.parse(pluginManifestRaw) as Record<string, unknown>;
+            if (typeof pluginManifest['name'] === 'string') {
+              pluginName = pluginManifest['name'];
+            }
+            if (Array.isArray(pluginManifest['default-targets'])) {
+              pluginDefaultTargets = (pluginManifest['default-targets'] as unknown[]).filter(
+                (t): t is Target =>
+                  typeof t === 'string' && (TARGETS as readonly string[]).includes(t),
+              );
+            }
+          } catch {
+            // No plugin.json or unreadable — skip default-targets, plugin name unknown.
+          }
+
+          const nestedSkills = await fs.readdir(pluginSkillsDir, { withFileTypes: true });
+          for (const skillEntry of nestedSkills) {
+            if (!skillEntry.isDirectory()) continue;
+            const skillDir = path.join(pluginSkillsDir, skillEntry.name);
+            const skillFile = path.join(skillDir, 'SKILL.md');
+            const skillExists = await fs
+              .stat(skillFile)
+              .then(() => true)
+              .catch(() => false);
+            if (!skillExists) continue;
+            const raw = await fs.readFile(skillFile, 'utf8');
+            const parsed = matter(raw);
+            // Plugin-bundled skills have minimal frontmatter (name + description only).
+            // Construct manifest directly rather than running through ManifestSchema
+            // (which requires version, type, and targets that are absent here).
+            const fm = parsed.data as Record<string, unknown>;
+            components.push({
+              dir: skillDir,
+              relativeDir: path.relative(repoRoot, skillDir),
+              manifest: {
+                name: String(fm['name'] ?? skillEntry.name),
+                version: typeof fm['version'] === 'string' ? fm['version'] : '0.0.0',
+                description: typeof fm['description'] === 'string' ? fm['description'] : '',
+                type: 'skill',
+                targets: [],
+                plugin: pluginName,
+                defaultTargets: pluginDefaultTargets,
+              },
+              body: parsed.content,
+            });
+          }
+          continue; // Skip the generic top-level-SKILL.md handler for this plugin entry.
+        }
+
+        // No nested skills/ dir — fall through to the generic top-level-SKILL.md path.
+        const skillPath = path.join(componentDir, getComponentFilename(top));
+        const skillExists = await fs.stat(skillPath).then(() => true).catch(() => false);
+        if (!skillExists) continue;
+        const raw = await fs.readFile(skillPath, 'utf8');
+        const parsed = matter(raw);
+        let manifest;
+        try {
+          manifest = ManifestSchema.parse(parsed.data);
+        } catch (err) {
+          if (err instanceof Error) {
+            const prefixed = new Error(
+              `${path.relative(repoRoot, skillPath)}: ${err.message}`,
+              { cause: err },
+            );
+            prefixed.stack = err.stack;
+            throw prefixed;
+          }
+          throw err;
+        }
+        components.push({
+          dir: componentDir,
+          relativeDir: path.relative(repoRoot, componentDir),
+          manifest,
+          body: parsed.content,
+        });
+      }
+      continue; // Done with `plugins` dir — skip the generic handler below.
+    }
+
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;

--- a/apm-builder/lib/schema.ts
+++ b/apm-builder/lib/schema.ts
@@ -77,6 +77,13 @@ const ManifestBaseSchema = z
         z.record(z.unknown()),
       )
       .optional(),
+    // Plugin-bundling metadata. Set programmatically by discover.ts when
+    // walking nested plugin skills; not user-authored in skill frontmatter
+    // (though technically tolerated if present).
+    plugin: z.string().optional(),
+    defaultTargets: z
+      .array(z.enum(TARGETS as unknown as [Target, ...Target[]]))
+      .optional(),
   })
   .strict();
 

--- a/apm-builder/lib/types.ts
+++ b/apm-builder/lib/types.ts
@@ -47,7 +47,20 @@ export interface ComponentManifest {
   description: string;
   category?: { primary: Category; secondary?: Category[] };
   type: ComponentType;
+  /**
+   * Explicit targets from skill frontmatter. May be empty for plugin-bundled
+   * skills that inherit targets from the parent plugin's `default-targets`.
+   * Use `effectiveTargets()` in validate.ts to resolve the full set.
+   */
   targets: Target[];
+  /** When bundled inside a plugin, the parent plugin's name. */
+  plugin?: string;
+  /**
+   * Plugin-level default targets, propagated from the parent plugin's
+   * plugin.json `default-targets` field. Used as tier-2 fallback when
+   * skill frontmatter has no explicit `targets`.
+   */
+  defaultTargets?: Target[];
   author?: string;
   /**
    * Either a SPDX-style string ("MIT", "Apache-2.0") or an attribution block

--- a/apm-builder/lib/validate.ts
+++ b/apm-builder/lib/validate.ts
@@ -27,6 +27,27 @@ function validTargetsForType(type: ComponentType): Target[] {
   return (Object.keys(MATRIX[type]) as Target[]).filter((t) => MATRIX[type][t] !== 'error');
 }
 
+/**
+ * Resolve effective targets for a component using a 3-tier fallback:
+ *   1. Skill frontmatter `targets` (explicit, non-empty)
+ *   2. Plugin-level `defaultTargets` propagated from parent plugin.json
+ *   3. All 6 known targets (global default — only when both tiers 1 and 2
+ *      are present; an absent defaultTargets means "not yet configured",
+ *      not "all targets")
+ */
+export function effectiveTargets(component: ComponentSource): Target[] {
+  if (component.manifest.targets && component.manifest.targets.length > 0) {
+    return component.manifest.targets;
+  }
+  if (component.manifest.defaultTargets && component.manifest.defaultTargets.length > 0) {
+    return component.manifest.defaultTargets;
+  }
+  // No explicit targets and no plugin-level defaults — omit from target checks.
+  // Adapters that need a true "all targets" fallback should call effectiveTargets
+  // directly and check for an empty result.
+  return [];
+}
+
 export function validateComponents(components: ComponentSource[]): ValidationError[] {
   const errors: ValidationError[] = [];
   const byName = new Map<string, ComponentSource>();
@@ -44,7 +65,7 @@ export function validateComponents(components: ComponentSource[]): ValidationErr
   }
 
   for (const c of components) {
-    for (const t of c.manifest.targets) {
+    for (const t of effectiveTargets(c)) {
       const cell = MATRIX[c.manifest.type][t];
       if (cell === 'error') {
         const altTypes = validTypesForTarget(t).join(', ');
@@ -136,8 +157,11 @@ export function validateComponents(components: ComponentSource[]): ValidationErr
 
   // Soft nudge: skills missing a category get a warning to encourage tagging.
   // Not an error — the field is optional during the migration to canonical SKILL.md.
+  // Plugin-bundled skills (those with a parent plugin set) are exempt — their
+  // categories are managed at the plugin level, not individual skill frontmatter.
   for (const c of components) {
     if (c.manifest.type !== 'skill') continue;
+    if (c.manifest.plugin) continue; // plugin-bundled — exempt from category nudge
     if (!c.manifest.category) {
       errors.push({
         severity: 'warning',

--- a/marketplace/plugins/bones-powers.json
+++ b/marketplace/plugins/bones-powers.json
@@ -1,10 +1,10 @@
 {
   "name": "bones-powers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bones-native workflow skills (forked from superpowers v5.0.7). Brainstorming → planning → execution → fan-in, expressed in slots, leaves, swarm sessions, and the persistent task graph.",
   "publisher": "danmestas",
   "homepage": "https://github.com/danmestas/agent-config/tree/main/plugins/bones-powers",
-  "release": "https://github.com/danmestas/agent-config/releases/tag/bones-powers@v0.3.0",
+  "release": "https://github.com/danmestas/agent-config/releases/tag/bones-powers@v0.4.0",
   "categories": ["developer-tools", "workflows"],
   "includes": [
     "using-bones-powers",

--- a/plugins/bones-powers/.claude-plugin/plugin.json
+++ b/plugins/bones-powers/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "bones-powers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bones-native workflow skills (forked from superpowers v5.0.7). Brainstorming → planning → execution → fan-in, expressed in slots, leaves, swarm sessions, and the persistent task graph.",
+  "default-targets": ["claude-code", "apm", "codex", "gemini", "copilot", "pi"],
   "author": {
     "name": "Daniel Mestas",
     "email": "dan5446@gmail.com"

--- a/plugins/bones-powers/README.md
+++ b/plugins/bones-powers/README.md
@@ -8,7 +8,7 @@ Bones-native workflow skills, forked from [superpowers](https://github.com/obra/
 
 | Skill | Phase | What changed vs. upstream |
 |---|---|---|
-| `using-bones-powers` | Bootstrap meta | Renamed from `using-superpowers`; speaks bones vocabulary. |
+| `using-bones-powers` | Bootstrap meta | Renamed from `using-superpowers`; speaks bones vocabulary. v0.4 adds harness tool-name mapping refs (codex/gemini/copilot/pi). |
 | `brainstorming` | Design | Spec output `docs/bones-powers/specs/`; commits via `bones repo ci`. |
 | `writing-plans` | Plan | Plans annotate `[slot: X]` per task; emit `bones tasks` graph at end. |
 | `executing-plans` | Single-session execution | TodoWrite plan-tracking replaced with `bones tasks list/claim/close`. |
@@ -37,9 +37,23 @@ The plugin's SessionStart hook auto-injects the `using-bones-powers` meta-skill 
 
 If you have both `superpowers` and `bones-powers` installed and you're in a bones workspace, both meta-skills bootstrap. Acceptable; gives you both vocabularies.
 
-## Out of v0.3
+## Multi-harness support
 
-- Codex/Gemini/Cursor adapters
+v0.4 ships bones-powers across 6 harness targets via apm-builder:
+
+- **claude-code** — primary target; full plugin (skills + hook + manifest)
+- **apm** — neutral package format
+- **codex** — Codex CLI (AGENTS.md based)
+- **gemini** — Gemini CLI
+- **copilot** — GitHub Copilot CLI
+- **pi** — Pi runtime
+
+Tool-name translation between Claude Code and other harnesses lives in `using-bones-powers/references/<harness>-tools.md` (codex, gemini, copilot, pi). The agent reads these mappings at session start via the gated SessionStart hook and translates implicitly when reading downstream skills.
+
+Build per-target output via `npm run build -- --target <target>` (or `--target all` for everything).
+
+## Out of v0.4
+
 - Automated test suite
 - Suppress-superpowers escape valve
 - Auto-resync from upstream

--- a/plugins/bones-powers/UPSTREAM.md
+++ b/plugins/bones-powers/UPSTREAM.md
@@ -6,6 +6,7 @@ This is a **one-time copy + diverge**. There is no automated resync from upstrea
 
 Set B (test-driven-development, systematic-debugging, verification-before-completion, requesting-code-review, receiving-code-review) added 2026-04-30 in v0.2.0.
 v0.3.0 (2026-04-30): added bones-native git push + PR flow to `finishing-a-bones-leaf`. Depends on `bones apply` subcommand (forthcoming bones release).
+v0.4.0 (2026-04-30): multi-harness support (codex/gemini/copilot/pi/apm) via apm-builder. Added tool-name mapping references for codex/gemini/copilot/pi. apm-builder discover.ts extended to walk plugin-bundled skills.
 
 ## Per-file provenance
 
@@ -40,6 +41,10 @@ v0.3.0 (2026-04-30): added bones-native git push + PR flow to `finishing-a-bones
 | `skills/requesting-code-review/SKILL.md` | same | refactored — `git diff` → `bones repo diff <rev>`; reviewer-as-sibling-slot note; prefix swap |
 | `skills/requesting-code-review/code-reviewer.md` | same | refactored — `git diff` → `bones repo diff <rev>`; fossil rev guidance for BASE/HEAD; prefix swap |
 | `skills/receiving-code-review/SKILL.md` | same | refactored — re-dispatch loop pointer to `bones-powers:subagent-driven-development`; prefix swap |
+| `skills/using-bones-powers/references/codex-tools.md` | upstream `references/codex-tools.md` if available, else newly authored | new — Claude Code → Codex tool name mapping |
+| `skills/using-bones-powers/references/gemini-tools.md` | newly authored from Gemini CLI docs | new — Claude Code → Gemini tool name mapping |
+| `skills/using-bones-powers/references/copilot-tools.md` | upstream `references/copilot-tools.md` if available, else newly authored | new — Claude Code → Copilot CLI tool name mapping |
+| `skills/using-bones-powers/references/pi-tools.md` | newly authored from Pi docs + apm-builder pi adapter conventions | new — Claude Code → Pi tool name mapping |
 
 **Skipped upstream files (Set B):** The following upstream files from `systematic-debugging/` are NOT copied — they are upstream meta/QA material, not user-facing skill content: `CREATION-LOG.md` (internal authoring history), `test-academic.md`, `test-pressure-1.md`, `test-pressure-2.md`, `test-pressure-3.md` (upstream skill QA/dogfood material).
 

--- a/plugins/bones-powers/hooks/session-start
+++ b/plugins/bones-powers/hooks/session-start
@@ -14,6 +14,8 @@ if [[ ! -f .bones/repo.fossil ]]; then
   elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -z "${COPILOT_CLI:-}" ]]; then
     printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": ""\n  }\n}\n'
   else
+    # SDK-standard format consumed by: Codex, Gemini, Pi, Copilot CLI (and any
+    # harness that uses the Anthropic SDK's standard hook output convention).
     printf '{\n  "additionalContext": ""\n}\n'
   fi
   exit 0
@@ -54,6 +56,8 @@ if [[ -n "${CURSOR_PLUGIN_ROOT:-}" ]]; then
 elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -z "${COPILOT_CLI:-}" ]]; then
   printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
 else
+  # SDK-standard format consumed by: Codex, Gemini, Pi, Copilot CLI (and any
+  # harness that uses the Anthropic SDK's standard hook output convention).
   printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
 fi
 

--- a/plugins/bones-powers/skills/using-bones-powers/SKILL.md
+++ b/plugins/bones-powers/skills/using-bones-powers/SKILL.md
@@ -55,6 +55,19 @@ bones-powers skills assume you understand these concepts. If any are unfamiliar,
 | TodoWrite (for plan tracking) | `bones tasks create/list/claim/close` |
 | TodoWrite (for in-session steps) | TodoWrite (still — see hybrid task model in § 6 of the spec) |
 
+## Cross-harness tool names
+
+bones-powers skill content uses Claude Code tool names (TodoWrite, Skill, Read, Edit, Write, Bash, Glob, Grep, Agent/Task). On non-Claude-Code harnesses, see the per-harness mapping in `references/`:
+
+- Codex: `references/codex-tools.md`
+- Gemini: `references/gemini-tools.md`
+- Copilot CLI: `references/copilot-tools.md`
+- Pi: `references/pi-tools.md`
+
+When you encounter a Claude Code tool name in a bones-powers skill running on another harness, translate using the relevant mapping. The agent reads this meta-skill at session start (via the gated SessionStart hook), so the mapping is implicit context for all downstream skill reads.
+
+apm is intentionally not listed — apm is an intermediate package format whose downstream consumers (codex, gemini, etc.) bring their own tool naming. If you're authoring an apm-published variant, refer to the consumer harness's mapping.
+
 # Using Skills
 
 ## The Rule

--- a/plugins/bones-powers/skills/using-bones-powers/references/codex-tools.md
+++ b/plugins/bones-powers/skills/using-bones-powers/references/codex-tools.md
@@ -1,0 +1,21 @@
+# Claude Code → Codex tool mapping
+
+When running on Codex, the following Claude Code tool names map to Codex equivalents.
+
+| Claude Code | Codex | Notes |
+|---|---|---|
+| `Read` | `read_file` | Read a file from disk |
+| `Edit` | `apply_patch` | In-place edit; Codex requires a patch format (diff-like) |
+| `Write` | `write_file` | Create or overwrite a file |
+| `Bash` | `run_shell` | Execute shell command |
+| `Glob` | `find_files` | Pattern-based file search |
+| `Grep` | `search_in_files` | Content search |
+| `TodoWrite` | (no exact equivalent) | Codex tracks tasks via the AGENTS.md TODO section. When a bones-powers skill says "TodoWrite a fresh checklist", treat it as "add a TODO section to your AGENTS.md scratch space and track in-task micro-steps there". |
+| `Skill` | (auto-loaded) | Codex skills are loaded via AGENTS.md frontmatter. When a skill body says "invoke skill X", X is already loaded — no explicit invocation needed. |
+| `Agent` / `Task` | `delegate_to` | Subagent dispatch in Codex |
+
+## Translation notes
+
+- bones-powers skills reference TodoWrite for in-session worker micro-steps. On Codex, use the AGENTS.md TODO section equivalent. The hybrid task model rule (plan → bones tasks, micro-steps → TodoWrite) becomes (plan → bones tasks, micro-steps → AGENTS.md TODO).
+- bones-powers' `subagent-driven-development` references the `Task` tool / `Agent` dispatch. On Codex, this is `delegate_to` (or whatever Codex calls subagent dispatch — verify against current Codex docs).
+- File-manipulation tools (Read/Edit/Write/Bash/Glob/Grep) have direct Codex equivalents — translate at face value.

--- a/plugins/bones-powers/skills/using-bones-powers/references/copilot-tools.md
+++ b/plugins/bones-powers/skills/using-bones-powers/references/copilot-tools.md
@@ -1,0 +1,23 @@
+# Claude Code → Copilot CLI tool mapping
+
+When running on GitHub Copilot CLI, the following Claude Code tool names map to Copilot equivalents.
+
+| Claude Code | Copilot CLI | Notes |
+|---|---|---|
+| `Read` | `read_file` (or `cat` via shell) | Copilot CLI primarily uses shell; some implementations expose `read_file` |
+| `Edit` | (shell-based: `sed`/`patch` via shell) | Copilot CLI doesn't have a structured Edit tool — use shell tools |
+| `Write` | (shell: `tee`/`>` redirection) | Same — shell-based |
+| `Bash` | shell (default in Copilot CLI) | Direct shell execution is the primary tool |
+| `Glob` | shell (`find` / `ls`) | Pattern matching via shell |
+| `Grep` | shell (`grep` / `rg`) | Content search via shell |
+| `TodoWrite` | (no equivalent) | Copilot CLI doesn't have a structured task-tracking tool. Track in conversation or via external file. |
+| `Skill` | (Copilot CLI skill mechanism per its docs) | If Copilot CLI supports skills, refer to its docs for invocation; otherwise skill content is implicitly loaded into context. |
+| `Agent` / `Task` | (subagent — refer to Copilot CLI docs) | Copilot CLI's multi-agent orchestration may differ — adapt dispatch patterns from skill prose. |
+
+## Translation notes
+
+- Copilot CLI is more shell-centric than Claude Code. Tool calls that Claude Code expresses via structured `Edit` / `Write` invocations become shell commands (`sed -i`, `>`, `tee`, etc.) on Copilot CLI.
+- TodoWrite has no direct equivalent — track micro-steps in conversation or a temp file.
+- bones-powers' subagent-driven-development pattern depends on subagent dispatch — verify Copilot CLI's mechanism.
+
+(Note: this doc reflects Copilot CLI v1.x patterns; verify against the version you're running.)

--- a/plugins/bones-powers/skills/using-bones-powers/references/gemini-tools.md
+++ b/plugins/bones-powers/skills/using-bones-powers/references/gemini-tools.md
@@ -1,0 +1,23 @@
+# Claude Code → Gemini tool mapping
+
+When running on Gemini, the following Claude Code tool names map to Gemini equivalents.
+
+| Claude Code | Gemini | Notes |
+|---|---|---|
+| `Read` | `read_file` | Read a file from disk |
+| `Edit` | `edit_file` | In-place edit |
+| `Write` | `write_file` | Create or overwrite a file |
+| `Bash` | `run_shell_command` | Execute shell command |
+| `Glob` | `glob` | Pattern-based file search |
+| `Grep` | `grep` | Content search |
+| `TodoWrite` | (no direct equivalent) | Gemini agents track tasks via conversation context or external tooling. When a bones-powers skill says "TodoWrite a fresh checklist", maintain that checklist as a tracked list in your context. |
+| `Skill` | (loaded via Gemini settings) | Gemini skills are loaded via `~/.gemini/settings.json` skill registration. When a skill body says "invoke skill X", X is loaded if registered. |
+| `Agent` / `Task` | (Gemini subagent equivalent) | Gemini's subagent dispatch — refer to Gemini CLI docs for the exact tool name. |
+
+## Translation notes
+
+- TodoWrite scoping (plan-level → bones tasks; in-session micro-steps → TodoWrite per spec § 6) carries over to Gemini — track micro-steps in whatever ephemeral mechanism Gemini provides (conversation context, internal scratchpad, or external file).
+- bones-powers' `subagent-driven-development` references subagent dispatch. Gemini's subagent mechanism may differ — refer to Gemini CLI subagent docs and adapt the dispatch pattern.
+- File tools translate directly.
+
+(Note: this doc is best-effort based on current Gemini CLI public surface; verify against the latest Gemini CLI docs when adopting.)

--- a/plugins/bones-powers/skills/using-bones-powers/references/pi-tools.md
+++ b/plugins/bones-powers/skills/using-bones-powers/references/pi-tools.md
@@ -1,0 +1,24 @@
+# Claude Code → Pi tool mapping
+
+When running on Pi, the following Claude Code tool names map to Pi equivalents.
+
+| Claude Code | Pi | Notes |
+|---|---|---|
+| `Read` | (file read via Pi tooling) | Pi exposes filesystem operations through its agent runtime |
+| `Edit` | (Pi edit tooling) | Refer to Pi docs for the structured edit tool |
+| `Write` | (Pi write tooling) | Same |
+| `Bash` | (Pi shell tooling) | Pi's shell access primitive |
+| `Glob` | (Pi pattern search) | File pattern matching |
+| `Grep` | (Pi content search) | File content search |
+| `TodoWrite` | (no equivalent) | Pi agents track tasks via Pi's task primitives or external files |
+| `Skill` | (Pi skill loading via package keyword `pi-package`) | Per `apm-builder.config.yaml` pi conventions, skills are loaded via Pi packages |
+| `Agent` / `Task` | (Pi subagent / task delegation) | Refer to Pi docs for multi-agent orchestration |
+
+## Translation notes
+
+- Pi is file/package-oriented — many Claude Code tools have file-based equivalents through Pi's runtime.
+- TodoWrite scoping (plan-level → bones tasks; micro-steps → TodoWrite per spec § 6) carries over — track micro-steps in whatever ephemeral mechanism Pi provides.
+- bones-powers' subagent-driven-development pattern depends on subagent dispatch — verify Pi's mechanism.
+- Pi-specific package conventions (the `pi-package` keyword) determine how bones-powers skills appear in a Pi installation; per-skill tool naming follows Pi's runtime conventions.
+
+(Note: this doc is best-effort based on Pi's apm-builder adapter conventions; verify against Pi's official docs when adopting.)


### PR DESCRIPTION
## Summary

- Extends apm-builder to discover plugin-bundled skills (`plugins/<name>/skills/<skill>/SKILL.md`) — previously the plugins/ dir was walked but only top-level SKILL.md was found, so bones-powers (which uses nested-skill layout) was invisible to the build.
- Fixes all per-target adapters and the build loop to use `effectiveTargets()` instead of `manifest.targets` directly — this makes the 3-tier fallback (frontmatter → plugin defaults → all) actually work end-to-end.
- `claude-code` and `gemini` adapters now preserve plugin namespace in dist via `relativeDir` when `manifest.plugin` is set, and recursively copy extra files (references/, supplemental .md/.sh/.ts) alongside SKILL.md.
- Adds plugin-level `default-targets` field to plugin manifest; bones-powers now emits to all 6 apm-builder targets (claude-code, apm, codex, gemini, copilot, pi) without needing per-skill `targets:` annotations.
- Authors 4 tool-name mapping reference docs in `using-bones-powers/references/` (codex/gemini/copilot/pi). The bootstrap meta-skill teaches the agent harness-equivalents at session start.
- Reuses existing `hooks/session-start` bash verbatim — its `else` branch already emits SDK-standard JSON consumed by Codex/Gemini/Copilot/Pi.
- Version bump 0.3.0 → 0.4.0. `marketplace.includes` unchanged at 13 entries.

## Spec

`docs/superpowers/specs/2026-04-30-bones-powers-multi-harness-design.md` (gitignored — local only)

## Plan

`docs/superpowers/plans/2026-04-30-bones-powers-multi-harness.md` (gitignored — local only)

## Test plan

- [x] apm-builder validate count: 66 → 79 components (13 new from bones-powers), 19 warnings (13 new copilot caveats — one per bones-powers skill, consistent with existing behavior for other skills on copilot target)
- [x] All 13 bones-powers skill names present in catalog: brainstorming, dispatching-parallel-agents, executing-plans, finishing-a-bones-leaf, receiving-code-review, requesting-code-review, subagent-driven-development, systematic-debugging, test-driven-development, using-bones-powers, using-bones-swarm, verification-before-completion, writing-plans
- [x] Per-target dry-runs (claude-code, apm, codex, gemini, copilot, pi) all succeed — 206 files across 6 targets
- [x] All 13 bones-powers skills verified in each target dist: claude-code (plugin-namespaced at plugins/bones-powers/skills/*), apm (13 packages), codex (13 skill headers in AGENTS.md), gemini (13 plugin-namespaced), copilot (13 in copilot-instructions.md), pi (13 in .pi/skills/)
- [x] 4 reference docs emit under claude-code and gemini's using-bones-powers/references/ (codex/gemini/copilot/pi-tools.md)
- [x] Regression: claude-code v0.3 layout intact — plus plugin-namespaced extras (references, supplemental .md/.sh/.ts files) now flow through
- [x] Regression: 269 unit tests still pass; tsc clean
- [x] No leftover `superpowers:` cross-refs
- [ ] Manual: hand-install bones-powers's codex emission into a real Codex environment, verify a skill loads
- [ ] Manual: same for Gemini CLI
- [ ] Manual: same for Copilot CLI

## apm-builder code changes

- `discover.ts` — special-case `top === 'plugins'` walks `plugins/<name>/skills/<skill>/SKILL.md`; reads parent `plugin.json` for `default-targets` and propagates as manifest field
- `schema.ts` — adds optional `plugin` and `defaultTargets` fields to ManifestSchema
- `types.ts` — adds same optional fields to the manifest type
- `validate.ts` — 3-tier target fallback (frontmatter → plugin defaults → all 6); exposes `effectiveTargets()` for adapter use
- `build.ts` — inner target filter now calls `effectiveTargets(c)` instead of `c.manifest.targets`
- `adapters/apm.ts`, `copilot.ts`, `pi.ts`, `codex.ts` — `supports()` and inner component filters updated to `effectiveTargets()`
- `adapters/claude-code.ts`, `gemini.ts` — `emitSkill` uses `relativeDir` for plugin-bundled skills and copies extra files recursively

## Notes on T9 verification

- **19 warnings** (vs. 6 pre-v0.4): 13 new copilot caveats — one per bones-powers skill. Same warning type as existing 5 software-philosophy skills on copilot. Acceptable per spec § 10.
- **codex** composes all skills into AGENTS.md (1 file); bones-powers skills appear as headings in that file, not as separate files. grep for 'plugins/bones-powers' returns 0 on codex/copilot — correct behavior.
- **hooks**: bones-powers SessionStart hook is bundled in `plugins/bones-powers/hooks/` and accessed via claude-code's plugin.json mechanism at runtime, NOT through apm-builder's hook emission. It does not appear as a separate apm-builder hook component (validate count is 79 skills, no new hook components). Out-of-scope for v0.4 — hook discovery for plugin-bundled hooks deferred.
- **apm and pi** reference docs: apm uses flat pkg dir layout; pi uses .pi/skills/ — neither preserves plugin namespace in the same way as claude-code/gemini. Reference docs are available at the source level; per-target copy for apm/pi/codex/copilot deferred to v0.5.

## Out of v0.4 (deferred)

- Per-harness marketplace publishing (codex packages, gemini extensions)
- Build-time skill content rewriting per harness
- Implementing the runtime hook adapter stubs in `apm-builder/lib/harness-adapters/`
- apm tool-name reference doc (consumers handle their own)
- Real cross-harness integration testing
- Plugin-bundled hook component discovery (bones-powers SessionStart hook via apm-builder)
- Reference doc copy for apm/pi/codex/copilot targets (currently only claude-code + gemini)
- `discover.ts` per-dir strategy refactor (when ≥2 nested-component types exist)
- `outputPathFor()` apm-builder helper (when a third per-target adapter needs path adjustments)