### PR TITLE
feat(wardrobe): Phase 2/4/5 — quick outfit + orchestrator-suit skill + taxonomy v2 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,36 @@ harness adapter changes, taxonomy shifts. The format is loosely based on
   <project>." Tools with their own spy skill (e.g.
   `spy-on-bones-session`) keep precedence; this picks up everything
   else. Tagged `primary: evolution`, `secondary: [tooling, backpressure]`.
+- **Taxonomy v2: role / stack / accessory** — Phase 1+2+4+5 of the
+  orchestrator-driven wardrobe rollout (see
+  `docs/plans/2026-05-08-orchestrator-driven-wardrobe.md`). Adds:
+  - 6 role outfits (`implementer`, `reviewer`, `planner`, `spy`,
+    `orchestrator`, `quick`) — outfit now answers "who you are."
+    `quick` uses the new `compose:` field (suit ≥ 0.10.0) to union
+    implementer + planner + reviewer for solo flow.
+  - 5 stack cuts (`go-backend`, `ts-frontend`, `python-data`,
+    `infra-cloudflare`, `bones-tooling`) — cut now answers "what
+    tech stack."
+  - 3 project context accessories (`project-bones`,
+    `project-serverdom`, `project-dagnats`) — accessory now carries
+    "where you are." Prefix `project-` avoids name collision with
+    the existing `bones` outfit (suit's namespace is flat).
+  - `skills/orchestrator-suit` — documents the spawn loop the
+    orchestrator outfit relies on: receive intent → classify → spawn
+    role-shaped child via stateless `suit claude` piped through
+    `harness-spawn --cmd` → monitor → cherry-pick → escalate → audit
+    log. Briefs are saved artifacts under `.scion/briefs/` or
+    `<workspace>/.orchestrator/briefs/`. Brief wins on conflict with
+    the role outfit's standing instructions.
+  - AGENTS.md gains a "Taxonomy v2" section documenting the new axes
+    and the venn-diagram composition algebra. v1 domain outfits and
+    postural cuts stay alive untouched; deprecation is a follow-up
+    plan after 2-3 real orchestrated runs land.
+
+  Compatible with `@agent-ops/suit` ≥ 0.10.0 (which ships the
+  composer venn algebra: `+`, `-` by name, `-` by `tag:<name>`).
+  Phase 3 (agent-harness `--cmd` flag) and Phase 6 (E2E proof) ship
+  separately.
 
 ### Changed
 

--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -204,3 +204,47 @@ This gives a one-command read on posture along any axis. Combined with `--catego
 - **Where `context-mode` lives.** Listed as `primary: tooling, secondary: [economy]`. Reasonable case for the inverse (`primary: economy, secondary: [tooling]`) since the *motivating* concern is window cost. Final tag is a judgement call for the retag PR.
 - **Evolution scope.** Defined here as observation → eval → proposal. Whether Evolution skills *apply* changes (mutate other skills directly) or only *propose* them (write to a queue for human review) is left to the Evolution spec doc.
 - **Functional vs category plugin overlap.** `software-philosophy` (functional) overlaps with `backpressure-essentials` (category). Both can coexist; consumers pick by intent. No deduplication required.
+
+---
+
+## Section 6: Composition axes — outfit / cut / accessory (v2)
+
+The 8-category taxonomy above describes how we *tag* individual components. The **composition axes** describe how outfits, cuts, and accessories assemble those tagged components into a session config. Two parallel models live in the repo today:
+
+| Layer | v1 (domain-shaped) | v2 (role-shaped) |
+|---|---|---|
+| **Outfit** | Domain you work in (`backend`, `frontend`, `kb`, `bones`, `aviation`, `meta`, `personal`, `stasi`) | Who you are (`implementer`, `reviewer`, `planner`, `spy`, `orchestrator`, `quick`) |
+| **Cut** | Postural overlay (`planning`, `reviewing`, `executing`, `focused`, `debugging`, `wait-watch`, …) | Tech stack you're working on (`go-backend`, `ts-frontend`, `python-data`, `infra-cloudflare`, `bones-tooling`) |
+| **Accessory** | Curated behavior bundle (`philosophy`, `vault`, `gh-project`, `linear`, `skill-author`) | All of v1, *plus* project context (`project-bones`, `project-serverdom`, `project-dagnats`) |
+
+v1 stays alive for **solo dressing** (one operator playing all roles serially in a single session); v2 is for **orchestrator-driven multi-pane work** (one orchestrator session dispatching role-shaped subharness children). They coexist; pick the layer that matches the use case.
+
+The `project-` prefix on v2 project accessories avoids name collision with v1 domain outfits — suit's component namespace is flat, so `bones` outfit and `bones` accessory cannot coexist; `project-bones` does.
+
+### Venn-diagram composition (suit ≥ 0.10.0)
+
+Outfits can declare a `compose:` field with set operators on other outfits:
+
+```yaml
+compose:
+  - implementer + planner + reviewer  # union skills from three role outfits
+  - implementer - tag:research        # remove anything tagged research
+```
+
+`+` unions skills/accessories/hooks. `-` removes by name or by freeform `tag:<name>` (matches against each skill's `tags` array — orthogonal to the 8-category taxonomy above, which uses `category.primary` / `category.secondary`). Operators apply only to *sets* — system-prompt prose only unions, in declared order, with brief-wins on conflict per the orchestrator-suit skill's precedence rule.
+
+Resolution is lazy in-memory at `suit claude` / `suit up` time — no DB, no cache. Forward-compat: unknown outfit operands and unknown tags resolve to empty sets; a typo in `compose:` doesn't fail the build.
+
+### Orchestrator-driven spawn
+
+`skills/orchestrator-suit/SKILL.md` documents the loop. Short version: the orchestrator session in the `orchestrator` outfit dispatches role-shaped children via:
+
+```bash
+PANE=$(harness-spawn claude --cwd <project> \
+  --cmd "suit claude --outfit implementer --cut go-backend --accessory project-bones \
+    -- --append-system-prompt-file .scion/briefs/<task-id>-implementer.md")
+```
+
+Stateless suit (`suit claude`, not `suit up`) means multiple roles can target the same project simultaneously without `.claude/` write contention. Briefs are saved files under `.scion/briefs/` (or `<workspace>/.orchestrator/briefs/`), not regenerated prose — same brief = reproducible child. The `--cmd` flag on `harness-spawn` is added in agent-harness Phase 3 of the rollout (until then, manual two-step in the same skill body).
+
+For the full implementation arc and rollout plan: `docs/plans/2026-05-08-orchestrator-driven-wardrobe.md`.

--- a/outfits/quick/outfit.md
+++ b/outfits/quick/outfit.md
@@ -1,0 +1,36 @@
+---
+name: quick
+version: 0.1.0
+type: outfit
+description: Quick generalist outfit composed from implementer + planner + reviewer for solo flow. Use when working alone on a small task and the role keeps shifting. For orchestrated multi-pane work, use the individual role outfits instead — quick is the v2 generalist replacement for v1 domain outfits.
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+categories:
+  - workflow
+  - evolution
+  - backpressure
+disable:
+  plugins:
+    - frontend-design
+    - frontend-design-codex
+    - swift-lsp
+  mcps: []
+  hooks: []
+skill_include: []
+skill_exclude: []
+compose:
+  - implementer + planner + reviewer
+---
+
+# Quick Outfit
+
+Solo generalist mode. You play implementer, planner, and reviewer as the work shape demands. The compose expression unions the skill sets of all three role outfits, so you get TDD discipline, planning thinking, and review lenses without committing to a single role posture.
+
+For orchestrated multi-pane work, use the role-specific outfits instead — `quick` is for the case where you're alone and the role keeps shifting. When orchestrated, role boundaries matter (the planner shouldn't implement, the implementer shouldn't redesign); when solo, the boundaries blur and that's fine.
+
+Pair with a stack cut (e.g. `--cut go-backend`) and a project accessory (e.g. `--accessory project-bones`) for a fully-dressed solo session.

--- a/skills/orchestrator-suit/SKILL.md
+++ b/skills/orchestrator-suit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: orchestrator-suit
+version: 0.1.0
+type: skill
+description: Use when you are the orchestrator session driving role-shaped subharness children. Loads when the orchestrator outfit is active. Documents the spawn loop — receive intent → classify → spawn role-shaped child via stateless suit + harness-spawn → monitor → cherry-pick worktree → escalate → audit log. Triggers on "orchestrate", "dispatch a worker", "spawn an implementer / reviewer / planner / spy", "run the multi-role pipeline", "drive child harnesses", "spawn a worker session".
+targets:
+  - claude-code
+  - apm
+  - codex
+  - gemini
+  - copilot
+  - pi
+category:
+  primary: workflow
+  secondary:
+    - integrations
+---
+
+# Orchestrator (suit-driven)
+
+You drive subharness children — implementer, reviewer, planner, spy — via stateless suit launches passed through harness-spawn. You do not write code, run tests, or implement features. If you reach for Edit / Write / Bash to do worker-shaped work, stop and dispatch a subharness instead.
+
+## The loop
+
+1. **Receive intent.** Read the operator's request fully. Identify success criteria, minimal deliverable, explicit out-of-scope.
+2. **Classify.** Light (single role, single dispatch) or heavy (multi-role pipeline)?
+3. **Compose the brief.** Write a task brief to `.scion/briefs/<task-id>-<role>.md` (or `<workspace>/.orchestrator/briefs/` if `.scion/` doesn't exist) capturing intent, context, acceptance criteria. Same brief = same child behavior; diffable across runs.
+4. **Spawn the child.** For each role needed, in sequence:
+   ```bash
+   PANE=$(harness-spawn claude --cwd <project> --cmd "suit claude --outfit <role> --cut <stack> --accessory project-<name> -- --append-system-prompt-file .scion/briefs/<task-id>-<role>.md")
+   ```
+5. **Monitor.** `harness-listen` for the child's Stop event. Read output via `tmux capture-pane -t $PANE -p`, but treat the transcript JSONL at `~/.claude/projects/-<encoded>/<session>.jsonl` as authoritative (`tmux` is a screen buffer; the JSONL has hooks, tool results, full content).
+6. **Cherry-pick.** Pull the child's commits into the orchestrator's working branch.
+7. **Dispatch next.** Implementer → reviewer → … per the pipeline.
+8. **Escalate batched decisions.** Decisions outside the brief route back to the operator.
+
+## Precedence rule
+
+When the role outfit's standing instructions and the task brief conflict, the **brief wins**. The brief is more recent, more specific, more authorised. Document the override in the brief itself for audit clarity.
+
+## Briefs as artifacts
+
+Briefs are saved files, not regenerated prose. `.scion/briefs/<task-id>-<role>.md`. This makes orchestration reproducible and auditable: re-running the same task spawns a child with the same context. Don't paraphrase a brief at spawn time — write the brief once, point the spawn at the file path.
+
+## Stateless not stateful
+
+Always use `suit claude --outfit X` (stateless) for child spawns, never `suit up --outfit X` (stateful). Stateful writes the project's `.claude/` tree, which races when two children of different roles target the same project simultaneously. Stateless composes config in memory and bypasses the write entirely — multiple panes, multiple roles, same project, no contention.
+
+## Audit log
+
+Append a JSON line per dispatch / classification / escalation to `.scion/audit.jsonl` (or `<workspace>/.orchestrator/audit.jsonl`). Format: RFC3339 timestamp, decision_id UUID, pane_id, role, brief path, outcome.
+
+```bash
+echo '{"ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","decision_id":"'$(uuidgen)'","pane":"'$PANE'","role":"implementer","brief":".scion/briefs/T-42-implementer.md","outcome":"dispatched"}' >> .scion/audit.jsonl
+```
+
+## Cross-vendor diversity (optional)
+
+The bones / darkish-factory pattern uses claude for implementer + codex for verifier/reviewer to get cross-vendor second opinions. Suit composition supports this: spawn the implementer with `suit claude --outfit implementer --cut <stack>`, and the reviewer with `suit codex --outfit reviewer --cut <stack>`. Same role outfit, different harness — the YAML is target-list-aware and emits the right config per harness.
+
+## What this skill is NOT
+
+- Not a substitute for darkish-factory's container-based orchestrator (`orchestrator-mode` skill); that one runs containerised workers, this one runs tmux-pane workers via suit composition.
+- Not the same as `subagent-driven-development`; that's for in-process subagents within one session, this is for cross-pane subharnesses across multiple sessions.
+- Not for running the pipeline yourself in a turn. **Dispatch.** Don't implement.
+
+## Reading the substrate
+
+- The full implementation plan: `wardrobe/docs/plans/2026-05-08-orchestrator-driven-wardrobe.md`
+- Role outfits: `wardrobe/outfits/{implementer,reviewer,planner,spy,orchestrator,quick}/outfit.md`
+- Stack cuts: `wardrobe/cuts/{go-backend,ts-frontend,python-data,infra-cloudflare,bones-tooling}/cut.md`
+- Project accessories: `wardrobe/accessories/project-{bones,serverdom,dagnats}/accessory.md`
+- Composer venn algebra (what `compose:` does): suit ≥ 0.10.0
+- Harness spawn with `--cmd` flag: agent-harness (Phase 3 of the plan; check `harness-spawn --help`)
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Writing code as the orchestrator | Stop. Dispatch an implementer subharness instead. |
+| Using `suit up` for child spawns | Use `suit claude --outfit X --cut Y --accessory Z` (stateless). `suit up` writes to project `.claude/` and races multi-role-per-project. |
+| Regenerating briefs from scratch each spawn | Write briefs to disk under `.scion/briefs/` or `.orchestrator/briefs/`. Same brief = reproducible child. |
+| Trusting `tmux capture-pane` over the JSONL transcript | tmux is screen buffer; JSONL has hooks, tool results, full content. JSONL wins. |
+| Pasting role instructions in the spawn brief | Role instructions live in the role outfit's body. The brief carries TASK context only. |
+| Spawning all children in parallel by default | Sequential pipeline (plan → impl → review) is usually right. Parallel only when tasks are truly independent. |


### PR DESCRIPTION
## Summary

Wraps up the wardrobe side of the orchestrator-driven refactor now that suit ≥ 0.10.0 ships the venn-diagram composer:

- **`outfits/quick`** — composes `implementer + planner + reviewer` for solo flow (the cross-role generalist that replaces v1 domain outfits when you don't want to commit to a single role posture). Uses suit ≥ 0.10.0's new `compose:` field.
- **`skills/orchestrator-suit`** — documents the spawn loop the orchestrator outfit relies on. Receive intent → classify → spawn role-shaped child via stateless `suit claude` piped through `harness-spawn --cmd` → monitor → cherry-pick → escalate → audit log. Briefs are saved artifacts under `.scion/briefs/` or `<workspace>/.orchestrator/briefs/`. Brief wins on conflict with the role outfit's standing instructions.
- **`TAXONOMY.md` Section 6** — documents v1 vs v2 composition axes side-by-side, the venn algebra, the orchestrator spawn pattern, and the `project-` prefix convention. (AGENTS.md is a build artifact and gitignored — TAXONOMY.md is the source-of-truth doc for composition.)
- **`CHANGELOG.md`** entry covers Phases 1+2+4+5 of the rollout.

## What's still deferred

- **Phase 3** (agent-harness `--cmd` flag) — independent repo (agent-harness), separate PR. The orchestrator-suit skill references `--cmd` in its spawn examples; until Phase 3 lands, the operator can substitute the manual two-step (`harness-spawn claude` → `harness-tell suit-claude-cmd`) documented in the same skill body.
- **Phase 6** (E2E proof — re-run the bones spy on serverdom through the new role chain) — behavioral session, not a PR.

## Test plan

- [x] `npm run validate` green: 126 components (was 124), 13 warnings (12 pre-existing + 1 new `orchestrator-suit on copilot emits with caveats` matching every other skill on copilot)
- [x] `npm run build -- --target all --dry-run` green: 150 files (was 144; +6 = orchestrator-suit emitting per-target adapter files for 6 targets)
- [x] `outfits/quick` validates with `compose: [implementer + planner + reviewer]` against the suit @ 0.10.0 composer (cleared npx cache locally; CI will pull fresh)
- [ ] CI green