### PR TITLE
feat(flight-deck): workflow lifecycle plugin (takeoff, landing, course-correct) — v0.1.0

### DIFF
--- a/marketplace/plugins/flight-deck.json
+++ b/marketplace/plugins/flight-deck.json
@@ -1,0 +1,10 @@
+{
+  "name": "flight-deck",
+  "version": "0.1.0",
+  "description": "Development session lifecycle skills: takeoff (begin), landing (post-merge cleanup), course-correct (rewind a bad chunk of work). Workflow taxonomy plugin — skills compose with finishing-a-bones-leaf, finishing-a-development-branch, and other workflow primitives.",
+  "publisher": "danmestas",
+  "homepage": "https://github.com/danmestas/agent-config/tree/main/plugins/flight-deck",
+  "release": "https://github.com/danmestas/agent-config/releases/tag/flight-deck@v0.1.0",
+  "categories": ["developer-tools", "workflows"],
+  "includes": ["takeoff", "landing", "course-correct"]
+}

--- a/plugins/flight-deck/.claude-plugin/plugin.json
+++ b/plugins/flight-deck/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "flight-deck",
+  "version": "0.1.0",
+  "description": "Development session lifecycle skills: takeoff (begin), landing (post-merge cleanup), course-correct (rewind a bad chunk of work). Workflow taxonomy plugin — skills compose with finishing-a-bones-leaf, finishing-a-development-branch, and other workflow primitives.",
+  "default-targets": ["claude-code", "apm", "codex", "gemini", "copilot", "pi"],
+  "author": {
+    "name": "Daniel Mestas",
+    "email": "dan5446@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": ["workflow", "lifecycle", "session", "cleanup", "post-merge", "worktree", "branches", "git", "rewind"]
+}

--- a/plugins/flight-deck/skills/course-correct/SKILL.md
+++ b/plugins/flight-deck/skills/course-correct/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: course-correct
+description: Rewind a bad chunk of work by capturing what was tried + learned to a summary file, then telling the user how to rewind their session context per harness. Use when an approach has failed, work has gone down the wrong path, the agent went in circles, the user wants to undo recent decisions, or the user says "course correct", "rewind", "we went down the wrong path", "this isn't working start over", or "roll back what we just did". Captures session learnings without destroying git history or the working tree.
+---
+
+# Course correct
+
+Bad path. Capture what was tried + learned, write the summary to disk, then tell the user how to rewind their session context. Does not modify git history or the working tree — files stay; the user manages git state separately if they want to discard them.
+
+## When to use
+
+- An approach has failed and circling back to a prior approach is the right call
+- The agent's been going in circles on a problem and a clean restart would help
+- The user wants to undo recent decisions but keep the learnings
+- User says "course correct", "rewind", "we went down the wrong path", "start over from <point>", "this isn't working"
+
+## Workflow
+
+### 1. Reflect on the session
+
+The agent reviews the recent session and answers internally:
+- What was the goal at the rewind point?
+- What approach(es) were tried?
+- What didn't work and why?
+- What concrete learnings should survive the rewind (so future-you doesn't re-tread the same dead-end)?
+
+### 2. Inventory recent changes
+
+```bash
+echo '---recent commits on this branch---'
+git log --oneline -20 "$(git merge-base HEAD main 2>/dev/null || echo HEAD~10)..HEAD" 2>/dev/null \
+  || git log --oneline -10
+echo '---uncommitted changes---'
+git status --porcelain | head -20
+echo '---files modified this session (uncommitted)---'
+git diff --name-only HEAD 2>/dev/null | head -20
+```
+
+### 3. Draft the summary
+
+Compose a draft summary covering:
+- **Goal**: what we were trying to do
+- **What was tried**: specific approaches, in order
+- **Why it didn't work**: root causes if known, symptoms if not
+- **Learnings**: things to remember next time
+- **Suggested rewind point**: which conversation point or commit to fall back to
+
+Show the draft to the user. Get explicit confirmation OR `$EDITOR` for editing.
+
+If `$EDITOR` is unset, fall back to `vi`. Use a temp file:
+
+```bash
+TMPFILE=$(mktemp -t course-correct.XXXXXX.md)
+cat > "$TMPFILE" <<EOF
+# Course correction: <topic>
+
+## Goal
+...
+
+## What was tried
+...
+
+## Why it didn't work
+...
+
+## Learnings
+...
+
+## Rewind point
+...
+EOF
+${EDITOR:-vi} "$TMPFILE"
+```
+
+### 4. Save the summary
+
+Write the final summary to `docs/course-corrections/YYYY-MM-DD-HH-MM-<topic>.md`. Topic is derived from the summary's title (slugified) or asked-for if absent.
+
+```bash
+mkdir -p docs/course-corrections
+TOPIC=<slugified-from-title>
+DEST="docs/course-corrections/$(date +%Y-%m-%d-%H-%M)-$TOPIC.md"
+cp "$TMPFILE" "$DEST"
+echo "Saved: $DEST"
+```
+
+Optionally `git add` the summary if the user wants it tracked. Don't commit automatically — let the user decide if course-correction artifacts belong in git history for this repo.
+
+### 5. Tell the user how to rewind
+
+Per harness:
+
+- **Claude Code**: "Press Esc twice to rewind to a prior conversation point. Reference the summary at `<path>` to re-orient."
+- **Codex / Gemini / Copilot CLI / Pi**: "These harnesses don't have a native rewind. Reference the summary at `<path>` going forward; treat the work above as discarded mentally. If you want a hard reset, exit the session and start a new one."
+
+The skill prints the appropriate guidance based on detected harness (env vars: `CLAUDE_PROJECT_DIR`, `CODEX_HOME`, `GEMINI_CLI`, etc.). When in doubt, print the Claude Code instruction with a fallback note.
+
+### 6. No git operations
+
+`course-correct` does NOT run `git reset`, `git checkout`, `git stash`, or any other git mutation. The course correction is a documentation artifact, not a destructive operation.
+
+If the user wants to discard uncommitted changes after the summary is saved:
+
+```bash
+git stash push -m "course-correct-$(date +%Y%m%d-%H%M)"  # safer
+# OR
+git checkout .  # destructive, prompt user
+```
+
+These are user-driven follow-up actions, not part of the skill's flow.
+
+## Composition with other skills
+
+- After invoking `course-correct`, the user typically restarts work with `flight-deck:takeoff` (fresh inventory) OR `superpowers:brainstorming` (if rethinking the design from scratch).
+- If the dead-end happened during plan execution, `flight-deck:course-correct` saves the learnings; the user then revises the plan via `superpowers:writing-plans` and re-invokes execution.
+
+## Safety rules
+
+- **Never** modify git history (`git reset`, `git rebase`, `git checkout`).
+- **Never** delete files from the working tree.
+- **Never** invoke the harness's rewind mechanism for the user — that's their action.
+- The summary is the artifact. Everything else is the user's call.
+
+## Tone
+
+Reflective, not panicky. The user is course-correcting deliberately; the skill should match that thoughtful tone. Concise but thorough on the "what was tried + learned" capture.

--- a/plugins/flight-deck/skills/landing/SKILL.md
+++ b/plugins/flight-deck/skills/landing/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: landing
+description: Post-merge cleanup workflow. Discusses uncommitted worktree changes per-worktree before deleting; handles local + remote merged branches, stale refs, dist/ build artifacts, and surfaces today's memory entries for review. Use when the user wants to wrap up after merging a PR, clean up worktrees, tidy branches, do post-merge cleanup, "land the plane", "land", remove stale feature branches, or close out a development session.
+---
+
+# Landing
+
+Post-merge cleanup. Methodical taxi-in: inventory first, decide section-by-section, never destroy uncommitted work without an explicit per-worktree decision.
+
+## When to use
+
+- After a PR is merged and you want to delete the local + remote feature branch
+- When `.worktrees/` has accumulated multiple stale checkouts
+- At the end of a development session to clean up the working environment
+- When the user says "land the plane", "clean up", "tidy worktrees", "wrap up after merge", or similar
+
+## Workflow
+
+Walk the user through cleanup in this order. Run the inventory first, then handle items section-by-section. Be terse — say what you're doing and ask only the questions that need an answer.
+
+### 1. Inventory
+
+Run these in one batch and present the results to the user as a single inventory block before doing anything destructive. Use absolute paths and don't assume cwd:
+
+```bash
+git worktree list
+echo '---per-worktree status---'
+for wt in $(git worktree list --porcelain | awk '/^worktree/ {print $2}' | grep -v "^$(git rev-parse --show-toplevel)$"); do
+  echo "=== $wt ==="
+  (cd "$wt" 2>/dev/null && git status --porcelain) || echo "(unable to enter)"
+done
+echo '---local merged branches (excluding main)---'
+git branch --merged main 2>/dev/null | grep -vE '^\*|main$|master$'
+echo '---remote merged feat/* branches---'
+gh pr list --state merged --limit 50 --json headRefName,number --search "head:feat/" 2>/dev/null \
+  | jq -r '.[] | select(.headRefName | startswith("feat/")) | "\(.headRefName) (#\(.number))"' \
+  | head -20
+echo '---remote refs to prune (dry-run)---'
+git remote prune origin --dry-run 2>&1 | grep -E 'would prune|^ ' | head -20
+echo '---dist/ size---'
+[ -d dist ] && du -sh dist 2>/dev/null || echo "(no dist/)"
+echo '---memory entries authored today---'
+MEMDIR=$(find ~/.claude/projects -maxdepth 2 -name "memory" -type d -path "*$(basename "$(pwd)")*" 2>/dev/null | head -1)
+if [ -n "$MEMDIR" ]; then
+  find "$MEMDIR" -name '*.md' -mtime -1 -type f 2>/dev/null | grep -v MEMORY.md | head -10 \
+    || echo "(no recent entries)"
+else
+  echo "(no project-specific memory dir found)"
+fi
+```
+
+After the inventory runs, present a concise summary:
+
+> **Inventory** (cleanup candidates):
+> - Worktrees to consider: N (M dirty)
+> - Local merged branches: N
+> - Remote merged feat/* branches: N
+> - Stale remote refs: N
+> - dist/: <size> or absent
+> - Today's memory entries: N (informational only)
+>
+> Proceed? (y/N)
+
+If user says no/abort → stop. Otherwise continue to step 2.
+
+### 2. Worktrees (per-worktree decisions)
+
+For each non-main worktree from the inventory:
+
+- **Clean** (per-worktree status was empty): announce "removing clean worktree at `<path>`" and run `git worktree remove <path>`. No prompt.
+- **Dirty** (per-worktree status had output): STOP. Show the user:
+  > Worktree at `<path>` has uncommitted changes:
+  >
+  > ```
+  > <paste the porcelain output>
+  > ```
+  >
+  > Options:
+  > - **(s)** stash to a named stash (e.g. `pre-cleanup-<branch>`), then remove worktree
+  > - **(c)** commit on the current branch, then remove worktree
+  > - **(d)** delete losing changes (`git worktree remove --force`)
+  > - **(k)** keep this worktree, skip cleanup
+  > - **(q)** abort cleanup entirely
+  >
+  > Choice for `<path>`?
+
+  Honor the user's per-worktree choice:
+  - **s**: `(cd <path> && git stash push -m "pre-cleanup-$(git branch --show-current)")` then `git worktree remove <path>`
+  - **c**: ask for a commit message; `(cd <path> && git add -A && git commit -m "<msg>")` then `git worktree remove <path>`
+  - **d**: `git worktree remove --force <path>` (after confirming once more — destructive)
+  - **k**: skip; note in final report
+  - **q**: stop the whole flow, jump to step 6
+
+### 3. Local + remote branches (batch confirm)
+
+After worktrees are handled:
+
+- List the local merged branches (excluding `main`/`master`). Ask: "Delete these N local branches? (y/N)" — single confirm, then `git branch -d <each>`. If `git branch -d` refuses any branch (unmerged commits), pause and ask user before `-D`.
+- List the remote merged feat/* branches. Ask: "Delete these N remote branches? (y/N)" — single confirm, then `git push origin --delete <branch1> <branch2> ...` in one batch.
+- After remote deletions: `git remote prune origin` (no prompt — implicit in the user's confirmation).
+
+If either list is empty, skip its prompt.
+
+### 4. dist/ directory
+
+If `dist/` exists from the inventory, ask: "Remove `dist/` (size: X)? (y/N)". If yes, `rm -rf dist`.
+
+### 5. Memory entries (informational only)
+
+If the inventory found memory entries authored today: list them with paths. Tell the user:
+
+> These memory entries were authored today. Review them at `<dir>` and prune any that are too narrow or session-specific. **I won't touch memory automatically.**
+
+Do NOT delete or modify any memory file. Move on.
+
+### 6. Final report
+
+Run `git status` and `git worktree list`. Show the user:
+
+> **Cleanup complete.**
+>
+> - Worktrees removed: N (kept: M)
+> - Local branches deleted: N
+> - Remote branches deleted: N
+> - Stale refs pruned: N
+> - dist/: removed / kept / absent
+>
+> ```
+> <output of git status>
+> ```
+
+If anything was kept (dirty worktrees user opted to keep, etc.), list it explicitly so the user knows what's left.
+
+## Composition with other skills
+
+- **`bones-powers:finishing-a-bones-leaf`** — after fan-in + git push + PR merge, hand off to `land-the-plane` to clean up the feature branch and worktree.
+- **`superpowers:finishing-a-development-branch`** — same handoff pattern for non-bones workflows.
+
+## Safety rules
+
+- **Never** delete a worktree with uncommitted changes without the user picking option (s/c/d) for that specific worktree.
+- **Never** force-delete (`-D`) a local branch that isn't merged without explicit user confirmation for that branch.
+- **Never** delete a remote branch that doesn't match `feat/*` (or is `main`/`master`).
+- **Never** modify memory files. List only.
+- If any step errors out, surface the error verbatim and ask the user before retrying or skipping.
+
+## Tone
+
+Terse. Don't narrate intent — just say what you're doing and ask the targeted question. Match the "land the plane" framing: end of flight, methodical taxi-in.

--- a/plugins/flight-deck/skills/takeoff/SKILL.md
+++ b/plugins/flight-deck/skills/takeoff/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: takeoff
+description: Beginning-of-session inventory and orientation. Surfaces stale worktrees, behind-origin state, recent specs/plans, open PRs, and recent memory entries to help the agent re-orient. Use when starting a new session, asking "where were we", running a takeoff check, beginning work, or wanting a situational report before diving in. Read-only — pure inventory + recommendations, no automatic actions.
+---
+
+# Takeoff
+
+Pre-flight check. Inventory the state of the repo and recent context, then suggest where to start. Read-only — surfaces information; user picks each next action.
+
+## When to use
+
+- Starting a new session ("let's get going", "where were we", "begin work")
+- Returning to a project after time away
+- Wanting a situational report before deciding what to work on
+- Checking for stale state from a prior crashed session
+
+## Workflow
+
+### 1. Inventory
+
+Run this batch and present results to the user as a single situational report:
+
+```bash
+echo '---branch + status---'
+git branch --show-current
+git status --porcelain | head -20
+echo '---active worktrees---'
+git worktree list
+echo '---commits ahead/behind origin/main---'
+git fetch origin main 2>/dev/null
+git rev-list --left-right --count HEAD...origin/main 2>/dev/null | awk '{print "ahead:", $1, "behind:", $2}'
+echo '---recent commits---'
+git log --oneline -10
+echo '---open PRs by user---'
+gh pr list --author @me --state open --json number,title,headRefName 2>/dev/null \
+  | jq -r '.[] | "#\(.number) \(.headRefName): \(.title)"' | head -10
+echo '---recent specs (last 7 days)---'
+find docs/superpowers/specs docs/superpowers/plans -mtime -7 -name '*.md' -type f 2>/dev/null | head -10
+echo '---npm install needed?---'
+if [ -f package-lock.json ] && [ ! -d node_modules ]; then
+  echo 'YES — node_modules missing'
+elif [ -f package-lock.json ] && [ "package-lock.json" -nt "node_modules/.package-lock.json" ] 2>/dev/null; then
+  echo 'YES — lockfile newer than installed'
+else
+  echo 'no'
+fi
+echo '---memory entries (last 7 days)---'
+MEMDIR=$(find ~/.claude/projects -maxdepth 2 -name "memory" -type d -path "*$(basename "$(pwd)")*" 2>/dev/null | head -1)
+[ -n "$MEMDIR" ] && find "$MEMDIR" -name '*.md' -mtime -7 -type f 2>/dev/null | grep -v MEMORY.md | head -10 || echo "(no project memory dir)"
+```
+
+### 2. Situational report
+
+Format the inventory as a concise report. Example shape:
+
+> **Where we are:**
+> - Branch: `<branch>` (clean / N modified files / etc.)
+> - Worktrees: N active (`<list>`)
+> - vs. origin/main: <ahead/behind>
+> - Recent: 3 commits in last day, 2 specs touched, 1 open PR
+> - Memory: 5 entries in last 7 days
+>
+> **Suggestions:**
+> - Stale worktree at `<path>` from prior session — resume `<branch>` or invoke `landing`?
+> - Behind origin/main by N — run `git pull --ff-only`?
+> - npm install needed — run it now?
+> - Recent unfinished plan: `<plan-path>` — resume?
+> - Open PR #N — check status with `gh pr checks <N>`?
+
+If nothing is in flight (clean tree, no recent activity, no open PRs), end with:
+> What's the goal for this session?
+
+### 3. No automatic actions
+
+`takeoff` is read-only. The agent presents the report and waits for the user to pick the next action. Don't run `git pull`, `npm install`, etc. without explicit user confirmation — even if the inventory says "needed".
+
+## Composition with other skills
+
+- Stale worktree detected → suggest `flight-deck:landing` for cleanup
+- Recent unfinished plan in `docs/superpowers/plans/` → suggest `superpowers:executing-plans` or `superpowers:subagent-driven-development`
+- No goal yet → suggest `superpowers:brainstorming` if the user wants to design something new
+
+## Safety rules
+
+- **Never** mutate state during inventory. No `git pull`, `npm install`, branch deletion, worktree creation.
+- **Never** assume the user wants to resume the most recent thing — always ask.
+- If `gh` isn't authenticated or `git fetch` fails, surface the error and continue with reduced inventory.
+
+## Tone
+
+Terse. Be a useful copilot during pre-flight: surface what matters, don't narrate everything found.


### PR DESCRIPTION
## Summary

New plugin `plugins/flight-deck/` — workflow lifecycle skills:

- **`takeoff`** — beginning-of-session inventory + recommendations (read-only). Surfaces stale worktrees, behind-origin state, recent specs/plans, open PRs, recent memory.
- **`landing`** — post-merge cleanup with per-worktree decisions for uncommitted changes. Local + remote merged branch deletion, stale ref pruning, dist/ cleanup, memory entry surfacing (informational only).
- **`course-correct`** — capture session learnings to a summary file when an approach has failed; tell the user how to rewind their session context per harness. No git mutation.

Plugin manifest with `default-targets: [claude-code, apm, codex, gemini, copilot, pi]` — emits across all 6 harness targets via apm-builder v0.4 plugin discovery.

## Spec

`docs/superpowers/specs/2026-04-30-flight-deck-design.md` (gitignored — local only)

## Plan

`docs/superpowers/plans/2026-04-30-flight-deck.md` (gitignored — local only)

## Test plan

- [x] All 3 SKILL.md frontmatter valid
- [x] plugin.json + marketplace JSON parse + version-aligned at 0.1.0
- [x] apm-builder validate: 79 → 82 components
- [x] All 6 per-target dry-runs succeed; flight-deck skills emit per target
- [x] No regression on bones-powers hook gate
- [ ] Manual: invoke `takeoff` in a fresh session, confirm inventory works
- [ ] Manual: invoke `landing` after a merge, confirm per-worktree prompts
- [ ] Manual: invoke `course-correct` after a "wrong path" moment, confirm summary lands

## Composition

- `bones-powers:finishing-a-bones-leaf` (after merge) → `flight-deck:landing`
- `flight-deck:takeoff` finds stale worktree → suggests `flight-deck:landing`
- Bad path mid-session → `flight-deck:course-correct` → user resumes via `flight-deck:takeoff`

## Out of v0.1 (deferred)

- Mid-session `cruise-altitude` skill (checkpoint state)
- `holding-pattern` skill (multi-day pause/resume)
- Auto-trigger via SessionStart hook (intentionally not present)
- Per-harness rewind UX integration

## Branch name note

Branch is `feat/land-the-plane` — pre-dates the rename to `flight-deck`. Functionality matches the new plugin name.