### PR TITLE
feat(doppler): add idiomatic setup guidance — keychain token, doppler.yaml, direnv, MCP

### DIFF
--- a/skills/doppler/SKILL.md
+++ b/skills/doppler/SKILL.md
@@ -17,6 +17,164 @@ category:
 
 Detect `.env` files, push secrets to Doppler, gitignore and delete the plaintext file, verify, and document.
 
+## Idiomatic project setup (recommended)
+
+These patterns cover ongoing use. The migration workflow below is a one-time bootstrap step.
+
+### 1. Token type taxonomy
+
+Pick the right token type for the context:
+
+| Token type | Format | Permissions | Use case | Notes |
+|---|---|---|---|---|
+| Personal Token | `dp.pt.xxx` | Full account | Daily-driver dev (your laptop) | No default expiry. Mint at dashboard → Settings → Tokens |
+| Service Token | `dp.st.xxx` | Config-scoped (one project + config) | CI / containers / production | Auto-detects project+config from token scope — no DOPPLER_PROJECT/DOPPLER_CONFIG env needed |
+| Service Account Token | `dp.sa.xxx` | Account-level, not human | Agents / automation services | No human-account scope; safer than Personal in shared automation |
+
+Production should **never** see a Personal Token. Use Service Tokens scoped per environment.
+
+### 2. Authenticate via macOS Keychain → DOPPLER_TOKEN
+
+Prefer keychain-managed Personal Token over `doppler login`:
+- `doppler login` stores in keychain too, but the entry can desync ("Token not found in system keyring"), get wiped on OS upgrade, or silently expire
+- Manual keychain via `security` is bulletproof and survives `doppler logout`/OS rebuilds
+- Env var (`DOPPLER_TOKEN`) precedence beats config-file beats keychain — the env var always wins, no config drift
+
+One-time setup:
+
+```bash
+# 1. Mint a Personal Token at https://dashboard.doppler.com/workplace/-/settings/me/tokens
+#    Choose "Never expires" if available
+
+# 2. Park in macOS Keychain (-U flag overwrites if entry exists)
+security add-generic-password -a "$USER" -s doppler-cli-token -w 'dp.pt.xxxxxxxx' -U
+
+# 3. Export from ~/.zshrc on shell startup
+export DOPPLER_TOKEN="$(security find-generic-password -a "$USER" -s doppler-cli-token -w 2>/dev/null)"
+```
+
+Linux equivalents: `secret-tool` (libsecret) or `pass` (gpg-based) — adapt the lookup pattern.
+
+### 3. Pin scope via `doppler.yaml` (committed)
+
+`doppler.yaml` at repo root pins project + config so fresh clones work without interactive `doppler setup`:
+
+```yaml
+# doppler.yaml — committed to the repo
+setup:
+  - project: myproject
+    config: dev
+```
+
+Monorepo variant — multiple sub-projects via `path:`:
+
+```yaml
+setup:
+  - project: backend
+    config: dev
+    path: backend/
+  - project: frontend
+    config: dev
+    path: frontend/
+```
+
+Override per-shell via env vars (e.g., switch to a CI config without editing the file):
+
+```bash
+DOPPLER_CONFIG=ci doppler run -- ./test
+```
+
+Precedence: `DOPPLER_PROJECT`/`DOPPLER_CONFIG` env > `doppler.yaml` > `.doppler/config.yaml` (created by `doppler setup`).
+
+Commit `doppler.yaml`. Gitignore `.doppler/`.
+
+### 4. direnv integration for auto-load on `cd`
+
+Add `.envrc` to the repo (commit it; it has no secrets — secrets come from Doppler at runtime):
+
+```bash
+# .envrc — auto-load Doppler secrets when cd-ing into this repo
+set -a
+source <(doppler secrets download --no-file --format env)
+test -f .env.local && source .env.local
+set +a
+```
+
+One-time approval per machine: `direnv allow`.
+
+**Caveat**: `eval`/`source` of env-format Doppler output breaks on secrets containing `?`, `*`, backticks, or multi-line values. For those, fall back to `doppler run --` invocation pattern:
+
+```bash
+doppler run -- ./your-script
+```
+
+### 5. Container / CI: service token in env
+
+Containers and CI should use a Service Token (config-scoped), never a Personal Token. Inject as env:
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    environment:
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN}  # dp.st.xxx — config-scoped service token
+```
+
+Inside container, install Doppler CLI and wrap your command:
+
+```dockerfile
+# Alpine
+RUN wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' \
+      -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
+    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
+    apk add doppler
+CMD ["doppler", "run", "--", "your-command-here"]
+```
+
+Service Token auto-detects project+config from its scope — no `DOPPLER_PROJECT`/`DOPPLER_CONFIG` env vars needed in containers.
+
+GitHub Actions:
+
+```yaml
+env:
+  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+steps:
+  - run: doppler run -- make test
+```
+
+### 6. Doppler MCP server (optional, for Claude Code agents)
+
+The official `@dopplerhq/mcp-server` (npm) gives Claude Code typed JSON tool responses for secret operations — vs. shell-parsing `doppler` CLI output. Works on the Free plan; published by Doppler.
+
+Add to `~/.claude.json` (user-scope) or repo `.mcp.json` (project-scope):
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"],
+      "env": { "DOPPLER_TOKEN": "${DOPPLER_TOKEN}" }
+    }
+  }
+}
+```
+
+`--read-only` gates write tools (set/update/delete) out of the agent's tool list — recommended unless you specifically want the agent to mutate secrets. Drop the flag to allow writes.
+
+To pin the MCP server to a single project: append `"--project", "myproject"` to args.
+
+> **Don't swallow stderr in shell setup.** Stale auth ("Token not found in system keyring", expired token, unreachable Doppler API) should surface immediately as a visible warning — not a silent secret-less environment that breaks your code with confusing "API_KEY undefined" errors hours later.
+>
+> Pattern from a working setup:
+> ```bash
+> if _doppler_out=$(doppler secrets download --no-file --format env 2>&1); then
+>   eval "$(printf '%s\n' "$_doppler_out" | grep -v '^DOPPLER_')"
+> else
+>   print -P "%F{yellow}doppler: $_doppler_out%f"  # visible warning
+> fi
+> ```
+
 ## Prerequisites
 
 ```bash
@@ -46,12 +204,18 @@ ls .env .env.* 2>/dev/null
 # Infer project name from directory or git remote
 PROJECT=$(basename $(git rev-parse --show-toplevel 2>/dev/null || pwd))
 
-# Create (idempotent — fails gracefully if exists)
+# Create the Doppler project (idempotent — fails gracefully if exists)
 doppler projects create "$PROJECT" --description "$(head -1 README.md 2>/dev/null)" 2>/dev/null || true
 
-# Link this directory
-doppler setup --project "$PROJECT" --config dev --no-interactive
+# Pin scope by committing doppler.yaml (replaces the older `doppler setup` flow)
+cat > doppler.yaml <<EOF
+setup:
+  - project: $PROJECT
+    config: dev
+EOF
 ```
+
+Commit `doppler.yaml` to the repo. Future clones don't need `doppler setup` — the CLI reads scope from this file.
 
 ### 3. Push Secrets
 
@@ -117,7 +281,12 @@ Adjust the "without secrets" note to describe what degrades gracefully (e.g., "n
 | Task | Command |
 |------|---------|
 | Install CLI | `brew install doppler` |
-| Login | `doppler login` |
+| Login | Personal Token in keychain (preferred) — see Idiomatic setup |
+| Mint Personal Token | Dashboard → Settings → Tokens → Create CLI Token (Never expires) |
+| Park token in keychain | `security add-generic-password -a "$USER" -s doppler-cli-token -w 'dp.pt.xxx' -U` |
+| Pin scope (committed) | Write `doppler.yaml` with `setup: [{project: X, config: Y}]` |
+| Auto-load via direnv | `.envrc` with `set -a; source <(doppler secrets download --no-file --format env); set +a` |
+| Container service token | `DOPPLER_TOKEN=dp.st.xxx` env var; `doppler run -- cmd` inside |
 | Create project | `doppler projects create NAME` |
 | Link directory | `doppler setup --project NAME --config dev --no-interactive` |
 | Set secrets | `doppler secrets set "KEY=value" "KEY2=value2"` |
@@ -165,3 +334,8 @@ steps:
 | Not verifying after migration | Always run `doppler run -- env \| grep KEY` |
 | Leaving `.env` after migration | Delete it — Doppler is the source of truth now |
 | Hardcoding `doppler run` in Makefile | Don't — keep Makefile working without Doppler. Users prefix manually. |
+| `doppler login` instead of keychain Personal Token | Token can desync, expire silently, or be wiped on OS upgrade — use manual keychain entry + `DOPPLER_TOKEN` env |
+| Per-clone `doppler setup` ceremony | Commit `doppler.yaml` instead — fresh clones just work |
+| Personal Token in CI/container | Use a Service Token (`dp.st.xxx`) — config-scoped, no human-account access |
+| Swallowing Doppler stderr in shell setup | Loud failures — show stale-auth warnings visibly, don't silently ship secret-less env |
+| `eval`/`source` of secrets with `?`/`*`/backticks/multiline | Fall back to `doppler run --` for those secrets — env-format download breaks on shell metacharacters |


### PR DESCRIPTION
## Summary

Updates `skills/doppler/SKILL.md` to incorporate ongoing-usage best practices that emerged from another project's research + applied changes. Existing one-time `.env`-to-Doppler migration workflow stays intact; idiomatic-setup section is added as the foundation that supports it.

## What's new

- **Token type taxonomy** — Personal (`dp.pt.xxx`), Service (`dp.st.xxx`), Service Account (`dp.sa.xxx`). Right token for the right context.
- **macOS Keychain → `DOPPLER_TOKEN`** — replaces `doppler login` (which silently expires / desyncs / wipes on OS upgrade)
- **`doppler.yaml`** committed for scope pinning — replaces per-clone `doppler setup --no-interactive` ceremony. Monorepo `path:` field supported.
- **direnv `.envrc` recipe** — `set -a` + `source <(doppler secrets download ...)`, with caveats for special chars
- **Container/CI** — service token in `DOPPLER_TOKEN` env, Dockerfile install recipe, GitHub Actions snippet
- **Doppler MCP server** (optional) — `@dopplerhq/mcp-server` for Claude Code agents; typed JSON tool responses; `--read-only` flag for safety
- **Loud-failures callout** — don't swallow stderr in shell setup; visible warnings on stale auth

## Spec

No formal spec doc — the changes were a single-skill content update based on a working setup in another project. Design summary discussed inline before execution.

## Test plan

- [x] Skill frontmatter intact
- [x] Line count grew from 168 → 341 (+178 lines from new sections)
- [x] All new keywords present: `doppler.yaml`, `DOPPLER_TOKEN`, `security add-generic-password`, `@dopplerhq/mcp-server`, `set -a`
- [x] 8 major sections, 12 sub-sections (was 7/6)
- [x] Local CI: 269/269 tests, validate (82 components, 22 warnings — all pre-existing), build dry-run all PASS
- [ ] Manual: hand-run skill in a fresh repo, confirm migration workflow + idiomatic setup both work end-to-end

## Out of scope (deferred)

- Mirroring the keychain block into `~/.zshrc` (skill content describes the pattern; user copies into their shell)
- Adding Doppler MCP entry to global `~/.claude/settings.json` (skill describes the JSON; user opts in)
- Skill version bump (no interface change; version stays at 0.1.0)