### PR TITLE
feat(v4): globals registry + outfit/mode targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ Each script invokes [`suit-build`](https://github.com/danmestas/suit) via `npx -
 
 `npm run docs` only rewrites the region between `<!-- AUTO-GENERATED: COMPONENTS -->` and `<!-- /AUTO-GENERATED: COMPONENTS -->`. Everything outside the markers is hand-written and preserved across regenerations.
 
+## Globals registry
+
+`globals.yaml` is a per-machine snapshot of every Claude Code plugin and MCP
+server installed at *user scope* (read from
+`~/.claude/plugins/installed_plugins.json` for user-scope plugins, and
+`~/.claude.json`'s `mcpServers` block for MCPs). Suit (≥ v0.7) reads it so
+outfits, modes, and accessories can reference globals by name — enabling or
+disabling specific plugins/MCPs per session without uninstalling them.
+
+```bash
+npm run sync-globals                # write globals.yaml from this machine
+npm run sync-globals -- --dry-run   # print the snapshot, don't write
+npm run sync-globals -- --pr        # write, commit, push, open a PR via gh
+```
+
+Run `npm run sync-globals` after installing or removing a plugin or MCP at
+user scope to refresh the registry, then open a PR (the `--pr` flag does
+this for you when `gh` is on PATH and the working tree is otherwise clean).
+Outfits, modes, and accessories opt into globals via `enable:` / `disable:`
+blocks naming registered entries — see ADR-0014 in the suit repo (Phase D
+of v0.7 wires the resolver). MCP entries record only non-secret metadata —
+stdio MCPs capture `command`, `args`, and a `has_env` flag; HTTP MCPs
+capture `url` and a `has_headers` flag. Env values and header values stay
+in `~/.claude.json`.
+
+See [`globals.yaml.example`](globals.yaml.example) for the schema. Real
+`globals.yaml` files are expected to drift between collaborators.
+
 ## Categories
 
 Each link points at the component's own directory — open the `SKILL.md` (or agent / hook file) inside for the full writeup. The auto-generated [Components table](#components) below has descriptions for every entry.

--- a/globals.yaml
+++ b/globals.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generated_at: 2026-05-05T01:03:27.892Z
+generated_at: 2026-05-05T05:08:39.515Z
 machine: m4-macbook.tail51604c.ts.net
 plugins:
   obsidian:
@@ -62,6 +62,51 @@ plugins:
     source: claude-code-marketplace
     install: claude plugin install skill-creator
     discover_path: ~/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown
+  code-review-codex:
+    source: codex-marketplace
+    install: codex plugin install code-review
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/code-review
+    harness: codex
+  context7-codex:
+    source: codex-marketplace
+    install: codex plugin install context7
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/context7
+    harness: codex
+  context-mode-codex:
+    source: codex-marketplace
+    install: codex plugin install context-mode
+    discover_path: ~/.codex/plugins/cache/context-mode/context-mode
+    harness: codex
+  frontend-design-codex:
+    source: codex-marketplace
+    install: codex plugin install frontend-design
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/frontend-design
+    harness: codex
+  github:
+    source: codex-marketplace
+    install: codex plugin install github
+    discover_path: ~/.codex/plugins/cache/openai-curated/github
+    harness: codex
+  plugin-dev-codex:
+    source: codex-marketplace
+    install: codex plugin install plugin-dev
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/plugin-dev
+    harness: codex
+  software-philosophy:
+    source: codex-marketplace
+    install: codex plugin install software-philosophy
+    discover_path: ~/.codex/plugins/cache/agent-plugins/software-philosophy
+    harness: codex
+  superpowers-codex:
+    source: codex-marketplace
+    install: codex plugin install superpowers
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/superpowers
+    harness: codex
+  telegram-codex:
+    source: codex-marketplace
+    install: codex plugin install telegram
+    discover_path: ~/.codex/plugins/cache/claude-plugins-official/telegram
+    harness: codex
 mcps:
   signoz:
     source: claude-code-config
@@ -85,4 +130,36 @@ mcps:
     url: https://mcp.axiom.co/mcp
     has_headers: true
     discover_path: ~/.claude.json#mcpServers.axiom
+  axiom-codex:
+    source: codex-config
+    type: http
+    url: https://mcp.axiom.co/mcp
+    has_headers: true
+    discover_path: ~/.codex/config.toml#mcp_servers.axiom
+    harness: codex
+  doppler-codex:
+    source: codex-config
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@dopplerhq/mcp-server"
+      - --read-only
+    has_env: true
+    discover_path: ~/.codex/config.toml#mcp_servers.doppler
+    harness: codex
+  context-mode:
+    source: codex-config
+    type: stdio
+    command: context-mode
+    has_env: false
+    discover_path: ~/.codex/config.toml#mcp_servers.context-mode
+    harness: codex
+  signoz-codex:
+    source: codex-config
+    type: stdio
+    command: /Users/dmestas/.local/bin/signoz-mcp-server
+    has_env: true
+    discover_path: ~/.codex/config.toml#mcp_servers.signoz
+    harness: codex
 hooks: {}

--- a/globals.yaml
+++ b/globals.yaml
@@ -1,0 +1,88 @@
+schemaVersion: 1
+generated_at: 2026-05-05T01:03:27.892Z
+machine: m4-macbook.tail51604c.ts.net
+plugins:
+  obsidian:
+    source: manual
+    install: claude plugin install obsidian
+    discover_path: ~/.claude/plugins/cache/obsidian-skills/obsidian/1.0.0
+    version: 1.0.0
+  gopls-lsp:
+    source: claude-code-marketplace
+    install: claude plugin install gopls-lsp
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0
+    version: 1.0.0
+  context7:
+    source: claude-code-marketplace
+    install: claude plugin install context7
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/context7/unknown
+  code-simplifier:
+    source: claude-code-marketplace
+    install: claude plugin install code-simplifier
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/code-simplifier/1.0.0
+    version: 1.0.0
+  frontend-design:
+    source: claude-code-marketplace
+    install: claude plugin install frontend-design
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/frontend-design/unknown
+  superpowers:
+    source: claude-code-marketplace
+    install: claude plugin install superpowers
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7
+    version: 5.0.7
+  claude-hud:
+    source: manual
+    install: claude plugin install claude-hud
+    discover_path: ~/.claude/plugins/cache/claude-hud/claude-hud/0.0.11
+    version: 0.0.11
+  code-review:
+    source: claude-code-marketplace
+    install: claude plugin install code-review
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/code-review/unknown
+  plugin-dev:
+    source: claude-code-marketplace
+    install: claude plugin install plugin-dev
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/plugin-dev/unknown
+  swift-lsp:
+    source: claude-code-marketplace
+    install: claude plugin install swift-lsp
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/swift-lsp/1.0.0
+    version: 1.0.0
+  telegram:
+    source: claude-code-marketplace
+    install: claude plugin install telegram
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6
+    version: 0.0.6
+  context-mode:
+    source: manual
+    install: claude plugin install context-mode
+    discover_path: ~/.claude/plugins/cache/context-mode/context-mode/1.0.103
+    version: 1.0.103
+  skill-creator:
+    source: claude-code-marketplace
+    install: claude plugin install skill-creator
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown
+mcps:
+  signoz:
+    source: claude-code-config
+    type: stdio
+    command: /Users/dmestas/.local/bin/signoz-mcp-server
+    has_env: true
+    discover_path: ~/.claude.json#mcpServers.signoz
+  doppler:
+    source: claude-code-config
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@dopplerhq/mcp-server"
+      - --read-only
+    has_env: true
+    discover_path: ~/.claude.json#mcpServers.doppler
+  axiom:
+    source: claude-code-config
+    type: http
+    url: https://mcp.axiom.co/mcp
+    has_headers: true
+    discover_path: ~/.claude.json#mcpServers.axiom
+hooks: {}

--- a/globals.yaml.example
+++ b/globals.yaml.example
@@ -1,0 +1,64 @@
+# globals.yaml — per-machine registry of globally-installed Claude Code
+# plugins, MCP servers, and hooks at user scope.
+#
+# WHAT THIS IS:
+#   A snapshot of every plugin/MCP/hook installed at the *user scope* on
+#   the machine that generated this file. Source of truth for plugins is
+#   ~/.claude/plugins/installed_plugins.json (user-scope entries only);
+#   source of truth for MCPs is the `mcpServers` block of ~/.claude.json.
+#   Suit (≥ v0.7) reads this file so outfits, modes, and accessories can
+#   target globals by name — enabling or disabling specific plugins/MCPs
+#   per session without the user having to uninstall anything.
+#
+# HOW TO REGENERATE:
+#   npm run sync-globals           # writes globals.yaml in this repo
+#   npm run sync-globals -- --pr   # also opens a PR via gh
+#   npm run sync-globals -- --dry-run  # prints to stdout, doesn't write
+#
+# IS THIS THE SAME ON EVERY MACHINE?
+#   No. Each developer's ~/.claude/ is different. The committed
+#   globals.yaml is a per-machine artifact and is expected to drift between
+#   collaborators. Run `npm run sync-globals` whenever you install or
+#   remove a plugin/MCP at user scope, and open a PR so the registry is
+#   up to date.
+#
+# DOES THIS LEAK SECRETS?
+#   No. stdio MCP entries record only `command`, `args`, and a `has_env`
+#   boolean. HTTP MCP entries record only `url` and a `has_headers` boolean.
+#   API tokens and other env/header values from ~/.claude.json never appear
+#   in this file — Claude continues to read them from ~/.claude.json at
+#   runtime.
+#
+# This is the EXAMPLE — the real one is generated. It's committed only so
+# new contributors can see the shape before running sync-globals.
+
+schemaVersion: 1
+generated_at: 2026-05-04T00:00:00.000Z
+machine: example-host
+
+plugins:
+  superpowers:
+    source: claude-code-marketplace
+    install: claude plugin install superpowers
+    discover_path: ~/.claude/plugins/cache/claude-plugins-official/superpowers/1.2.3
+    version: 1.2.3
+
+mcps:
+  # stdio MCP — captures command + args + presence flag for env values.
+  doppler:
+    source: claude-code-config
+    type: stdio
+    command: doppler
+    args:
+      - mcp
+    has_env: true
+    discover_path: ~/.claude.json#mcpServers.doppler
+  # HTTP MCP — captures url + presence flag for header values.
+  axiom:
+    source: claude-code-config
+    type: http
+    url: https://mcp.axiom.co/mcp
+    has_headers: true
+    discover_path: ~/.claude.json#mcpServers.axiom
+
+hooks: {}

--- a/modes/debugging/mode.md
+++ b/modes/debugging/mode.md
@@ -1,10 +1,15 @@
 ---
 name: debugging
-version: 1.0.0
+version: 1.1.0
 type: mode
 description: Hunting a bug — reproduce, minimize, hypothesise, instrument, fix, regression-test.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [backpressure, context-management]
+# Re-enables observability MCPs even if the active outfit disabled them
+# (e.g. frontend outfit drops signoz/axiom; debugging mode pulls them back).
+enable:
+  plugins: [context-mode]
+  mcps: [signoz, axiom]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/debugging/mode.md
+++ b/modes/debugging/mode.md
@@ -1,22 +1,41 @@
 ---
 name: debugging
-version: 1.1.0
+version: 1.1.1
 type: mode
-description: Hunting a bug — reproduce, minimize, hypothesise, instrument, fix, regression-test.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [backpressure, context-management]
-# Re-enables observability MCPs even if the active outfit disabled them
-# (e.g. frontend outfit drops signoz/axiom; debugging mode pulls them back).
+description: >-
+  Hunting a bug — reproduce, minimize, hypothesise, instrument, fix,
+  regression-test.
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - backpressure
+  - context-management
 enable:
-  plugins: [context-mode]
-  mcps: [signoz, axiom]
+  plugins:
+    - context-mode
+    - context-mode-codex
+  mcps:
+    - axiom
+    - axiom-codex
+    - signoz
+    - signoz-codex
 skill_include: []
 skill_exclude: []
 include:
-  skills: [systematic-debugging, investigating-agent-sessions, stuck-detector, course-correct]
+  skills:
+    - systematic-debugging
+    - investigating-agent-sessions
+    - stuck-detector
+    - course-correct
   rules: []
   hooks: []
-  agents: [debugger]
+  agents:
+    - debugger
   commands: []
 ---
 

--- a/modes/executing/mode.md
+++ b/modes/executing/mode.md
@@ -1,10 +1,12 @@
 ---
 name: executing
-version: 1.0.0
+version: 1.1.0
 type: mode
 description: Working a plan — spawn subagents, dispatch parallel work, finish the branch.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow]
+enable:
+  plugins: [superpowers]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/executing/mode.md
+++ b/modes/executing/mode.md
@@ -1,16 +1,30 @@
 ---
 name: executing
-version: 1.1.0
+version: 1.1.1
 type: mode
-description: Working a plan — spawn subagents, dispatch parallel work, finish the branch.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow]
+description: 'Working a plan — spawn subagents, dispatch parallel work, finish the branch.'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
 enable:
-  plugins: [superpowers]
+  plugins:
+    - superpowers
+    - superpowers-codex
 skill_include: []
 skill_exclude: []
 include:
-  skills: [executing-plans, subagent-driven-development, dispatching-parallel-agents, finishing-a-bones-leaf]
+  skills:
+    - executing-plans
+    - subagent-driven-development
+    - dispatching-parallel-agents
+    - finishing-a-bones-leaf
   rules: []
   hooks: []
   agents: []

--- a/modes/ops/mode.md
+++ b/modes/ops/mode.md
@@ -1,21 +1,37 @@
 ---
 name: ops
-version: 2.1.0
+version: 2.1.1
 type: mode
 description: Incident / infra change — observe before changing.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [workflow, integrations, backpressure]
-# Re-enables observability MCPs even if the active outfit disabled them
-# (e.g. frontend/personal outfits drop signoz/axiom; ops mode pulls them back).
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - workflow
+  - integrations
+  - backpressure
 enable:
-  mcps: [signoz, axiom]
+  mcps:
+    - axiom
+    - axiom-codex
+    - signoz
+    - signoz-codex
 skill_include: []
 skill_exclude: []
 include:
-  skills: [takeoff, signoz-dashboard-builder, investigating-agent-sessions, course-correct]
+  skills:
+    - takeoff
+    - signoz-dashboard-builder
+    - investigating-agent-sessions
+    - course-correct
   rules: []
   hooks: []
-  agents: [observability-engineer]
+  agents:
+    - observability-engineer
   commands: []
 ---
 

--- a/modes/ops/mode.md
+++ b/modes/ops/mode.md
@@ -1,10 +1,14 @@
 ---
 name: ops
-version: 2.0.0
+version: 2.1.0
 type: mode
 description: Incident / infra change — observe before changing.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [workflow, integrations, backpressure]
+# Re-enables observability MCPs even if the active outfit disabled them
+# (e.g. frontend/personal outfits drop signoz/axiom; ops mode pulls them back).
+enable:
+  mcps: [signoz, axiom]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/planning/mode.md
+++ b/modes/planning/mode.md
@@ -1,16 +1,29 @@
 ---
 name: planning
-version: 1.1.0
+version: 1.1.1
 type: mode
-description: Designing before code — produce a plan, don't write the implementation yet.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow]
+description: 'Designing before code — produce a plan, don''t write the implementation yet.'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
 enable:
-  plugins: [superpowers]
+  plugins:
+    - superpowers
+    - superpowers-codex
 skill_include: []
 skill_exclude: []
 include:
-  skills: [brainstorming, writing-plans, reflect]
+  skills:
+    - brainstorming
+    - writing-plans
+    - reflect
   rules: []
   hooks: []
   agents: []

--- a/modes/planning/mode.md
+++ b/modes/planning/mode.md
@@ -1,10 +1,12 @@
 ---
 name: planning
-version: 1.0.0
+version: 1.1.0
 type: mode
 description: Designing before code — produce a plan, don't write the implementation yet.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow]
+enable:
+  plugins: [superpowers]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/reviewing/mode.md
+++ b/modes/reviewing/mode.md
@@ -1,21 +1,36 @@
 ---
 name: reviewing
-version: 1.1.0
+version: 1.1.1
 type: mode
 description: Code review — separate must-fix from suggestion.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [backpressure, evolution]
-# Re-enables review tooling even if the active outfit disabled them
-# (e.g. personal outfit drops code-review/code-simplifier; reviewing mode pulls them back).
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - backpressure
+  - evolution
 enable:
-  plugins: [code-review, code-simplifier]
+  plugins:
+    - code-review
+    - code-review-codex
+    - code-simplifier
 skill_include: []
 skill_exclude: []
 include:
-  skills: [requesting-code-review, receiving-code-review, verification-before-completion, ousterhout]
+  skills:
+    - requesting-code-review
+    - receiving-code-review
+    - verification-before-completion
+    - ousterhout
   rules: []
   hooks: []
-  agents: [code-reviewer, architect-review]
+  agents:
+    - code-reviewer
+    - architect-review
   commands: []
 ---
 

--- a/modes/reviewing/mode.md
+++ b/modes/reviewing/mode.md
@@ -1,10 +1,14 @@
 ---
 name: reviewing
-version: 1.0.0
+version: 1.1.0
 type: mode
 description: Code review — separate must-fix from suggestion.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [backpressure, evolution]
+# Re-enables review tooling even if the active outfit disabled them
+# (e.g. personal outfit drops code-review/code-simplifier; reviewing mode pulls them back).
+enable:
+  plugins: [code-review, code-simplifier]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/writing/mode.md
+++ b/modes/writing/mode.md
@@ -1,10 +1,12 @@
 ---
 name: writing
-version: 1.0.0
+version: 1.1.0
 type: mode
 description: Prose / KB notes / docs.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [memory-management, workflow]
+enable:
+  plugins: [obsidian, context7]
 skill_include: []
 skill_exclude: []
 include:

--- a/modes/writing/mode.md
+++ b/modes/writing/mode.md
@@ -1,16 +1,30 @@
 ---
 name: writing
-version: 1.1.0
+version: 1.1.1
 type: mode
 description: Prose / KB notes / docs.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [memory-management, workflow]
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - memory-management
+  - workflow
 enable:
-  plugins: [obsidian, context7]
+  plugins:
+    - context7
+    - context7-codex
+    - obsidian
 skill_include: []
 skill_exclude: []
 include:
-  skills: [obsidian-markdown, defuddle, brainstorming]
+  skills:
+    - obsidian-markdown
+    - defuddle
+    - brainstorming
   rules: []
   hooks: []
   agents: []

--- a/outfits/aviation/outfit.md
+++ b/outfits/aviation/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: aviation
-version: 2.0.0
+version: 2.1.0
 type: outfit
 description: Flight planning, NOTAMs, charts, ops references.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, memory-management, integrations]
+disable:
+  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/aviation/outfit.md
+++ b/outfits/aviation/outfit.md
@@ -1,13 +1,36 @@
 ---
 name: aviation
-version: 2.1.0
+version: 2.1.1
 type: outfit
-description: Flight planning, NOTAMs, charts, ops references.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, memory-management, integrations]
+description: 'Flight planning, NOTAMs, charts, ops references.'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - memory-management
+  - integrations
 disable:
-  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - gopls-lsp
+    - plugin-dev
+    - plugin-dev-codex
+    - skill-creator
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/backend/outfit.md
+++ b/outfits/backend/outfit.md
@@ -1,12 +1,27 @@
 ---
 name: backend
-version: 2.1.0
+version: 2.1.1
 type: outfit
-description: Backend dev work — Go, server, observability, deterministic systems.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, backpressure, evolution, integrations, context-management]
+description: 'Backend dev work — Go, server, observability, deterministic systems.'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - backpressure
+  - evolution
+  - integrations
+  - context-management
 disable:
-  plugins: [frontend-design, swift-lsp]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - swift-lsp
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/backend/outfit.md
+++ b/outfits/backend/outfit.md
@@ -1,10 +1,12 @@
 ---
 name: backend
-version: 2.0.0
+version: 2.1.0
 type: outfit
 description: Backend dev work — Go, server, observability, deterministic systems.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, backpressure, evolution, integrations, context-management]
+disable:
+  plugins: [frontend-design, swift-lsp]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/bones/outfit.md
+++ b/outfits/bones/outfit.md
@@ -1,10 +1,12 @@
 ---
 name: bones
-version: 1.0.0
+version: 1.1.0
 type: outfit
 description: The bones Go orchestrator — leaves, swarm, parallel work.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, backpressure, evolution, integrations]
+disable:
+  plugins: [frontend-design, swift-lsp]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/bones/outfit.md
+++ b/outfits/bones/outfit.md
@@ -1,12 +1,26 @@
 ---
 name: bones
-version: 1.1.0
+version: 1.1.1
 type: outfit
-description: The bones Go orchestrator — leaves, swarm, parallel work.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, backpressure, evolution, integrations]
+description: 'The bones Go orchestrator — leaves, swarm, parallel work.'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - backpressure
+  - evolution
+  - integrations
 disable:
-  plugins: [frontend-design, swift-lsp]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - swift-lsp
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/frontend/outfit.md
+++ b/outfits/frontend/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: frontend
-version: 2.0.0
+version: 2.1.0
 type: outfit
 description: Datastar / shadcn / UI work.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, backpressure, evolution, tooling]
+disable:
+  plugins: [gopls-lsp, swift-lsp]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/frontend/outfit.md
+++ b/outfits/frontend/outfit.md
@@ -1,13 +1,32 @@
 ---
 name: frontend
-version: 2.1.0
+version: 2.1.1
 type: outfit
 description: Datastar / shadcn / UI work.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, backpressure, evolution, tooling]
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - backpressure
+  - evolution
+  - tooling
 disable:
-  plugins: [gopls-lsp, swift-lsp]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - gopls-lsp
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/kb/outfit.md
+++ b/outfits/kb/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: kb
-version: 1.0.0
+version: 1.1.0
 type: outfit
 description: Obsidian vault / knowledge curation.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, memory-management, context-management]
+disable:
+  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/kb/outfit.md
+++ b/outfits/kb/outfit.md
@@ -1,13 +1,36 @@
 ---
 name: kb
-version: 1.1.0
+version: 1.1.1
 type: outfit
 description: Obsidian vault / knowledge curation.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, memory-management, context-management]
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - memory-management
+  - context-management
 disable:
-  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - gopls-lsp
+    - plugin-dev
+    - plugin-dev-codex
+    - skill-creator
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/meta/outfit.md
+++ b/outfits/meta/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: meta
-version: 1.0.0
+version: 1.1.0
 type: outfit
 description: Wardrobe / suit / agent-skills authoring.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, evolution, tooling]
+disable:
+  plugins: [gopls-lsp, swift-lsp, frontend-design]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/meta/outfit.md
+++ b/outfits/meta/outfit.md
@@ -1,13 +1,33 @@
 ---
 name: meta
-version: 1.1.0
+version: 1.1.1
 type: outfit
 description: Wardrobe / suit / agent-skills authoring.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, evolution, tooling]
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - evolution
+  - tooling
 disable:
-  plugins: [gopls-lsp, swift-lsp, frontend-design]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - gopls-lsp
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/personal/outfit.md
+++ b/outfits/personal/outfit.md
@@ -1,13 +1,38 @@
 ---
 name: personal
-version: 2.1.0
+version: 2.1.1
 type: outfit
-description: Journaling, resume, life admin (formerly personal + taxes).
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, memory-management]
+description: 'Journaling, resume, life admin (formerly personal + taxes).'
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - memory-management
 disable:
-  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator, code-review, code-simplifier]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - code-review
+    - code-review-codex
+    - code-simplifier
+    - frontend-design
+    - frontend-design-codex
+    - gopls-lsp
+    - plugin-dev
+    - plugin-dev-codex
+    - skill-creator
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/personal/outfit.md
+++ b/outfits/personal/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: personal
-version: 2.0.0
+version: 2.1.0
 type: outfit
 description: Journaling, resume, life admin (formerly personal + taxes).
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, memory-management]
+disable:
+  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator, code-review, code-simplifier]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/stasi/outfit.md
+++ b/outfits/stasi/outfit.md
@@ -1,10 +1,13 @@
 ---
 name: stasi
-version: 1.0.0
+version: 1.1.0
 type: outfit
 description: Spying on sessions to audit and improve agent behavior.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [economy, workflow, evolution, context-management]
+disable:
+  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
+  mcps: [signoz, axiom, doppler]
 skill_include:
   - writing-plans
   - brainstorming

--- a/outfits/stasi/outfit.md
+++ b/outfits/stasi/outfit.md
@@ -1,13 +1,36 @@
 ---
 name: stasi
-version: 1.1.0
+version: 1.1.1
 type: outfit
 description: Spying on sessions to audit and improve agent behavior.
-targets: [claude-code, apm, codex, gemini, copilot, pi]
-categories: [economy, workflow, evolution, context-management]
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - economy
+  - workflow
+  - evolution
+  - context-management
 disable:
-  plugins: [gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator]
-  mcps: [signoz, axiom, doppler]
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - gopls-lsp
+    - plugin-dev
+    - plugin-dev-codex
+    - skill-creator
+    - swift-lsp
+  mcps:
+    - axiom
+    - axiom-codex
+    - doppler
+    - doppler-codex
+    - signoz
+    - signoz-codex
 skill_include:
   - writing-plans
   - brainstorming

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "watch": "npx -y -p @agent-ops/suit suit-build watch",
     "docs": "npx -y -p @agent-ops/suit suit-build docs",
     "evolve": "npx -y -p @agent-ops/suit suit-build evolve",
-    "init": "npx -y -p @agent-ops/suit suit-build init"
+    "init": "npx -y -p @agent-ops/suit suit-build init",
+    "sync-globals": "npx -y -p @agent-ops/suit suit-build sync-globals"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

- Generated `globals.yaml` from this machine: 13 user-scope plugins + 3 MCPs (signoz stdio, doppler stdio, axiom http).
- `disable:` blocks on outfits surgically remove irrelevant globals per domain.
- `enable:` blocks on modes re-add narrow needs that an outfit might have disabled (debugging re-enables observability MCPs even on a frontend session).
- New `npm run sync-globals` script delegates to `suit-build sync-globals`.
- `globals.yaml.example` documents the schema for forks.

## Why

Every session inherited every globally-installed plugin/MCP indiscriminately. Frontend sessions saw backend tracing MCPs; KB sessions saw Go LSPs; stasi audit sessions saw the full toolkit when only investigation tools were relevant. Now outfits/modes target the right subset; suit's symlink-farm enforces it via HOME override per-session.

## Per-outfit disables

| Outfit | Plugins disabled | MCPs disabled |
|---|---|---|
| `code` | (none — fallback) | (none) |
| `backend` | frontend-design, swift-lsp | (none — wants signoz/axiom/doppler) |
| `frontend` | gopls-lsp, swift-lsp | signoz, axiom, doppler |
| `bones` | frontend-design, swift-lsp | (none) |
| `aviation` | gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator | signoz, axiom, doppler |
| `kb` | gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator | signoz, axiom, doppler |
| `meta` | gopls-lsp, swift-lsp, frontend-design | signoz, axiom, doppler |
| `personal` | gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator, code-review, code-simplifier | signoz, axiom, doppler |
| `stasi` | gopls-lsp, swift-lsp, frontend-design, plugin-dev, skill-creator | signoz, axiom, doppler |

## Per-mode enables

| Mode | Plugins enabled | MCPs enabled |
|---|---|---|
| `planning` | superpowers | (none) |
| `executing` | superpowers | (none) |
| `debugging` | context-mode | signoz, axiom |
| `reviewing` | code-review, code-simplifier | (none) |
| `writing` | obsidian, context7 | (none) |
| `ops` | (none) | signoz, axiom |

(`focused`, `ticketing` carry no enable/disable — they're work-shapes neutral to externals.)

## Dependencies

Requires suit ≥ **0.7.0** (https://github.com/danmestas/suit/pull/26). The `enable:` / `disable:` schema and the symlink-farm filtering both ship in 0.7.

## Test plan

- [x] `npm run validate` (against local suit 0.7) — `OK (102 components, 7 warnings)` (pre-existing target-emit caveats)
- [ ] manual after suit 0.7 publishes: `npm run sync-globals -- --dry-run` produces a clean snapshot
- [ ] manual: `suit up --outfit frontend` results in tempdir without signoz/axiom/doppler MCPs
- [ ] manual: `suit up --outfit frontend --mode debugging` re-adds signoz/axiom (mode beats outfit)

## Companion

- ADR-0014 in suit: `docs/adr/0014-globals-targeting.md`