### PR TITLE
Repo hygiene: fix marketplace JSON

### DIFF
--- a/marketplace/agent-config.json
+++ b/marketplace/agent-config.json
@@ -1,10 +1,10 @@
 {
-  "name": "agent-skills",
+  "name": "agent-config",
   "version": "0.1.0",
   "description": "Multi-harness skills monorepo: skills, plugins, rules, hooks, agents, MCP servers built once, published per-harness.",
   "publisher": "danmestas",
-  "homepage": "https://github.com/danmestas/agent-skills",
-  "release": "https://github.com/danmestas/agent-skills/releases/latest",
+  "homepage": "https://github.com/danmestas/agent-config",
+  "release": "https://github.com/danmestas/agent-config/releases/latest",
   "categories": ["productivity", "developer-tools"],
   "includes": "all"
 }


### PR DESCRIPTION
## Summary

One small hygiene fix:

1. **Fix `marketplace/agent-config.json`** — `name` was `agent-skills` and URLs pointed at `github.com/danmestas/agent-skills` (a repo that never existed). Real repo is `agent-config`.

Note: The brief mentioned dropping `_evolution_todo` from `package.json`, but that field is already absent — no change needed.

No content changes. No suit-side impact.

## Test plan

- [x] `npm run validate` passes (68 components, 6 unrelated warnings)
- [x] `marketplace/agent-config.json` parses as valid JSON
- [x] `package.json` parses as valid JSON