### PR TITLE
feat(skills): spy-on-bones-session 0.2 — JSONL-first + hook-protocol checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ harness adapter changes, taxonomy shifts. The format is loosely based on
 - All outfits referencing `idiomatic-go` (backend, bones, personal, kb,
   aviation, frontend's exclude, engineer's vs-comparison prose) updated to
   `golang-patterns`.
+- `skills/spy-on-bones-session` bumped 0.1.0 → 0.2.0 from lessons learned
+  running an end-to-end spy on `serverdom`. Adds: hook-protocol verification
+  sub-phase (catches the SessionStart `--json` envelope-shape bug class
+  before Phase 4); network-egress check on the bones hub process; explicit
+  "JSONL-is-the-truth, tmux capture is screen buffer" stance; a high-value
+  first-calls playbook (start `bones tasks watch --json` BEFORE anything
+  else; enumerate every subcommand `--help`); operator-coaching block on
+  REPL-only slash commands (`/doctor`, `claude doctor` TUI hangs on
+  redirect); idle-operator handling so a no-show doesn't burn three
+  9-minute `harness-listen` timeouts; an optional Phase 7 architectural
+  reflection that mandates source-grounded path:line citations via Explore
+  subagent rather than behavior-only speculation; new "What I did NOT
+  exercise" section in the report template (typical spy hits ~15% of bones
+  surface area). Adds 5 entries to Common mistakes table covering each
+  pattern.
 
 ### BREAKING
 

--- a/skills/spy-on-bones-session/SKILL.md
+++ b/skills/spy-on-bones-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spy-on-bones-session
-version: 0.1.0
+version: 0.2.0
 description: >-
   Audit how bones behaves on a target project by fingerprinting <project>
   before and after `bones up`, capturing `bones status` plus any other state
@@ -98,7 +98,10 @@ fingerprint flow; ask the user how to proceed.
 Same captures as Phase 1, into `after/`. Plus bones-specific state:
 
 - `bones status` (full output, not abbreviated)
-- `bones tasks prime --json` if the subcommand exists in this version
+- `bones tasks status` — note that this verb lazy-starts the hub even
+  when `bones status` does not. Record the divergence.
+- `bones tasks prime --json` — this is what the SessionStart hook
+  invokes; capture it now and inspect the output shape
 - `bones swarm status` if available
 - `<project>/.bones/` — `find ... -type f -exec stat ... \;` for every file
 - Tail (last 50 lines) of every `<project>/.bones/*.log` and `<project>/.orchestrator/*.log`
@@ -107,12 +110,69 @@ Same captures as Phase 1, into `after/`. Plus bones-specific state:
   `hooks` — diffed against `before/`
 - `ps` again to see new bones-related processes
 - New transcript files in `~/.claude/projects/-...<project encoded>/`
+- **Network egress check:** `lsof -c bones -i TCP | grep ESTABLISHED`
+  — enumerate non-localhost outbound connections. Some are
+  one-shot-at-hub-init and disappear quickly, so capture twice (now
+  and again at the end of Phase 4). Reverse-DNS / whois any non-trivial
+  remote IPs and note them as findings if undisclosed in `bones up` output.
+- **Hook-protocol shape check:** for each command bones installed in
+  `.claude/settings.json` hooks, dry-run it directly and verify its
+  stdout is wrapped in Claude Code's hook protocol envelope —
+  `{"hookSpecificOutput":{"hookEventName":"...","additionalContext":"..."}}`.
+  Bare JSON like `{"open_tasks":[]...}` is silently discarded by
+  Claude Code, so a hook that emits raw structured data is functionally
+  dead. (See "Hook-protocol verification" sub-phase below.)
 
 Compute diffs into `after/diffs/`:
 - `diff before/files.txt after/files.txt` → files added/removed
 - `diff before/settings.json after/settings.json` → config bones rewrote
 
+### Sub-phase: Hook-protocol verification
+
+After Phase 3, before Phase 4, do this one-shot check — the
+bones SessionStart hook is a high-value, easy-to-miss bug
+surface:
+
+```sh
+# 1. Run the hook command standalone and inspect its output
+bones tasks prime --json | jq '.'
+
+# 2. The output MUST be shaped like:
+# {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}
+# If it's instead {"open_tasks":[],"peers":[...],...} — bones has no envelope
+# and Claude Code will drop the output entirely. That's a P1 finding.
+```
+
+If the operator then opens a Claude session and you find the new
+transcript JSONL, you can confirm the diagnosis directly:
+
+```sh
+TX=$(ls -t ~/.claude/projects/-...<project>/*.jsonl | head -1)
+# Grep the aggregated context for any token from bones' output:
+grep -c 'open_tasks' "$TX"   # 0 = bones output never made it into agent context
+```
+
 ## Phase 4 — Spy the live session
+
+### JSONL is the truth, not tmux
+
+`tmux capture-pane` shows you the screen buffer — lines wrap, content
+scrolls past, `[from %59]`-style prompt-injections collapse onto one
+line. **The transcript JSONL at
+`~/.claude/projects/-<encoded-project-path>/<session-uuid>.jsonl` is
+the authoritative record.** Default to JSONL-first analysis:
+
+- After every operator tool-use, jq the corresponding line and read
+  the actual `tool_use_result.content` rather than scrolling tmux.
+- Hook attachments are JSONL events with `attachment.hookEvent`,
+  `attachment.stdout`, `attachment.exitCode`. They never appear on
+  the user's screen — only the JSONL has them.
+- If the JSONL and `tmux capture-pane` disagree, JSONL wins.
+
+Use tmux capture only for "what does the operator currently see in
+their input box" — never for analysis.
+
+### Operator handoff
 
 Tell the operator (verbatim or close):
 
@@ -121,18 +181,41 @@ Tell the operator (verbatim or close):
 > you're done, or if you hit something that feels wrong — I want to
 > hear about it as it happens, not after."
 
-Find the new transcript JSONL the moment it appears. The encoded
-path replaces `/` with `-` and prefixes with `-`:
+Find the new transcript JSONL the moment it appears:
 
 ```
 TX_DIR=~/.claude/projects/$(echo "<project>" | tr / -)
 ls -t "$TX_DIR"/*.jsonl | head -1
 ```
 
-Watch live. Use the harness `Monitor` tool on the new JSONL — each
-new event arrives as a notification. In parallel, also Monitor:
-- `<project>/.bones/*.log` (hub log, swarm log, anything appending)
+### High-value first calls
+
+Before letting the operator drive freely, get these captures —
+they prove or disprove the most common bones bugs in seconds:
+
+1. **`bones tasks watch --json` running BEFORE anything else.**
+   Have the operator (or you) launch it in a backgrounded shell and
+   tee output to a file. Every event from then on lands in that
+   stream. Without this you can only post-hoc reconstruct the event
+   stream from snapshots — which is exactly the lossy reconstruction
+   bones itself does in `bones status`.
+2. **The hook-protocol check from Phase 3** — confirm the
+   SessionStart additionalContext does or does not include bones'
+   priming output. (Do this in the new Claude session's transcript
+   too, not just standalone.)
+3. **`bones --help` AND `bones <verb> --help` for every verb you
+   care about.** The top-level `--help` hides a lot; rich filters
+   only appear under `bones tasks list --help`, `bones tasks claim
+   --help`, etc. Discoverability gaps are themselves findings.
+
+### Watch live
+
+In parallel, also Monitor:
+- `<project>/.bones/*.log` (hub log, swarm log, anything appending) —
+  caveat: bones v0.12 hub logs lifecycle-only, so silence here is
+  expected and is itself a finding (no RPC audit trail)
 - `<project>/.orchestrator/*.log` if present
+- The operator's transcript JSONL (each new event is a notification)
 
 For every event observed, classify into one of three buckets and
 write to `findings.md` immediately (don't batch — memory rots fast):
@@ -154,6 +237,43 @@ Each finding gets:
 - Expected (what should have happened)
 - Repro hint (minimal steps if obvious)
 
+### Operator coaching
+
+Things the operator (and you) cannot do — set expectations early so
+you don't burn 3+ minutes finding out:
+
+- **Slash commands (`/doctor`, `/clear`, `/compact`, etc.) are
+  REPL-only.** They can't be invoked from a tool call, can't be
+  redirected to a file, won't fall through to a subprocess. If you
+  need data from one — e.g. the "Found N settings issues" detail
+  from `/doctor` — ask the operator to run it by hand, ESC out of
+  the TUI, and paste the relevant lines into a file under
+  `/tmp/spy-…/`.
+- **`claude doctor` (the shell subcommand) is an interactive TUI
+  too**, not a redirect-friendly CLI. It will hang on `> /tmp/...`
+  redirection. Same workaround.
+- **`harness-tell` injects literal text into the input box.** Slash
+  commands typed there ARE recognized by Claude Code, but it's the
+  same as the operator typing them — no scripting around the TUI.
+
+### What to do if the operator stays idle
+
+If the operator goes idle for 10+ minutes after the handoff (e.g.
+the orchestrator's "they're about to run X" never materializes), you
+have two options:
+
+1. **Drive small read-only tasks yourself.** Send the operator
+   (or run yourself out-of-band) a sequence of bones verbs that
+   exercise lifecycle: `tasks create / claim / show / close / list
+   / watch`. You'll find the bulk of the daily-driver bugs without
+   needing the operator's specific workflow.
+2. **Skip to Phase 5–6 cleanly.** A spy report from Phases 1–3 +
+   self-driven verb sweep is still useful. State explicitly in the
+   report what was *not* exercised so the reader knows the gaps.
+
+Do not wait indefinitely. Burning a 9-minute `harness-listen`
+timeout three times is not investigation, it's stalling.
+
 ## Phase 5 — Quiescence sanity check
 
 When the operator pauses or finishes, run `bones status` again and
@@ -161,6 +281,9 @@ compare to Phase 3. Anything that drifted unexpectedly (orphan
 processes, leftover holds, stale tasks, missing artifacts) is a
 finding. Also `lsof` any long-lived bones processes — held files in
 `~/.Trash/` or in deleted state dirs are a known orphan pattern.
+
+Re-run the network egress check — note any outbound connections
+that appeared/disappeared since Phase 3.
 
 ## Phase 6 — Report
 
@@ -193,10 +316,35 @@ bones <version> · <OS> · project type · git HEAD <sha>
 ### Improvements
 …
 
+## What I did NOT exercise
+- List untouched verbs (swarm dispatch / join / fanin / reap, tasks
+  link / autoclaim / compact / aggregate, repo / sync / bridge /
+  notify / plan / apply / logs / workspaces, the PreCompact hook,
+  multi-peer flow, `bones doctor`, etc.).
+- A normal spy covers ~15% of bones' surface area. Be honest about
+  the gap.
+
 ## Hand-off
 Next: `superpowers:systematic-debugging` on the P0/P1 bugs, then
 `to-issues` to file. Workspace at /tmp/spy-…/ for raw evidence.
 ```
+
+## Phase 7 — Architectural reflection (only if asked)
+
+If the user requests an architectural reflection / root-cause
+clustering / "why are these bugs related," the answer must be
+source-grounded, not behavior-grounded:
+
+- Spawn an Explore subagent on `/Users/dmestas/projects/bones`
+  with the specific bugs and a path:line-required output format.
+  Behavior alone can't tell you "is this two bugs in different
+  call sites or one upstream bug?" — only the source can.
+- Cite `path:line` for every architectural claim. Quote source
+  comments where authors have already named the design choice
+  (e.g. `cli/status.go` has a comment that admits the missing
+  event log — that's gold).
+- Verify "X-line fix" claims against actual code before publishing.
+  Behavioral observation rarely tells you fix size; code does.
 
 ## Discipline
 
@@ -217,6 +365,8 @@ This skill inherits the read-only mindset and verification rules from
 - **Operator-nuke-instinct is itself a finding.** If the operator
   reaches for a "blow it all away" recovery, the underlying tool is
   missing a recovery affordance. File that as an improvement.
+- **Verify fix-size claims against source.** "5-line fix" is a claim
+  the source has to back. If you didn't read it, don't say it.
 
 ## Common mistakes
 
@@ -224,7 +374,12 @@ This skill inherits the read-only mindset and verification rules from
 |---|---|
 | Fingerprinting only `.bones/` | Also check `.claude/`, `.orchestrator/`, `.fossil/`, `.worktrees/`, project root, transcript dir |
 | Watching only the JSONL | Tail bones-side logs in parallel — sometimes the bug is hub-side, never surfaces in the session |
+| Trusting `tmux capture-pane` over the transcript JSONL | tmux is screen buffer (line-truncated, scroll-bound). The JSONL is authoritative. Default to JSONL-first analysis. |
 | Reporting "operator got confused" without a root cause | Trace to a specific bones output / missing prompt / unclear status — that's the real finding |
 | Forgetting to pin bones version | Capture `bones --version` in Phase 1 *and* Phase 3 — version may change mid-session if `bones up` self-updates |
 | Letting the operator finish before opening `findings.md` | Capture live; details fade in minutes |
 | Confusing existing repo state with bones-added state | The Phase-1 fingerprint is what disambiguates — don't skip it because the project "looks clean" |
+| Asking the operator to "redirect /doctor output" to a file | `/doctor` is REPL-only and `claude doctor` is a TUI. Both will hang on redirect. Have the operator paste output by hand. |
+| Conflating "bones SessionStart hook fired" with "its output reached the agent" | Hook firing means exit-code 0 and stdout captured. Output reaching the agent requires `hookSpecificOutput` envelope shape. Verify with `grep` of the new transcript's `additionalContext`. |
+| Calling fixes "X lines" without verifying against source | Behavioral observation rarely tells you fix size. Spawn an Explore agent or read the source before claiming. |
+| Waiting indefinitely for an idle operator | After 10 min idle, drive read-only verbs yourself or skip to Phase 5–6. Stalling on `harness-listen` timeouts is not investigation. |


### PR DESCRIPTION
## Summary

- Bumps `skills/spy-on-bones-session` to 0.2.0 from lessons running an end-to-end spy on serverdom (full audit at `/tmp/spy-audit/FINAL-ISSUES.md`).
- Catches the SessionStart `--json` envelope-shape bug class in Phase 3 instead of post-mortem; mandates JSONL-over-tmux as the source of truth; adds idle-operator escape hatch and an optional Phase 7 reflection that requires source-grounded path:line citations.
- CHANGELOG entry under `[Unreleased] ### Changed`.

## Test plan

- [x] `npm run validate` passes locally (110 components, 12 pre-existing warnings, exit 0)
- [x] `npm run build -- --target all --dry-run` passes locally (143 files across 6 targets, exit 0)
- [x] Body content identical between wardrobe canonical and `~/.claude/skills/spy-on-bones-session/SKILL.md` (sha-verified)
- [ ] CI green