### PR TITLE
feat(v5): rename modes to cuts (companion to suit v0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wardrobe
 
-Dan's content monorepo for AI-coding harnesses. Outfits, modes, accessories,
+Dan's content monorepo for AI-coding harnesses. Outfits, cuts, accessories,
 skills, agents, hooks, rules, and commands — authored once in canonical
 formats and shipped to Claude Code, APM, Codex, Gemini CLI, Copilot CLI, and
 Pi via [`suit`](https://github.com/danmestas/suit).
@@ -16,7 +16,7 @@ launch a harness:
 ```bash
 npm install -g @agent-ops/suit
 suit init https://github.com/danmestas/wardrobe
-suit claude --outfit backend --mode focused
+suit claude --outfit backend --cut focused
 ```
 
 Or work against a local clone:
@@ -32,10 +32,10 @@ Layer accessories onto the session at invocation time. Accessories can be a cura
 
 ```bash
 # bundle accessory
-suit claude --outfit backend --mode debugging --accessory philosophy
+suit claude --outfit backend --cut debugging --accessory philosophy
 
 # singleton accessory — any component name resolves
-suit claude --outfit backend --mode executing --accessory pr-policy --accessory test-driven-development
+suit claude --outfit backend --cut executing --accessory pr-policy --accessory test-driven-development
 ```
 
 ## What's in here
@@ -43,23 +43,23 @@ suit claude --outfit backend --mode executing --accessory pr-policy --accessory 
 | Directory | What it contains |
 |---|---|
 | `outfits/` | Long-lived role bundles (aviation, backend, bones, code, frontend, kb, meta, personal, stasi) — set the baseline component set. Every outfit force-loads the universal core4: `writing-plans`, `brainstorming`, `subagent-driven-development`, `systematic-debugging`. |
-| `modes/` | Work-shape overlays (debugging, executing, focused, ops, planning, reviewing, ticketing, writing) — extend/override outfit components and inject a prompt body. |
+| `cuts/` | Work-shape overlays (debugging, design, executing, focused, ops, planning, reviewing, ticketing, wait-watch, writing) — extend/override outfit components and inject a prompt body. |
 | `accessories/` | Two layers: (a) curated multi-component bundles (philosophy, skill-author, vault, gh-project) live here as `accessory.md`; (b) any wardrobe component name (skill / hook / rule / agent / command) is also reachable via `--accessory <name>` through accessory-as-role fall-through (suit ≥ 0.6, ADR-0013). |
 | `skills/` | Flat shared pool of `SKILL.md` capabilities triggered by description. Carry a `category:` block per the 8-axis TAXONOMY. |
 | `agents/` | Subagent definitions (`AGENT.md`). |
 | `hooks/` | Event-driven scripts (`HOOK.md` entrypoint, payload alongside). |
-| `rules/` | Harness-native rules referenced by outfits/modes/accessories. Currently: `pr-policy`. |
+| `rules/` | Harness-native rules referenced by outfits/cuts/accessories. Currently: `pr-policy`. |
 | `commands/` | Slash commands (`COMMAND.md`). |
 | `docs/` | Authoring docs (TAXONOMY, CONVENTIONS, CONTEXT, contributing, GH project setup, plans, ADRs). |
 
 ## How content gets to your harness
 
-When you run `suit claude --outfit backend --mode focused`, suit:
+When you run `suit claude --outfit backend --cut focused`, suit:
 
 1. Starts with an empty component set.
 2. Applies the outfit (`outfits/backend/outfit.md`) → fills baseline.
-3. Applies the mode (`modes/focused/mode.md`) → merges/overrides components
-   plus injects the mode body as additional context.
+3. Applies the cut (`cuts/focused/cut.md`) → merges/overrides components
+   plus injects the cut body as additional context.
 4. Applies each `--accessory <name>` flag in order.
 5. Emits per-harness via existing adapters into a temp tree the harness
    reads at launch.
@@ -77,7 +77,7 @@ and layout decisions.
 This is Dan's personal/team config. To start your own:
 
 - Fork [`suit-template`](https://github.com/danmestas/suit-template) —
-  minimal starter with one outfit and one mode.
+  minimal starter with one outfit and one cut.
 - Or fork this repo as a richer starting point and trim what you don't want.
 - Or `suit init https://github.com/your-username/your-fork` once your fork
   exists.
@@ -103,7 +103,7 @@ category:
 
 - [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) — cross-cutting rules every component follows (fail-safe hooks, flat-line changelogs, `.agent-config/` state directory, cross-harness contract).
 - [`docs/TAXONOMY.md`](docs/TAXONOMY.md) — the 8-axis taxonomy (Economy, Workflow, BackPressure, Tooling, Integrations, ContextManagement, MemoryManagement, Evolution) used to classify and bundle components.
-- [`docs/CONTEXT.md`](docs/CONTEXT.md) — domain vocabulary (skill, outfit, mode, accessory, harness, adapter, prelaunch, suit session).
+- [`docs/CONTEXT.md`](docs/CONTEXT.md) — domain vocabulary (skill, outfit, cut, accessory, harness, adapter, prelaunch, suit session).
 - [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — how to run validation locally and submit a PR.
 
 ## Building
@@ -127,7 +127,7 @@ Each script invokes [`suit-build`](https://github.com/danmestas/suit) via `npx -
 server installed at *user scope* (read from
 `~/.claude/plugins/installed_plugins.json` for user-scope plugins, and
 `~/.claude.json`'s `mcpServers` block for MCPs). Suit (≥ v0.7) reads it so
-outfits, modes, and accessories can reference globals by name — enabling or
+outfits, cuts, and accessories can reference globals by name — enabling or
 disabling specific plugins/MCPs per session without uninstalling them.
 
 ```bash
@@ -139,7 +139,7 @@ npm run sync-globals -- --pr        # write, commit, push, open a PR via gh
 Run `npm run sync-globals` after installing or removing a plugin or MCP at
 user scope to refresh the registry, then open a PR (the `--pr` flag does
 this for you when `gh` is on PATH and the working tree is otherwise clean).
-Outfits, modes, and accessories opt into globals via `enable:` / `disable:`
+Outfits, cuts, and accessories opt into globals via `enable:` / `disable:`
 blocks naming registered entries — see ADR-0014 in the suit repo (Phase D
 of v0.7 wires the resolver). MCP entries record only non-secret metadata —
 stdio MCPs capture `command`, `args`, and a `has_env` flag; HTTP MCPs

--- a/cuts/debugging/cut.md
+++ b/cuts/debugging/cut.md
@@ -1,7 +1,7 @@
 ---
 name: debugging
-version: 1.1.1
-type: mode
+version: 1.1.2
+type: cut
 description: >-
   Hunting a bug — reproduce, minimize, hypothesise, instrument, fix,
   regression-test.
@@ -41,7 +41,7 @@ include:
 
 Hunting a bug. Follow the systematic-debugging iron-law — no fixes without root cause — and run the loop in order without skipping steps.
 
-You are in debugging mode. Enforce the systematic-debugging iron-law: no fixes
+You are in debugging cut. Enforce the systematic-debugging iron-law: no fixes
 without root cause. Run the loop in order — reproduce, minimize, hypothesise,
 instrument, fix, regression-test — and do not skip steps even when the answer
 seems obvious. A "probably this" patch without a verified repro is how regressions

--- a/cuts/design/cut.md
+++ b/cuts/design/cut.md
@@ -1,7 +1,7 @@
 ---
 name: design
-version: 1.0.0
-type: mode
+version: 1.0.1
+type: cut
 description: 'UI / UX work — visual hierarchy, accessibility, interaction polish.'
 targets:
   - claude-code
@@ -29,11 +29,11 @@ include:
   commands: []
 ---
 
-You're in design mode. The work is UI/UX-shaped — visual hierarchy, interaction patterns, accessibility, polish. You design before you implement: sketch the layout first, name the affordances, audit usability, then translate to code.
+You're in design cut. The work is UI/UX-shaped — visual hierarchy, interaction patterns, accessibility, polish. You design before you implement: sketch the layout first, name the affordances, audit usability, then translate to code.
 
 ## Tool ladder
 
-- **`ui-ux-pro-max`** (from the `frontend-design` plugin, force-loaded by this mode) — the go-to skill for end-to-end design passes. Most capable design surface available; use it as the default.
+- **`ui-ux-pro-max`** (from the `frontend-design` plugin, force-loaded by this cut) — the go-to skill for end-to-end design passes. Most capable design surface available; use it as the default.
 - **`norman`** — usability heuristics. Reach for this when reviewing or auditing: affordances, feedback, mapping, error prevention. Pairs with `ui-ux-pro-max` for the "is this design actually usable" check.
 - **`vitaly`** — accessibility-first form and component design. Use whenever the artifact has inputs, controls, or anything keyboard/screen-reader users will touch.
 - **`obsidian-markdown`** — capture decisions as you go. Callouts (`> [!warning]`, `> [!note]`) are the right shape for "we picked X over Y because Z" trade-off notes.

--- a/cuts/executing/cut.md
+++ b/cuts/executing/cut.md
@@ -1,7 +1,7 @@
 ---
 name: executing
-version: 1.1.1
-type: mode
+version: 1.1.2
+type: cut
 description: 'Working a plan — spawn subagents, dispatch parallel work, finish the branch.'
 targets:
   - claude-code
@@ -33,7 +33,7 @@ include:
 
 Working an existing plan. Move the plan forward — spawn subagents for parallelizable work, mark task list items complete as you go, and finish the branch when done.
 
-You are in executing mode. Follow the active plan; don't redesign it mid-flight
+You are in executing cut. Follow the active plan; don't redesign it mid-flight
 unless evidence forces a change, and even then surface the deviation explicitly.
 Spawn subagents for parallelizable work — research, multi-file edits, mechanical
 refactors, and broad searches all dispatch better than they execute inline.

--- a/cuts/focused/cut.md
+++ b/cuts/focused/cut.md
@@ -1,7 +1,7 @@
 ---
 name: focused
-version: 2.0.0
-type: mode
+version: 2.0.1
+type: cut
 description: Single-task deep focus, no scope creep.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [backpressure, workflow]
@@ -17,6 +17,6 @@ include:
 
 Single-task deep focus. Stay on the work in front of you and resist scope creep.
 
-You are in focused mode. Stay on the current task. Do not refactor adjacent code,
+You are in focused cut. Stay on the current task. Do not refactor adjacent code,
 do not propose unrelated improvements. If you notice something else, mention it
 in one line and move on.

--- a/cuts/ops/cut.md
+++ b/cuts/ops/cut.md
@@ -1,7 +1,7 @@
 ---
 name: ops
-version: 2.1.1
-type: mode
+version: 2.1.2
+type: cut
 description: Incident / infra change — observe before changing.
 targets:
   - claude-code
@@ -37,7 +37,7 @@ include:
 
 Incident or infra change work. Observe before changing — the cost of a bad action under pressure is always higher than the cost of pausing to look.
 
-You are in ops mode. Observe before changing. Take inventory first via `takeoff` —
+You are in ops cut. Observe before changing. Take inventory first via `takeoff` —
 read what's there before you touch anything. Pull metrics, traces, and logs to
 ground every hypothesis in evidence, not assumption. Prefer the smallest-blast-radius
 change that addresses the issue; staged rollouts and feature flags over wholesale

--- a/cuts/planning/cut.md
+++ b/cuts/planning/cut.md
@@ -1,7 +1,7 @@
 ---
 name: planning
-version: 1.1.1
-type: mode
+version: 1.1.2
+type: cut
 description: 'Designing before code — produce a plan, don''t write the implementation yet.'
 targets:
   - claude-code
@@ -32,7 +32,7 @@ include:
 
 Designing before code. The deliverable here is a plan, not an implementation — defer writing code until the shape of the work is clear.
 
-You are in planning mode. Plan only — do not write the implementation yet. Your
+You are in planning cut. Plan only — do not write the implementation yet. Your
 deliverable is a written plan: structure, components, interfaces, sequencing,
 trade-offs, open questions. Brainstorm the problem space before you settle on an
 approach; cheap exploration up front saves expensive rework downstream. When

--- a/cuts/reviewing/cut.md
+++ b/cuts/reviewing/cut.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing
-version: 1.1.1
-type: mode
+version: 1.1.2
+type: cut
 description: Code review — separate must-fix from suggestion.
 targets:
   - claude-code
@@ -36,7 +36,7 @@ include:
 
 Code review work — sending or receiving. Review in passes, separate must-fix from suggestion, and verify before declaring complete.
 
-You are in reviewing mode. Review in passes — correctness first, then design,
+You are in reviewing cut. Review in passes — correctness first, then design,
 then tests, then docs — so each pass has a single lens and findings don't blur
 together. Separate must-fix from suggestion explicitly; conflating the two
 costs the author trust and slows the next round. Apply Ousterhout-style

--- a/cuts/ticketing/cut.md
+++ b/cuts/ticketing/cut.md
@@ -1,7 +1,7 @@
 ---
 name: ticketing
-version: 1.0.0
-type: mode
+version: 1.0.1
+type: cut
 description: Issue / PR writing — produce tracer-bullet vertical slices.
 targets: [claude-code, apm, codex, gemini, copilot, pi]
 categories: [workflow, integrations]
@@ -17,7 +17,7 @@ include:
 
 Issue and PR writing. Produce tracer-bullet vertical slices — each ticket is independently grabbable, with clear acceptance criteria and links to the work it depends on.
 
-You are in ticketing mode. Produce tracer-bullet vertical slices: each issue
+You are in ticketing cut. Produce tracer-bullet vertical slices: each issue
 should be independently grabbable, end-to-end through the stack, and small
 enough that a single contributor can ship it without coordination. One
 independently-grabbable issue per ticket — no umbrellas, no "and then also" tails.

--- a/cuts/wait-watch/cut.md
+++ b/cuts/wait-watch/cut.md
@@ -1,7 +1,7 @@
 ---
 name: wait-watch
-version: 1.0.0
-type: mode
+version: 1.0.1
+type: cut
 description: >-
   Waiting on external events — polling CI, watching builds, monitoring long
   jobs.
@@ -24,7 +24,7 @@ include:
   commands: []
 ---
 
-You're in wait-watch mode. The session's job is to wait on something external (a build, a CI run, a deploy, a long-running job) and act when it completes. The hard part isn't the waiting — it's picking the right cadence so context stays warm and tokens don't burn.
+You're in wait-watch cut. The session's job is to wait on something external (a build, a CI run, a deploy, a long-running job) and act when it completes. The hard part isn't the waiting — it's picking the right cadence so context stays warm and tokens don't burn.
 
 ## Cadence rules
 
@@ -41,6 +41,7 @@ Don't think in round-number minutes — think in cache windows.
 - **`Monitor`** — stream events from a long-running process; each stdout line is a notification. Right for watching a tail-able log.
 - **`Bash` with `run_in_background: true`** — fire-and-forget; you get notified when the command exits. Right for one-shot completion (a build, a test run).
 - **`ScheduleWakeup`** (only inside `/loop` dynamic mode) — self-paced check-ins. Pass the same `/loop` prompt back; pick `delaySeconds` per the cadence rules above.
+
 - **`CronCreate`** — only for genuinely recurring tasks (every morning, every hour). Not for "check this build in 10 minutes."
 
 ## The reason field

--- a/cuts/writing/cut.md
+++ b/cuts/writing/cut.md
@@ -1,7 +1,7 @@
 ---
 name: writing
-version: 1.1.1
-type: mode
+version: 1.1.2
+type: cut
 description: Prose / KB notes / docs.
 targets:
   - claude-code
@@ -33,7 +33,7 @@ include:
 
 Prose, knowledge-base notes, and docs. Write for clarity, lead with the why, and keep it tight — terse complete sentences over flowery ones.
 
-You are in writing mode. Write for clarity. Lead with the why before the what —
+You are in writing cut. Write for clarity. Lead with the why before the what —
 readers landing cold need the motivation up front, not buried under context.
 Use callouts and wikilinks where the harness supports them so notes link
 into the broader graph rather than living as isolated artifacts. Keep it tight:

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -16,23 +16,23 @@ concept that future code should reference by name, add it here.
 - **outfit** — long-lived role bundle (e.g. backend, frontend, machines).
   Lives in `outfits/<name>/outfit.md`. Sets the baseline component set for
   a session.
-- **mode** — work-shape overlay (e.g. focused, code, design, ops). Lives
-  in `modes/<name>/mode.md`. Extends/overrides outfit components and
+- **cut** — work-shape overlay (e.g. focused, debugging, planning, ops). Lives
+  in `cuts/<name>/cut.md`. Extends/overrides outfit components and
   injects a prompt body.
 - **accessory** — small, named, repeatable add-on applied via
   `--accessory`. Lives in `accessories/<name>/accessory.md`.
 
-Resolution order at `suit` prelaunch: empty → outfit → mode → accessory…
+Resolution order at `suit` prelaunch: empty → outfit → cut → accessory…
 See suit ADR-0010 for the rename rationale and ADR-0011 for the layout.
 
 ## Build pipeline ([`suit`](https://github.com/danmestas/suit))
 
 The build pipeline lives in the standalone [`suit` repo](https://github.com/danmestas/suit). wardrobe invokes `suit-build <cmd>` via `npx`. Glossary of pipeline concepts:
 
-- **manifest** — the YAML frontmatter on a component (SKILL.md, AGENT.md, HOOK.md, RULES.md, COMMAND.md, outfit.md, mode.md, accessory.md).
+- **manifest** — the YAML frontmatter on a component (SKILL.md, AGENT.md, HOOK.md, RULES.md, COMMAND.md, outfit.md, cut.md, accessory.md).
 - **catalog** — the discovered set of components for a given harness home (e.g. `~/.claude/skills/`).
 - **harness** — a downstream agent runtime: `claude-code`, `apm`, `codex`, `gemini`, `copilot`, `pi`.
 - **adapter** — code that emits a component into one harness's expected layout. Lives in suit.
-- **resolution** — the outfit/mode/accessory-applied view of a catalog: which skills to drop, what mode prompt to inject. Computed and persisted by suit when callers (e.g. the `suit` launcher) need both.
+- **resolution** — the outfit/cut/accessory-applied view of a catalog: which skills to drop, what cut prompt to inject. Computed and persisted by suit when callers (e.g. the `suit` launcher) need both.
 - **suit session** — the lifecycle of one `suit <harness> ...` invocation. Stages, in order: (1) resolveTarget, (2) persistResolution, (3) prelaunchForTarget, (4) exec. Implemented in suit.
-- **prelaunch** — the harness-specific composition step that builds a temp HOME or package dir with outfit-/mode-/accessory-resolved components before spawning the harness binary.
+- **prelaunch** — the harness-specific composition step that builds a temp HOME or package dir with outfit-/cut-/accessory-resolved components before spawning the harness binary.

--- a/docs/plans/wardrobe-restructure-v3.md
+++ b/docs/plans/wardrobe-restructure-v3.md
@@ -1,4 +1,4 @@
-# Wardrobe restructure v3 — bullet-proof outfits/modes/accessories
+# Wardrobe restructure v3 — bullet-proof outfits/cuts/accessories
 
 Status: **Draft** — proposal for review.
 Date: 2026-05-04
@@ -13,7 +13,7 @@ Methodology: systematic-debugging + dx-audit, anchored on session-usage signal m
 | Bucket | Count | State |
 |---|---:|---|
 | outfits | 6 | aviation, backend, frontend, machines, personal, taxes |
-| modes | 4 | code, design, focused, ops |
+| cuts | 4 | code, design, focused, ops |
 | accessories | 0 | placeholder README only |
 | skills | 70 | flat pool, all `targets:` set, **0 categorized** |
 | agents | 6 | architect-review, code-reviewer, debugger, gh-project-expert, golang-pro, observability-engineer |
@@ -24,12 +24,12 @@ Methodology: systematic-debugging + dx-audit, anchored on session-usage signal m
 ### 1.2 Defects
 
 1. **Outfit `skill_include` is too narrow.** Every outfit force-loads 0–3 skills. Heavy-use skills (planning, brainstorming, debugging, subagent dispatch) are not in any outfit; they rely entirely on description matching. That's not bullet-proof — a session that doesn't surface the right description never loads them.
-2. **Modes are body-only.** ADR-0010 made `include:` first-class on modes; none of the 4 modes use it. Modes are just prompt injection.
+2. **Cuts are body-only.** ADR-0010 made `include:` first-class on cuts; none of the 4 cuts use it. Cuts are just prompt injection.
 3. **Zero accessories.** ADR-0010 made accessories first-class for piecemeal opt-in; none exist.
 4. **TAXONOMY unused.** `docs/TAXONOMY.md` defines 8 categories. 0 / 70 skills carry a `categories:` field; only outfits do (and inconsistently).
 5. **Stale outfits.** `aviation` and `taxes` have empty `skill_include`. `aviation` excludes nothing despite Dan having 4 active aviation repos.
 6. **Duplicate domains, missing roles.** No outfit for the bones orchestrator project (Dan's #1 active repo, 36 sessions). No outfit for KB authoring (12 sessions on Knowledge-Base alone). No outfit for wardrobe/suit/agent-skills meta-tooling work (~21 sessions across those repos).
-7. **Mode taxonomy doesn't match work shape.** `code` mode injects "you are in code mode" — that overlaps with what every outfit already implies. `ops` mode has no body in current files. Real work shapes that recur: planning, executing, debugging, reviewing, ticketing, writing.
+7. **Cut taxonomy doesn't match work shape.** `code` cut injects "you are in code cut" — that overlaps with what every outfit already implies. `ops` cut has no body in current files. Real work shapes that recur: planning, executing, debugging, reviewing, ticketing, writing.
 
 ### 1.3 Session-usage signal (last 60 days, 71 projects)
 
@@ -57,6 +57,8 @@ Methodology: systematic-debugging + dx-audit, anchored on session-usage signal m
 | 5 | systematic-debugging | 21 |
 | 6 | using-git-worktrees | 19 |
 | 7 | orchestrator-mode | 15 |
+
+(Note: `orchestrator-mode` is the literal skill name, not the wardrobe primitive.)
 | 8 | obsidian-markdown | 8 |
 | 9 | test-driven-development | 8 |
 | 10 | finishing-a-development-branch | 7 |
@@ -83,13 +85,13 @@ Every primitive needs a one-sentence test. If a thing doesn't fit a test, it doe
 | Primitive | Test |
 |---|---|
 | **outfit** | "What kind of project is this?" — domain bundle, set once per session, large (5–15 force-loaded skills + agents + hooks + rules). |
-| **mode** | "What shape of work am I doing right now?" — work-shape overlay, smaller (3–8 skills), can replace outfit components. Includes a prompt body that biases the session. |
+| **cut** | "What shape of work am I doing right now?" — work-shape overlay, smaller (3–8 skills), can replace outfit components. Includes a prompt body that biases the session. |
 | **accessory** | "What single capability or constraint do I want layered on top?" — repeatable, additive only, 1–4 components per accessory. |
 | **skill** | "What's a single capability triggered by description?" — flat pool. Categories are the only structural axis. |
 
 **Invariants:**
 1. Outfits never overlap in domain. One project = one outfit choice.
-2. Modes never overlap in work-shape. One session-time = one mode (can switch).
+2. Cuts never overlap in work-shape. One session-time = one cut (can switch).
 3. Accessories are commutative — order doesn't change semantics.
 4. The 4 universal skills (`writing-plans`, `brainstorming`, `subagent-driven-development`, `systematic-debugging`) are force-loaded by **every** outfit. No exceptions. This is the bullet-proof core.
 
@@ -123,9 +125,9 @@ Drop: `taxes` (folds into `personal`).
 - systematic-debugging
 ```
 
-### 3.2 Modes (8 — replaces current 4)
+### 3.2 Cuts (8 — replaces current 4)
 
-| Mode | "I am doing..." | `include` | Body bias |
+| Cut | "I am doing..." | `include` | Body bias |
 |---|---|---|---|
 | `focused` (keep) | one task, no scope creep | — | "stay on the task; mention adjacent issues in one line; don't refactor neighbors" |
 | `planning` | designing before code | brainstorming + writing-plans + grill-me + reflect | "plan only, don't write code yet; produce a deliverable plan; ask one question at a time" |
@@ -136,7 +138,7 @@ Drop: `taxes` (folds into `personal`).
 | `writing` | prose / KB notes / docs | obsidian-markdown + defuddle + brainstorming | "write for clarity; lead with the why; use callouts and wikilinks; keep it tight" |
 | `ops` (keep, populate) | incident / infra change | takeoff + signoz-dashboard-builder + investigating-agent-sessions + course-correct | "observe before changing; take inventory first (takeoff); pull metrics; smallest-blast-radius first" |
 
-Drop: `code`, `design` (collapse — `code` was just "you are coding" which every outfit already implies; `design` collapses into `frontend` + `writing` modes layered).
+Drop: `code`, `design` (collapse — `code` was just "you are coding" which every outfit already implies; `design` collapses into `frontend` + `writing` cuts layered).
 
 ### 3.3 Accessory-as-role (revised)
 
@@ -184,7 +186,7 @@ All 70 skills get a `categories:` field. Mapping (one-pass, draft):
 
 ### 3.5 Default-resolution heuristics
 
-Add a `--auto` mode to `suit up` that picks an outfit based on repo signal:
+Add a `--auto` flag to `suit up` that picks an outfit based on repo signal:
 
 | Signal | Picked outfit |
 |---|---|
@@ -206,14 +208,14 @@ Single coordinated PR, like ADR-0011 was. Phases inside the PR:
 
 1. **Phase A — taxonomy backfill.** Add `categories:` to all 70 skills via a script (one-pass mapping per §3.4, hand-correct the long tail). Land on `feat/v3-restructure` branch.
 2. **Phase B — outfit rewrite.** Rewrite the 6 existing outfit files to the new `skill_include` shape; add 2 new outfits (`bones`, `kb`, `meta`); delete `taxes`.
-3. **Phase C — mode rewrite.** Drop `code` and `design`. Keep `focused`, populate `ops`. Add 6 new modes (`planning`, `executing`, `debugging`, `reviewing`, `ticketing`, `writing`). Each gets `include:` per §3.2.
+3. **Phase C — cut rewrite.** Drop `code` and `design`. Keep `focused`, populate `ops`. Add 6 new cuts (`planning`, `executing`, `debugging`, `reviewing`, `ticketing`, `writing`). Each gets `include:` per §3.2.
 4. **Phase D — accessories.** Create 10 accessory dirs with `accessory.md` per §3.3. Includes `rules/` fragments for `pr-policy` (this requires `rules/` to actually have content for the first time — write the PR-policy rule directly).
-5. **Phase E — validation.** Run `suit list outfits|modes|accessories` against the rewritten wardrobe and verify discovery. Run `suit show outfit <name>` for each. Run `suit prelaunch --dry-run` to confirm strict-include resolution doesn't break.
+5. **Phase E — validation.** Run `suit list outfits|cuts|accessories` against the rewritten wardrobe and verify discovery. Run `suit show outfit <name>` for each. Run `suit prelaunch --dry-run` to confirm strict-include resolution doesn't break.
 6. **Phase F — docs.** Update `wardrobe/README.md` "What's in here" table. Update `docs/TAXONOMY.md` if any category got dropped. Add `docs/COMPOSITION.md` documenting the scope rules from §2.
 
 **Suit-side change required:** the accessory-as-role behavior (§3.3) is **not** in the current resolver. ADR-0013 (in suit) documents the change; suit/src/lib/accessory.ts grows fall-through resolution; suit version bumps to 0.6.0. Wardrobe v3 PR depends on suit 0.6.0 being merged + released first.
 
-**Risk:** strict `include:` will fail prelaunch if a referenced skill name is wrong. Mitigation: a single `suit doctor`-like script that walks every outfit/mode/accessory and verifies all `include:` references resolve to a wardrobe component. Run it as the last step of phase E; gate the merge on a clean pass.
+**Risk:** strict `include:` will fail prelaunch if a referenced skill name is wrong. Mitigation: a single `suit doctor`-like script that walks every outfit/cut/accessory and verifies all `include:` references resolve to a wardrobe component. Run it as the last step of phase E; gate the merge on a clean pass.
 
 ---
 


### PR DESCRIPTION
Companion to [suit#XX](https://github.com/danmestas/suit/pulls). Same metaphor argument: `cut` reinforces the outfit/cut/accessory tailoring vocabulary; `mode` was a generic CS term that broke it.

## Changes

- `modes/` → `cuts/` (10 entries: debugging, design, executing, focused, ops, planning, reviewing, ticketing, wait-watch, writing). `git mv` preserves blame.
- Each `mode.md` → `cut.md`. Frontmatter `type: mode` → `type: cut`. Patch versions bumped.
- Body text "you are in <X> mode" → "you are in <X> cut".
- README + CONTEXT + restructure plan updated.

## Borderline calls

- `orchestrator-mode` skill name kept (literal identifier).
- `context-mode` plugin name kept (different concept).
- `/loop dynamic mode` (Claude Code feature) kept.
- Auto-generated components table left to regenerate via `npm run docs` once suit 0.9.0 publishes.

## Validation

`OK (108 components, 11 warnings)` against local suit 0.9.0 build. Pre-existing warnings only.

## CI expectation

CI uses `npx -y -p @agent-ops/suit` which pulls `latest` from npm — currently 0.8.3 (which only knows `type: mode`). CI will fail until suit 0.9.0 merges + publishes. Re-run after publish.