### PR TITLE
fix(agent): wrap CC-native frontmatter in nested agent: block

### DIFF
--- a/agents/gh-project-expert/AGENT.md
+++ b/agents/gh-project-expert/AGENT.md
@@ -41,9 +41,10 @@ description: |
   Project configuration questions benefit from the agent's knowledge of all 6 templates and when to use each.
   </commentary>
   </example>
-model: inherit
-color: cyan
-tools: ["Read", "Write", "Bash", "Grep", "Glob"]
+agent:
+  model: inherit
+  color: cyan
+  tools: [Read, Write, Bash, Grep, Glob]
 ---
 
 You are a GitHub Projects V2 expert. You orchestrate project setup, daily operations, charters, and bulk management using the `gh` CLI.


### PR DESCRIPTION
## Summary
Tactical fix for a v0.4 schema/wardrobe interaction discovered during the realtime e2e smoke test (companion to [suit#15](https://github.com/danmestas/suit/pull/15)).

## What broke
\`agents/gh-project-expert/AGENT.md\` had Claude-Code-canonical top-level keys (\`model: inherit\`, \`color: cyan\`, \`tools: [...]\`). Before suit Phase 1.5, this file was buried under \`plugins/gh-project-management/agents/\` — suit's discover never walked it.

After Phase 4 (wardrobe restructure) flattened it to \`agents/gh-project-expert/AGENT.md\`, and suit Phase 1.5 taught discover to find AGENT.md files, the file now flows through suit's \`ManifestBaseSchema.parse()\`. That schema is \`.strict()\`, so it rejects unknown keys:

    Unrecognized key(s) in object: 'model', 'color', 'tools'

## Fix
Move \`model\`/\`color\`/\`tools\` into the nested \`agent: {...}\` block that suit's schema already accepts (see ManifestBaseSchema's AgentBlock).

\`\`\`diff
- model: inherit
- color: cyan
- tools: ["Read", "Write", "Bash", "Grep", "Glob"]
+ agent:
+   model: inherit
+   color: cyan
+   tools: [Read, Write, Bash, Grep, Glob]
\`\`\`

## Verified
\`suit claude --outfit backend --mode focused\` against this wardrobe now passes the realtime e2e smoke battery (3/3 PASS for claude / codex / pi).

## Backlog item
Consider \`.passthrough()\` for harness-primitive schemas (Skill / Agent / Hook / Rules / Plugin) so future agent files can use harness-canonical frontmatter directly. Would belong as a separate suit PR.