### PR TITLE
feat(suit): add .suit/default.yaml so suit claude works without flags

### DIFF
--- a/.suit/default.yaml
+++ b/.suit/default.yaml
@@ -1,0 +1,3 @@
+default:
+  persona: aviation
+  mode: code


### PR DESCRIPTION
## Summary
- `agent-config` had no `.suit/default.yaml`, so `suit claude` invoked without `--persona` / `--mode` errored.
- Sets default to `aviation` + `code` — the dominant working context (FireStorm Flight Services data plane).
- Overridable per-session via flags or project overlays at `<cwd>/.suit/`.

## Test plan
- [x] `suit list personas` shows aviation
- [x] `suit list modes` shows code
- [ ] After merge + `suit sync`, `suit claude` (no flags) launches with aviation + code applied