### PR TITLE
docs(plans): permissions-system implementation plan

### DIFF
--- a/docs/plans/2026-05-11-permissions-system.md
+++ b/docs/plans/2026-05-11-permissions-system.md
@@ -2,18 +2,21 @@
 
 > **For agentic workers:** Use `subagent-driven-development` (recommended) or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This plan spans two repos; respect the **phase gate** at the end of Phase 1.
 
-**Goal:** Let wardrobe outfits (and later cuts/accessories) author a `permissions:` block in frontmatter that suit composes and emits as harness-native permission config for Claude Code, Codex, Gemini, and Pi.
+**Goal:** Let wardrobe outfits author a `permissions:` block in frontmatter that suit emits verbatim into each target harness's native permission config file.
 
-**Architecture:** Hybrid schema — a thin LCD (`mode`, `bash_allow`, `mcp.<server>.{enabled,enabled_tools,disabled_tools}`) compiles per-harness; a per-target passthrough block (`permissions.claude.*`, `permissions.codex.*`, etc.) is emitted verbatim and deep-merged over the LCD output. Missing block = no emit (harness defaults apply). Suit ships the schema + 4 adapter emitters first; wardrobe adds the first canary outfit after suit releases.
+**Architecture:** Pure passthrough. The `permissions:` block has four opaque sub-fields — `claude`, `codex`, `gemini`, `pi` — each deep-merged verbatim into the target's native config file via a shared `applyPassthroughPermissions` helper. No LCD vocabulary; authors write each harness's native syntax directly. Missing block (or missing target sub-block) = no emit, harness defaults apply.
+
+**Rationale for passthrough-only (v1):** An LCD vocabulary (`mode` / `bash_allow` / `mcp.*`) was sketched and rejected after Ousterhout review. The proposed verbs covered too little of real-world permission semantics to be a deep abstraction; the bulk of authoring would have fallen through to passthrough anyway, with surprise merge precedence between LCD-compiled output and passthrough overrides. The LCD was also a leaky abstraction — e.g. Claude's `defaultMode='default'` and Codex's `approval_policy='on-request'` don't mean the same thing mechanically, so any mapping table would have misled authors. LCD verbs may be promoted in v2 once ≥3 outfits author permissions and a real repeat pattern emerges.
 
 **Tech Stack:** TypeScript, Zod v4, Vitest (suit). YAML frontmatter, markdown (wardrobe).
 
-**Scope:** Outfits only in v1. Cuts/accessories declaring `permissions:` is a deliberate non-goal — schema validation will reject for now, to be lifted in v2 once the merge-precedence question is resolved.
+**Scope:** Outfits only in v1. Cuts/accessories declaring `permissions:` will fail validation (Zod `.strict()`) — composition semantics for layered permission merges are deferred to v2.
 
 **Non-goals:**
-- Cut/accessory `permissions:` blocks (v2)
+- Cut/accessory `permissions:` blocks
+- LCD / unified rule vocabulary across harnesses
+- Cross-harness rule translation (Claude `Bash(npm run *)` → Codex `prefix_rules` etc.) — write both if you want both
 - Migrating the existing evolution-detector (`suit/src/lib/evolution/permissions.ts`) into the new pipeline
-- Auto-translating Claude wildcards into Codex prefix rules — out of scope; passthrough handles that
 
 ---
 
@@ -23,18 +26,18 @@
 
 | File | Responsibility | Action |
 |---|---|---|
-| `src/lib/schema.ts` | Zod schemas for component frontmatter | Modify — add `PermissionsBlockSchema`, attach to `OutfitSchema` only |
+| `src/lib/schema.ts` | Zod schemas for component frontmatter | Modify — add `PermissionsBlockSchema` (4 opaque fields), attach to `OutfitSchema` only |
 | `src/lib/types.ts` | Type exports | Modify — export `PermissionsBlock` type |
-| `src/adapters/claude-code.ts` | Emit Claude Code artifacts | Modify — add `emitPermissions` helper, merge into `.claude/settings.fragment.json` |
-| `src/adapters/codex.ts` | Emit Codex artifacts | Modify — emit permissions into `codex.config.toml` |
-| `src/adapters/gemini.ts` | Emit Gemini artifacts | Modify — emit into `.gemini/settings.fragment.json` + warnings for unmapped LCD |
-| `src/adapters/pi.ts` | Emit Pi artifacts | Modify — emit `--tools` flag template into a new `.pi/permissions.json` + warnings |
-| `src/lib/resolution.ts` | Layer-merge outfit/cut/accessory | No change expected — verify `deepMerge` already covers `permissions` |
-| `src/tests/adapters/permissions/` | Test fixtures for permission emit | Create — one fixture per adapter, golden-file pattern |
-| `src/tests/adapters/claude-code.test.ts` | Existing tests | Modify — add permissions cases |
-| `src/tests/adapters/codex.test.ts` | Existing tests | Modify — add permissions cases |
-| `src/tests/adapters/gemini.test.ts` | Existing tests | Modify — add permissions cases |
-| `src/tests/adapters/pi.test.ts` | Existing tests | Modify — add permissions cases |
+| `src/adapters/_permissions.ts` | Shared passthrough emit helper | Create — single deep module: `applyPassthroughPermissions(permissions, target, destination)` |
+| `src/adapters/claude-code.ts` | Emit Claude Code artifacts | Modify — one-line call to helper, merge into `.claude/settings.fragment.json` |
+| `src/adapters/codex.ts` | Emit Codex artifacts | Modify — one-line call, merge into `codex.config.toml` |
+| `src/adapters/gemini.ts` | Emit Gemini artifacts | Modify — one-line call, merge into `.gemini/settings.fragment.json` |
+| `src/adapters/pi.ts` | Emit Pi artifacts | Modify — write `permissions.pi` verbatim to `.pi/permissions.json` |
+| `src/lib/resolution.ts` | Layer-merge outfit/cut/accessory | No change expected — `permissions` only on outfits in v1 |
+| `src/tests/schema.permissions.test.ts` | Schema tests | Create |
+| `src/tests/adapters/_permissions.test.ts` | Helper tests | Create |
+| `src/tests/adapters/permissions/<target>-basic/` | Golden fixtures per target | Create (4 fixture dirs) |
+| `src/tests/adapters/{claude-code,codex,gemini,pi}.test.ts` | Existing adapter tests | Modify — add one passthrough case each |
 
 ### wardrobe repo (`/Users/dmestas/projects/wardrobe`)
 
@@ -42,19 +45,20 @@
 |---|---|---|
 | `outfits/backend/outfit.md` | Canary outfit with first `permissions:` block | Modify |
 | `docs/HARNESS_INTEGRATION.md` | Authoring docs for component frontmatter | Modify — add `permissions:` field documentation |
-| `docs/plans/2026-05-11-permissions-system.md` | This plan | Create |
+| `docs/plans/2026-05-11-permissions-system.md` | This plan | Create (this file) |
 
 ---
 
-## Phase 1 — suit: schema + adapters + tests
+## Phase 1 — suit: schema + shared helper + 4 adapter wirings + tests
 
 > **Repo:** `/Users/dmestas/projects/suit`. Branch off `main`: `git checkout -b feat/permissions-block`.
 
-### Task 1: Define `PermissionsBlockSchema` in suit `[slot: any]`
+### Task 1: Define `PermissionsBlockSchema` (passthrough-only)  `[slot: any]`
 
 **Files:**
-- Modify: `src/lib/schema.ts` (insert before `ManifestBaseSchema` definition at line ~58)
+- Modify: `src/lib/schema.ts` (insert before `ManifestBaseSchema` at line ~58)
 - Modify: `src/lib/types.ts` (add type export at end of file)
+- Create: `src/tests/schema.permissions.test.ts`
 
 - [ ] **Step 1: Write the failing test**
 
@@ -65,33 +69,28 @@ import { describe, expect, it } from 'vitest';
 import { PermissionsBlockSchema } from '../lib/schema.js';
 
 describe('PermissionsBlockSchema', () => {
-  it('accepts a fully-populated LCD + passthrough block', () => {
+  it('accepts an empty block', () => {
+    expect(() => PermissionsBlockSchema.parse({})).not.toThrow();
+  });
+
+  it('accepts all four target sub-blocks with opaque content', () => {
     const input = {
-      mode: 'default',
-      bash_allow: ['git', 'npm'],
-      mcp: {
-        signoz: { enabled: true, enabled_tools: ['signoz_search_logs'] },
-      },
-      claude: { allow: ['Bash(git status:*)'], deny: [] },
-      codex: { sandbox_mode: 'workspace-write' },
-      gemini: { security: { folderTrust: { enabled: true } } },
+      claude: { allow: ['Bash(git status:*)'], deny: ['Bash(rm -rf:*)'] },
+      codex: { sandbox_mode: 'workspace-write', rules: { prefix_rules: [{ prefix: 'git ' }] } },
+      gemini: { security: { folderTrust: { enabled: true } }, mcpServers: { signoz: { enabled: true } } },
       pi: { tools: ['read', 'bash'] },
     };
     expect(() => PermissionsBlockSchema.parse(input)).not.toThrow();
   });
 
-  it('rejects unknown LCD mode values', () => {
-    expect(() => PermissionsBlockSchema.parse({ mode: 'nope' })).toThrow();
+  it('rejects unknown top-level keys (no LCD vocabulary in v1)', () => {
+    expect(() => PermissionsBlockSchema.parse({ mode: 'default' })).toThrow();
+    expect(() => PermissionsBlockSchema.parse({ bash_allow: ['git'] })).toThrow();
+    expect(() => PermissionsBlockSchema.parse({ mcp: {} })).toThrow();
   });
 
-  it('accepts an empty block', () => {
-    expect(() => PermissionsBlockSchema.parse({})).not.toThrow();
-  });
-
-  it('treats passthrough targets as opaque (accepts unknown keys)', () => {
-    expect(() =>
-      PermissionsBlockSchema.parse({ claude: { foo: { bar: 1 } } }),
-    ).not.toThrow();
+  it('rejects null target blocks', () => {
+    expect(() => PermissionsBlockSchema.parse({ claude: null })).toThrow();
   });
 });
 ```
@@ -106,19 +105,8 @@ Expected: FAIL with "PermissionsBlockSchema is not exported"
 In `src/lib/schema.ts`, add before `ManifestBaseSchema`:
 
 ```typescript
-const McpServerPermissionSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    enabled_tools: z.array(z.string()).optional(),
-    disabled_tools: z.array(z.string()).optional(),
-  })
-  .strict();
-
 export const PermissionsBlockSchema = z
   .object({
-    mode: z.enum(['default', 'accept-edits', 'plan', 'yolo']).optional(),
-    bash_allow: z.array(z.string()).optional(),
-    mcp: z.record(z.string(), McpServerPermissionSchema).optional(),
     claude: z.record(z.string(), z.unknown()).optional(),
     codex: z.record(z.string(), z.unknown()).optional(),
     gemini: z.record(z.string(), z.unknown()).optional(),
@@ -129,7 +117,7 @@ export const PermissionsBlockSchema = z
 export type PermissionsBlock = z.infer<typeof PermissionsBlockSchema>;
 ```
 
-In `src/lib/types.ts`, add at the bottom:
+In `src/lib/types.ts`, append:
 
 ```typescript
 export type { PermissionsBlock } from './schema.js';
@@ -144,15 +132,15 @@ Expected: PASS (4 tests)
 
 ```bash
 git add src/lib/schema.ts src/lib/types.ts src/tests/schema.permissions.test.ts && \
-git commit -m "feat(schema): add PermissionsBlockSchema for outfit frontmatter"
+git commit -m "feat(schema): add PermissionsBlockSchema (passthrough-only)"
 ```
 
 ---
 
-### Task 2: Attach `permissions:` to `OutfitSchema` only (reject on cut/accessory) `[slot: any]`
+### Task 2: Attach `permissions:` to `OutfitSchema` only  `[slot: any]`
 
 **Files:**
-- Modify: `src/lib/schema.ts:122` (OutfitSchema), `src/lib/schema.ts:140` (CutSchema), `src/lib/schema.ts:155` (AccessorySchema)
+- Modify: `src/lib/schema.ts` (OutfitSchema at line ~122; CutSchema and AccessorySchema unchanged — `.strict()` will reject)
 
 - [ ] **Step 1: Write the failing test**
 
@@ -162,23 +150,35 @@ Append to `src/tests/schema.permissions.test.ts`:
 import { OutfitSchema, CutSchema, AccessorySchema } from '../lib/schema.js';
 
 describe('Permissions attachment', () => {
-  const base = { name: 'x', version: '0.0.1', description: 'd', type: 'outfit' };
+  const base = { name: 'x', version: '0.0.1', description: 'd' };
 
   it('outfit accepts permissions block', () => {
     expect(() =>
-      OutfitSchema.parse({ ...base, type: 'outfit', permissions: { mode: 'default' } }),
+      OutfitSchema.parse({
+        ...base,
+        type: 'outfit',
+        permissions: { claude: { allow: [] } },
+      }),
     ).not.toThrow();
   });
 
   it('cut rejects permissions block in v1', () => {
     expect(() =>
-      CutSchema.parse({ ...base, type: 'cut', permissions: { mode: 'default' } }),
+      CutSchema.parse({
+        ...base,
+        type: 'cut',
+        permissions: { claude: { allow: [] } },
+      }),
     ).toThrow();
   });
 
   it('accessory rejects permissions block in v1', () => {
     expect(() =>
-      AccessorySchema.parse({ ...base, type: 'accessory', permissions: { mode: 'default' } }),
+      AccessorySchema.parse({
+        ...base,
+        type: 'accessory',
+        permissions: { claude: { allow: [] } },
+      }),
     ).toThrow();
   });
 });
@@ -187,11 +187,11 @@ describe('Permissions attachment', () => {
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/tests/schema.permissions.test.ts`
-Expected: FAIL (outfit case fails — `permissions` not recognized)
+Expected: FAIL (outfit case — `permissions` not yet recognized)
 
 - [ ] **Step 3: Implement**
 
-In `src/lib/schema.ts`, modify `OutfitSchema` (around line 122) to extend with `permissions`:
+In `src/lib/schema.ts`, extend `OutfitSchema` only:
 
 ```typescript
 export const OutfitSchema = ManifestBaseSchema.extend({
@@ -201,12 +201,12 @@ export const OutfitSchema = ManifestBaseSchema.extend({
 }).strict();
 ```
 
-CutSchema and AccessorySchema remain unchanged — Zod's `.strict()` will reject unknown `permissions` keys.
+CutSchema and AccessorySchema remain unchanged — `.strict()` rejects unknown `permissions` keys automatically.
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run src/tests/schema.permissions.test.ts`
-Expected: PASS (7 tests total)
+Expected: PASS (7 tests total across both describes)
 
 - [ ] **Step 5: Verify whole-repo validation still works**
 
@@ -222,15 +222,101 @@ git commit -m "feat(schema): attach permissions block to outfit only (v1 scope)"
 
 ---
 
-### Task 3: Claude Code adapter — emit LCD + passthrough `[slot: any]`
+### Task 3: Shared `applyPassthroughPermissions` helper  `[slot: any]`
+
+This is the single deep module the four adapters share. It hides the "is the block present?", "is the target sub-block present?", and "deep-merge into destination" steps behind a one-line call.
+
+**Files:**
+- Create: `src/adapters/_permissions.ts`
+- Create: `src/tests/adapters/_permissions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/adapters/_permissions.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { applyPassthroughPermissions } from '../../adapters/_permissions.js';
+
+describe('applyPassthroughPermissions', () => {
+  it('returns destination unchanged when permissions is undefined', () => {
+    const dest = { existing: 'value' };
+    expect(applyPassthroughPermissions(undefined, 'claude', dest)).toEqual({ existing: 'value' });
+  });
+
+  it('returns destination unchanged when target sub-block is missing', () => {
+    const dest = { existing: 'value' };
+    expect(applyPassthroughPermissions({ codex: { sandbox_mode: 'x' } }, 'claude', dest)).toEqual({ existing: 'value' });
+  });
+
+  it('deep-merges the target sub-block into the destination', () => {
+    const dest = { permissions: { allow: ['Bash(git:*)'] } };
+    const result = applyPassthroughPermissions(
+      { claude: { permissions: { allow: ['Bash(npm:*)'], deny: ['Bash(rm:*)'] } } },
+      'claude',
+      dest,
+    );
+    expect(result).toEqual({
+      permissions: { allow: ['Bash(git:*)', 'Bash(npm:*)'], deny: ['Bash(rm:*)'] },
+    });
+  });
+
+  it('does not mutate the destination object', () => {
+    const dest = { existing: 'value' };
+    applyPassthroughPermissions({ claude: { added: 'new' } }, 'claude', dest);
+    expect(dest).toEqual({ existing: 'value' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/adapters/_permissions.test.ts`
+Expected: FAIL with "Cannot find module '../../adapters/_permissions.js'"
+
+- [ ] **Step 3: Implement helper**
+
+Create `src/adapters/_permissions.ts`:
+
+```typescript
+import type { Target } from '../lib/types.js';
+import type { PermissionsBlock } from '../lib/schema.js';
+import { deepMerge } from '../lib/merge.js';
+
+export function applyPassthroughPermissions(
+  permissions: PermissionsBlock | undefined,
+  target: Target,
+  destination: Record<string, unknown>,
+): Record<string, unknown> {
+  const block = permissions?.[target];
+  if (!block) return destination;
+  return deepMerge(destination, block) as Record<string, unknown>;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/adapters/_permissions.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adapters/_permissions.ts src/tests/adapters/_permissions.test.ts && \
+git commit -m "feat(adapters): add applyPassthroughPermissions shared helper"
+```
+
+---
+
+### Task 4: Wire Claude Code adapter  `[slot: any]`
 
 **Files:**
 - Modify: `src/adapters/claude-code.ts` (existing `emitSettings` around line ~99)
-- Create: `src/tests/adapters/permissions/claude-code-basic/outfit.md` (fixture)
-- Create: `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settings.fragment.json` (golden)
+- Create: `src/tests/adapters/permissions/claude-code-basic/outfit.md`
+- Create: `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settings.fragment.json`
 - Modify: `src/tests/adapters/claude-code.test.ts`
 
-- [ ] **Step 1: Write the fixture**
+- [ ] **Step 1: Create the fixture**
 
 Create `src/tests/adapters/permissions/claude-code-basic/outfit.md`:
 
@@ -242,16 +328,14 @@ description: fixture
 type: outfit
 targets: [claude]
 permissions:
-  mode: default
-  bash_allow: [git, npm]
-  mcp:
-    signoz:
-      enabled: true
-      enabled_tools: [signoz_search_logs]
   claude:
-    allow: ["Bash(go test:*)"]
-    deny: ["Bash(rm -rf:*)"]
-    additionalDirectories: ["~/src"]
+    allow:
+      - "Bash(git status:*)"
+      - "mcp__signoz__signoz_search_logs"
+    deny:
+      - "Bash(rm -rf:*)"
+    additionalDirectories:
+      - "~/src"
 ---
 ```
 
@@ -260,8 +344,7 @@ Create `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settin
 ```json
 {
   "permissions": {
-    "defaultMode": "default",
-    "allow": ["Bash(git:*)", "Bash(npm:*)", "mcp__signoz__signoz_search_logs", "Bash(go test:*)"],
+    "allow": ["Bash(git status:*)", "mcp__signoz__signoz_search_logs"],
     "deny": ["Bash(rm -rf:*)"],
     "additionalDirectories": ["~/src"]
   }
@@ -270,10 +353,10 @@ Create `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settin
 
 - [ ] **Step 2: Write the failing test**
 
-In `src/tests/adapters/claude-code.test.ts`, add:
+In `src/tests/adapters/claude-code.test.ts`, append:
 
 ```typescript
-it('emits permissions block — LCD compile + passthrough merge', async () => {
+it('emits permissions.claude verbatim into settings fragment', async () => {
   const result = await runGolden(
     claudeCodeAdapter,
     path.join(HERE, 'permissions/claude-code-basic'),
@@ -284,52 +367,34 @@ it('emits permissions block — LCD compile + passthrough merge', async () => {
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions block"`
+Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions.claude"`
 Expected: FAIL (no permissions emitted)
 
-- [ ] **Step 4: Implement `compilePermissions` helper**
+- [ ] **Step 4: Wire the helper**
 
-In `src/adapters/claude-code.ts`, add before `emitSettings`:
+In `src/adapters/claude-code.ts`, import the helper at the top:
 
 ```typescript
-function compileClaudePermissions(p: PermissionsBlock | undefined): Record<string, unknown> | undefined {
-  if (!p) return undefined;
-  const allow: string[] = [];
-  const ask: string[] = [];
-  const deny: string[] = [];
-  const out: Record<string, unknown> = {};
-
-  if (p.mode) out.defaultMode = p.mode;
-  if (p.bash_allow) for (const cmd of p.bash_allow) allow.push(`Bash(${cmd}:*)`);
-  if (p.mcp) {
-    for (const [server, cfg] of Object.entries(p.mcp)) {
-      if (cfg.enabled === false) deny.push(`mcp__${server}`);
-      for (const tool of cfg.enabled_tools ?? []) allow.push(`mcp__${server}__${tool}`);
-      for (const tool of cfg.disabled_tools ?? []) deny.push(`mcp__${server}__${tool}`);
-    }
-  }
-  if (allow.length) out.allow = allow;
-  if (ask.length) out.ask = ask;
-  if (deny.length) out.deny = deny;
-
-  // Passthrough — deep-merge target-specific block on top
-  if (p.claude) {
-    const merged = deepMerge(out, p.claude) as Record<string, unknown>;
-    // additionalDirectories lives at the top level of permissions in Claude
-    return merged;
-  }
-  return out;
-}
+import { applyPassthroughPermissions } from './_permissions.js';
 ```
 
-In the `emitSettings` function, merge `compileClaudePermissions(component.manifest.permissions)` into the `permissions` key of the settings fragment.
+Inside the function that builds the settings fragment object (find `emitSettings` or the `.claude/settings.fragment.json` writer), after the existing settings object is built and before it's serialized:
+
+```typescript
+const withPermissions = applyPassthroughPermissions(
+  component.manifest.permissions,
+  'claude',
+  settings,
+);
+// ...then serialize `withPermissions` instead of `settings`.
+```
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions block"`
+Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions.claude"`
 Expected: PASS
 
-- [ ] **Step 6: Run all Claude adapter tests for regressions**
+- [ ] **Step 6: Run all Claude adapter tests**
 
 Run: `npx vitest run src/tests/adapters/claude-code.test.ts`
 Expected: PASS (all)
@@ -338,19 +403,20 @@ Expected: PASS (all)
 
 ```bash
 git add src/adapters/claude-code.ts src/tests/adapters/claude-code.test.ts src/tests/adapters/permissions/claude-code-basic && \
-git commit -m "feat(adapter/claude): emit permissions block to settings fragment"
+git commit -m "feat(adapter/claude): emit permissions.claude into settings fragment"
 ```
 
 ---
 
-### Task 4: Codex adapter — emit LCD + passthrough `[slot: any]`
+### Task 5: Wire Codex adapter  `[slot: any]`
 
 **Files:**
 - Modify: `src/adapters/codex.ts`
-- Create: `src/tests/adapters/permissions/codex-basic/{outfit.md, expected/codex.config.toml}`
+- Create: `src/tests/adapters/permissions/codex-basic/outfit.md`
+- Create: `src/tests/adapters/permissions/codex-basic/expected/codex.config.toml`
 - Modify: `src/tests/adapters/codex.test.ts`
 
-- [ ] **Step 1: Write the fixture**
+- [ ] **Step 1: Create the fixture**
 
 Create `src/tests/adapters/permissions/codex-basic/outfit.md`:
 
@@ -362,15 +428,17 @@ description: fixture
 type: outfit
 targets: [codex]
 permissions:
-  mode: default
-  bash_allow: [git, npm]
-  mcp:
-    signoz:
-      enabled: true
-      enabled_tools: [signoz_search_logs]
   codex:
-    sandbox_mode: workspace-write
     approval_policy: on-request
+    sandbox_mode: workspace-write
+    rules:
+      prefix_rules:
+        - prefix: "git "
+        - prefix: "npm "
+    mcp_servers:
+      signoz:
+        enabled: true
+        enabled_tools: ["signoz_search_logs"]
 ---
 ```
 
@@ -393,10 +461,10 @@ enabled_tools = ["signoz_search_logs"]
 
 - [ ] **Step 2: Write the failing test**
 
-In `src/tests/adapters/codex.test.ts`, add:
+In `src/tests/adapters/codex.test.ts`, append:
 
 ```typescript
-it('emits permissions block — bash_allow → prefix_rules, mcp passthrough', async () => {
+it('emits permissions.codex verbatim into codex.config.toml', async () => {
   const result = await runGolden(codexAdapter, path.join(HERE, 'permissions/codex-basic'));
   expect(result.diff).toEqual([]);
 });
@@ -404,42 +472,29 @@ it('emits permissions block — bash_allow → prefix_rules, mcp passthrough', a
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions block"`
+Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions.codex"`
 Expected: FAIL
 
-- [ ] **Step 4: Implement `compileCodexPermissions`**
+- [ ] **Step 4: Wire the helper**
 
-In `src/adapters/codex.ts`, add:
+In `src/adapters/codex.ts`, import and apply before serializing to TOML:
 
 ```typescript
-function compileCodexPermissions(p: PermissionsBlock | undefined): Record<string, unknown> | undefined {
-  if (!p) return undefined;
-  const out: Record<string, unknown> = {};
-  const codexModeMap: Record<string, string> = {
-    'default': 'on-request',
-    'accept-edits': 'on-request',
-    'plan': 'untrusted',
-    'yolo': 'never',
-  };
-  if (p.mode) out.approval_policy = codexModeMap[p.mode];
-  if (p.bash_allow) {
-    out.rules = { prefix_rules: p.bash_allow.map((cmd) => ({ prefix: `${cmd} ` })) };
-  }
-  if (p.mcp) {
-    out.mcp_servers = Object.fromEntries(
-      Object.entries(p.mcp).map(([k, v]) => [k, { ...v }]),
-    );
-  }
-  // Codex passthrough deep-merged last (overrides LCD)
-  return p.codex ? (deepMerge(out, p.codex) as Record<string, unknown>) : out;
-}
+import { applyPassthroughPermissions } from './_permissions.js';
+
+// ...inside the function that builds the codex config object, before TOML.stringify:
+const configWithPermissions = applyPassthroughPermissions(
+  component.manifest.permissions,
+  'codex',
+  config,
+);
 ```
 
-Wire into the TOML emit path in `codex.ts` (look for `codex.config.toml` emission).
+Note: deep-merge into the in-memory config object before TOML serialization. Existing TOML writer handles the rest.
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions block"`
+Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions.codex"`
 Expected: PASS
 
 - [ ] **Step 6: Run all Codex adapter tests**
@@ -451,19 +506,20 @@ Expected: PASS (all)
 
 ```bash
 git add src/adapters/codex.ts src/tests/adapters/codex.test.ts src/tests/adapters/permissions/codex-basic && \
-git commit -m "feat(adapter/codex): emit permissions block to codex.config.toml"
+git commit -m "feat(adapter/codex): emit permissions.codex into codex.config.toml"
 ```
 
 ---
 
-### Task 5: Gemini adapter — partial LCD + passthrough + warnings `[slot: any]`
+### Task 6: Wire Gemini adapter  `[slot: any]`
 
 **Files:**
 - Modify: `src/adapters/gemini.ts`
-- Create: `src/tests/adapters/permissions/gemini-basic/{outfit.md, expected/.gemini/settings.fragment.json}`
+- Create: `src/tests/adapters/permissions/gemini-basic/outfit.md`
+- Create: `src/tests/adapters/permissions/gemini-basic/expected/.gemini/settings.fragment.json`
 - Modify: `src/tests/adapters/gemini.test.ts`
 
-- [ ] **Step 1: Write the fixture**
+- [ ] **Step 1: Create the fixture**
 
 Create `src/tests/adapters/permissions/gemini-basic/outfit.md`:
 
@@ -475,14 +531,13 @@ description: fixture
 type: outfit
 targets: [gemini]
 permissions:
-  mode: default
-  bash_allow: [git, npm]
-  mcp:
-    signoz:
-      enabled: false
   gemini:
+    general:
+      defaultApprovalMode: default
     security:
       folderTrust: { enabled: true }
+    mcpServers:
+      signoz: { enabled: true }
 ---
 ```
 
@@ -490,82 +545,46 @@ Create `src/tests/adapters/permissions/gemini-basic/expected/.gemini/settings.fr
 
 ```json
 {
-  "general": {
-    "defaultApprovalMode": "default"
-  },
-  "mcpServers": {
-    "signoz": {
-      "enabled": false
-    }
-  },
-  "security": {
-    "folderTrust": {
-      "enabled": true
-    }
-  }
+  "general": { "defaultApprovalMode": "default" },
+  "security": { "folderTrust": { "enabled": true } },
+  "mcpServers": { "signoz": { "enabled": true } }
 }
 ```
 
 - [ ] **Step 2: Write the failing test**
 
-In `src/tests/adapters/gemini.test.ts`, add:
+In `src/tests/adapters/gemini.test.ts`, append:
 
 ```typescript
-it('emits permissions — mode mapped, mcp passthrough, bash_allow warned', async () => {
-  const warnings: string[] = [];
-  const result = await runGolden(geminiAdapter, path.join(HERE, 'permissions/gemini-basic'), {
-    onWarn: (m: string) => warnings.push(m),
-  });
+it('emits permissions.gemini verbatim into .gemini/settings.fragment.json', async () => {
+  const result = await runGolden(geminiAdapter, path.join(HERE, 'permissions/gemini-basic'));
   expect(result.diff).toEqual([]);
-  expect(warnings.some((w) => /bash_allow.*ignored/.test(w))).toBe(true);
 });
 ```
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions"`
+Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions.gemini"`
 Expected: FAIL
 
-- [ ] **Step 4: Implement `compileGeminiPermissions`**
+- [ ] **Step 4: Wire the helper**
 
-In `src/adapters/gemini.ts`, add:
+In `src/adapters/gemini.ts`, import and apply before serializing the settings fragment:
 
 ```typescript
-function compileGeminiPermissions(
-  p: PermissionsBlock | undefined,
-  warn: (m: string) => void,
-): Record<string, unknown> | undefined {
-  if (!p) return undefined;
-  const out: Record<string, unknown> = {};
-  const modeMap: Record<string, string> = {
-    'default': 'default',
-    'accept-edits': 'auto_edit',
-    'plan': 'plan',
-    'yolo': 'yolo',
-  };
-  if (p.mode) out.general = { defaultApprovalMode: modeMap[p.mode] };
-  if (p.bash_allow?.length) {
-    warn(`gemini: bash_allow [${p.bash_allow.join(', ')}] ignored — Gemini has no per-command rule grammar`);
-  }
-  if (p.mcp) {
-    out.mcpServers = Object.fromEntries(
-      Object.entries(p.mcp).map(([k, v]) => [k, { enabled: v.enabled }]),
-    );
-    for (const [server, cfg] of Object.entries(p.mcp)) {
-      if (cfg.enabled_tools || cfg.disabled_tools) {
-        warn(`gemini: mcp.${server} tool-level allow/deny ignored — Gemini gates at server level only`);
-      }
-    }
-  }
-  return p.gemini ? (deepMerge(out, p.gemini) as Record<string, unknown>) : out;
-}
-```
+import { applyPassthroughPermissions } from './_permissions.js';
 
-Thread the adapter's warning sink through `emit()`. If no warning sink exists yet, add one to `AdapterContext` (`src/lib/types.ts`).
+// ...inside the settings-fragment build path:
+const settingsWithPermissions = applyPassthroughPermissions(
+  component.manifest.permissions,
+  'gemini',
+  settings,
+);
+```
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions"`
+Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions.gemini"`
 Expected: PASS
 
 - [ ] **Step 6: Run all Gemini adapter tests**
@@ -576,20 +595,23 @@ Expected: PASS (all)
 - [ ] **Step 7: Commit**
 
 ```bash
-git add src/adapters/gemini.ts src/tests/adapters/gemini.test.ts src/tests/adapters/permissions/gemini-basic src/lib/types.ts && \
-git commit -m "feat(adapter/gemini): emit partial permissions + warn on unmappable LCD"
+git add src/adapters/gemini.ts src/tests/adapters/gemini.test.ts src/tests/adapters/permissions/gemini-basic && \
+git commit -m "feat(adapter/gemini): emit permissions.gemini into settings fragment"
 ```
 
 ---
 
-### Task 6: Pi adapter — `--tools` template + warnings `[slot: any]`
+### Task 7: Wire Pi adapter  `[slot: any]`
+
+Pi has no existing destination file for permissions. We emit `permissions.pi` to a new `.pi/permissions.json` for forward compatibility — Pi today ignores it, but authors get a single place to declare intent (matches the existing `.pi/mcp.experimental.json` convention).
 
 **Files:**
 - Modify: `src/adapters/pi.ts`
-- Create: `src/tests/adapters/permissions/pi-basic/{outfit.md, expected/.pi/permissions.json}`
+- Create: `src/tests/adapters/permissions/pi-basic/outfit.md`
+- Create: `src/tests/adapters/permissions/pi-basic/expected/.pi/permissions.json`
 - Modify: `src/tests/adapters/pi.test.ts`
 
-- [ ] **Step 1: Write the fixture**
+- [ ] **Step 1: Create the fixture**
 
 Create `src/tests/adapters/permissions/pi-basic/outfit.md`:
 
@@ -601,8 +623,6 @@ description: fixture
 type: outfit
 targets: [pi]
 permissions:
-  mode: default
-  bash_allow: [git, npm]
   pi:
     tools: [read, bash, write]
 ---
@@ -618,49 +638,50 @@ Create `src/tests/adapters/permissions/pi-basic/expected/.pi/permissions.json`:
 
 - [ ] **Step 2: Write the failing test**
 
-In `src/tests/adapters/pi.test.ts`, add:
+In `src/tests/adapters/pi.test.ts`, append:
 
 ```typescript
-it('emits pi permissions as --tools template, warns on unmappable LCD', async () => {
-  const warnings: string[] = [];
-  const result = await runGolden(piAdapter, path.join(HERE, 'permissions/pi-basic'), {
-    onWarn: (m: string) => warnings.push(m),
-  });
+it('emits permissions.pi verbatim into .pi/permissions.json', async () => {
+  const result = await runGolden(piAdapter, path.join(HERE, 'permissions/pi-basic'));
   expect(result.diff).toEqual([]);
-  expect(warnings.some((w) => /bash_allow.*--tools/.test(w))).toBe(true);
-  expect(warnings.some((w) => /mode.*ignored/.test(w))).toBe(true);
+});
+
+it('emits nothing when permissions.pi is absent', async () => {
+  // ...use an existing pi fixture without a permissions block...
+  const result = await runGolden(piAdapter, path.join(HERE, 'pi/basic'));
+  expect(result.files.some((f) => f.path.endsWith('.pi/permissions.json'))).toBe(false);
 });
 ```
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits pi permissions"`
+Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits permissions.pi"`
 Expected: FAIL
 
-- [ ] **Step 4: Implement `compilePiPermissions`**
+- [ ] **Step 4: Wire the helper**
 
-In `src/adapters/pi.ts`, add:
+In `src/adapters/pi.ts`, add an emit step that writes `.pi/permissions.json` when `permissions.pi` is present:
 
 ```typescript
-function compilePiPermissions(
-  p: PermissionsBlock | undefined,
-  warn: (m: string) => void,
-): Record<string, unknown> | undefined {
-  if (!p) return undefined;
-  if (p.mode) warn(`pi: mode '${p.mode}' ignored — Pi has no settings-level mode toggle`);
-  if (p.bash_allow?.length) {
-    warn(`pi: bash_allow [${p.bash_allow.join(', ')}] not declarative — pass via --tools at launch instead`);
-  }
-  if (p.mcp) warn(`pi: mcp tool-level gating not supported`);
-  return p.pi ?? undefined;
+import { applyPassthroughPermissions } from './_permissions.js';
+
+// ...inside the emit() function, after existing emits:
+const piPerms = applyPassthroughPermissions(
+  component.manifest.permissions,
+  'pi',
+  {},
+);
+if (Object.keys(piPerms).length > 0) {
+  emittedFiles.push({
+    path: '.pi/permissions.json',
+    contents: JSON.stringify(piPerms, null, 2) + '\n',
+  });
 }
 ```
 
-Emit the returned object to `.pi/permissions.json` if non-undefined.
-
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits pi permissions"`
+Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits permissions.pi"`
 Expected: PASS
 
 - [ ] **Step 6: Run all Pi adapter tests**
@@ -672,64 +693,77 @@ Expected: PASS (all)
 
 ```bash
 git add src/adapters/pi.ts src/tests/adapters/pi.test.ts src/tests/adapters/permissions/pi-basic && \
-git commit -m "feat(adapter/pi): emit permissions passthrough + warn on unmappable LCD"
+git commit -m "feat(adapter/pi): emit permissions.pi to .pi/permissions.json"
 ```
 
 ---
 
-### Task 7: Suit-side integration sanity + PR `[slot: any]`
+### Task 8: Suit-side integration sanity + PR  `[slot: any]`
 
-**Files:** none modified — verification only.
+**Files:** none modified — verification + release workflow.
 
 - [ ] **Step 1: Run full validation + test suite**
 
 Run: `npm run validate && npx vitest run`
-Expected: PASS
+Expected: PASS (all)
 
 - [ ] **Step 2: Run typecheck**
 
-Run: `npm run typecheck` (or `tsc --noEmit` if no script exists)
+Run: `npm run typecheck` (or `tsc --noEmit` if no script)
 Expected: PASS
 
-- [ ] **Step 3: Manually emit a fixture and inspect**
+- [ ] **Step 3: Identify local CI surface**
 
-Run from suit repo root:
+Run: `ls .github/workflows/ && cat .github/workflows/*.yml`
+Note what CI runs (typical: validate, test, build, typecheck).
+
+- [ ] **Step 4: Run local CI equivalents**
+
+Run whatever CI runs, locally. Per project CLAUDE.md, do not declare PR ready until local CI is green. If a step relies on infra not reproducible locally, surface that explicitly.
+
+Expected: all green.
+
+- [ ] **Step 5: Manual emit smoke test**
 
 ```bash
-node dist/cli.js show outfit claude-perm-basic --emit /tmp/perm-test 2>&1
-ls -la /tmp/perm-test/.claude/
-cat /tmp/perm-test/.claude/settings.fragment.json
+node dist/cli.js show outfit claude-perm-basic --emit /tmp/perm-smoke --target claude 2>&1
+cat /tmp/perm-smoke/.claude/settings.fragment.json
 ```
 
-Expected: `.claude/settings.fragment.json` contains the merged permissions block matching the Task 3 golden.
+Expected: file contents match the Task 4 golden.
 
-- [ ] **Step 4: Push branch and open PR**
+Repeat for codex/gemini/pi targets.
+
+- [ ] **Step 6: Push branch and open PR**
 
 ```bash
 git push -u origin feat/permissions-block
-gh pr create --title "feat: permissions block for outfit frontmatter + 4-adapter emit" --body "$(cat <<'EOF'
+gh pr create --title "feat: permissions block (passthrough) for outfit frontmatter" --body "$(cat <<'EOF'
 ## Summary
-- Add `PermissionsBlockSchema` (LCD: mode / bash_allow / mcp.<server>.*, plus per-target passthrough)
-- Attach `permissions:` to OutfitSchema only (cuts/accessories rejected — v2 scope)
-- Emit per-harness: Claude Code settings fragment, Codex TOML, Gemini settings fragment (partial + warnings), Pi permissions.json (passthrough + warnings)
-- Golden-file tests for each adapter
+- `PermissionsBlockSchema` with four opaque sub-fields (claude/codex/gemini/pi)
+- Attached to OutfitSchema only; CutSchema and AccessorySchema reject via Zod `.strict()`
+- Shared `applyPassthroughPermissions` helper deep-merges target sub-block into adapter's native destination
+- Per-adapter emits: Claude → `.claude/settings.fragment.json`, Codex → `codex.config.toml`, Gemini → `.gemini/settings.fragment.json`, Pi → new `.pi/permissions.json`
+- No LCD vocabulary in v1 (Ousterhout-driven design decision — see linked wardrobe plan)
 
 ## Test plan
+- [ ] Schema tests pass (PermissionsBlockSchema + attachment)
+- [ ] Helper tests pass (`_permissions.test.ts`)
+- [ ] One passthrough golden fixture per adapter, all green
 - [ ] `npm run validate` passes
-- [ ] `npx vitest run` passes (all adapter + schema tests)
-- [ ] `npm run typecheck` passes
-- [ ] Manual emit smoke-tested on each fixture
+- [ ] `npx vitest run` passes
+- [ ] Local CI equivalents replicated green
+- [ ] Manual emit smoke test for all four targets
 EOF
 )"
 ```
 
-- [ ] **Step 5: Run local CI before declaring ready**
+- [ ] **Step 7: Wait for remote CI**
 
-Per project CLAUDE.md, identify what CI runs (read `.github/workflows/*.yml` in suit) and replicate locally. Common surface: `npm test`, `npm run validate`, `npm run typecheck`, `npm run build`.
+Run: `gh pr checks $(gh pr view --json number -q .number)`
+Distinguish transient infra failures from real failures explicitly when reporting status.
 
-Expected: all local CI green before declaring PR ready. If any step depends on infra not reproducible locally, surface explicitly.
-
-- [ ] **Step 6: Wait for human merge and release**
+- [ ] **Step 8: Wait for human merge and release**
 
 🛑 **PHASE GATE.** Do not proceed to Phase 2 until:
 1. The suit PR is merged to `main`.
@@ -744,7 +778,7 @@ The wardrobe canary will fail validation otherwise.
 
 > **Repo:** `/Users/dmestas/projects/wardrobe`. Branch off `main`: `git checkout -b feat/permissions-canary-backend`.
 
-### Task 8: Add `permissions:` block to `outfits/backend/outfit.md` `[slot: any]`
+### Task 9: Add `permissions:` block to `outfits/backend/outfit.md`  `[slot: any]`
 
 **Files:**
 - Modify: `outfits/backend/outfit.md` (frontmatter)
@@ -752,41 +786,30 @@ The wardrobe canary will fail validation otherwise.
 - [ ] **Step 1: Read existing frontmatter**
 
 Run: `head -30 outfits/backend/outfit.md`
-Note the current frontmatter shape.
+Note current frontmatter shape.
 
-- [ ] **Step 2: Add `permissions:` block to frontmatter**
+- [ ] **Step 2: Add `permissions:` block (Claude-only for first canary)**
 
-Insert (preserving existing frontmatter fields):
+Insert into frontmatter (preserving existing fields):
 
 ```yaml
 permissions:
-  mode: default
-  bash_allow:
-    - git
-    - npm
-    - go
-    - rg
-  mcp:
-    signoz:
-      enabled: true
-      enabled_tools:
-        - signoz_search_logs
-        - signoz_query_metrics
-        - signoz_search_traces
-    axiom:
-      enabled: true
-    doppler:
-      enabled: true
-      enabled_tools:
-        - doppler_secrets_get
-        - doppler_secrets_list
   claude:
+    allow:
+      - "Bash(git status:*)"
+      - "Bash(git diff:*)"
+      - "Bash(go test:*)"
+      - "Bash(go build:*)"
+      - "Bash(npm run test:*)"
+      - "mcp__signoz__signoz_search_logs"
+      - "mcp__signoz__signoz_query_metrics"
+      - "mcp__signoz__signoz_search_traces"
     deny:
       - "Bash(git push:main)"
       - "Bash(rm -rf:*)"
 ```
 
-Rationale (for plan reader, not the file): `backend` already loads signoz/axiom/doppler MCPs per its CLAUDE.md; this just narrows tool surface. The Claude `deny` block enforces the PR-policy rule at the permission layer rather than relying on the agent reading `pr-policy` accessory text.
+The block is intentionally Claude-only. Other harness sub-blocks can be added in follow-up commits as outfit-author intent forms — the schema rejects only unknown *top-level* keys, not missing sub-blocks.
 
 - [ ] **Step 3: Validate against suit schema**
 
@@ -795,8 +818,6 @@ Expected: PASS
 
 - [ ] **Step 4: Emit and inspect each target**
 
-Run:
-
 ```bash
 for t in claude codex gemini pi; do
   echo "=== $t ==="
@@ -804,11 +825,11 @@ for t in claude codex gemini pi; do
 done
 ```
 
-Expected: each target produces a permissions artifact in its conventional path; Gemini and Pi log warnings about ignored `bash_allow` entries (this is correct, not a bug).
+Expected:
+- Claude target produces `.claude/settings.fragment.json` containing the merged permissions block
+- Codex / Gemini / Pi targets produce no permissions artifact (no `permissions.codex` / `.gemini` / `.pi` in the outfit)
 
-- [ ] **Step 5: Diff against pre-change emit to confirm scope**
-
-Run:
+- [ ] **Step 5: Diff against pre-change emit**
 
 ```bash
 git stash
@@ -817,18 +838,18 @@ git stash pop
 diff -ru /tmp/canary-before/.claude /tmp/canary-claude/.claude | head -40
 ```
 
-Expected: the only diff is the new `permissions` key in `settings.fragment.json`.
+Expected: only diff is the new `permissions` key in `settings.fragment.json`.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add outfits/backend/outfit.md && \
-git commit -m "feat(outfit/backend): add permissions block (canary for new schema)"
+git commit -m "feat(outfit/backend): add permissions.claude block (canary)"
 ```
 
 ---
 
-### Task 9: Document `permissions:` field in HARNESS_INTEGRATION.md `[slot: any]`
+### Task 10: Document `permissions:` field in HARNESS_INTEGRATION.md  `[slot: any]`
 
 **Files:**
 - Modify: `docs/HARNESS_INTEGRATION.md`
@@ -836,63 +857,57 @@ git commit -m "feat(outfit/backend): add permissions block (canary for new schem
 - [ ] **Step 1: Read current structure**
 
 Run: `head -120 docs/HARNESS_INTEGRATION.md`
-Note where frontmatter fields are documented (likely a table).
+Find where frontmatter fields are documented.
 
-- [ ] **Step 2: Add a `permissions:` section**
+- [ ] **Step 2: Add `permissions:` section**
 
-Append (or insert in the appropriate frontmatter-fields location):
+Append (or insert in the frontmatter-fields location):
 
 ````markdown
 ### `permissions:` (outfit-only, v1)
 
-Authoring surface for harness permission/approval configs. Composed of a thin
-LCD (lowest-common-denominator) plus per-target passthrough.
+Authoring surface for harness-native permission / approval config. Four opaque
+sub-blocks, one per target harness. Each sub-block is emitted verbatim into the
+target's native config file via deep-merge.
 
 ```yaml
 permissions:
-  # LCD — emitted per-harness via adapter translation
-  mode: default               # default | accept-edits | plan | yolo
-  bash_allow: [git, npm, go]  # exact command names
-  mcp:
-    <server-id>:
-      enabled: true | false
-      enabled_tools: [...]    # optional tool allowlist
-      disabled_tools: [...]   # optional tool denylist (applied after enabled_tools)
-
-  # Passthrough — emitted verbatim into the target's native config
-  claude: { allow: [...], ask: [...], deny: [...], additionalDirectories: [...] }
-  codex:  { approval_policy: ..., sandbox_mode: ..., rules: { prefix_rules: [...] } }
-  gemini: { security: { ... }, mcpServers: { ... } }
+  claude: { allow: [...], ask: [...], deny: [...], additionalDirectories: [...], defaultMode: ... }
+  codex:  { approval_policy: ..., sandbox_mode: ..., rules: { prefix_rules: [...] }, mcp_servers: { ... } }
+  gemini: { general: { defaultApprovalMode: ... }, security: { ... }, mcpServers: { ... } }
   pi:     { tools: [...] }
 ```
 
-**Per-harness coverage:**
+Write each sub-block in that harness's native syntax — there is no
+cross-harness translation in v1. If you want the same permission expressed for
+multiple harnesses, write it in each sub-block.
 
-| Field | Claude Code | Codex | Gemini | Pi |
-|---|---|---|---|---|
-| `mode` | ✅ `defaultMode` | ✅ `approval_policy` | ✅ `general.defaultApprovalMode` | ⚠️ warn (no setting) |
-| `bash_allow` | ✅ `Bash(<cmd>:*)` | ✅ `rules.prefix_rules[]` | ⚠️ warn (no rule grammar) | ⚠️ warn (use CLI `--tools`) |
-| `mcp.*.enabled` | ✅ | ✅ | ✅ | ⚠️ warn |
-| `mcp.*.enabled_tools` / `disabled_tools` | ✅ | ✅ | ⚠️ warn (server-level only) | ⚠️ warn |
-| `<target>:` passthrough | ✅ | ✅ | ✅ | ✅ |
+**Emit destinations:**
 
-Missing `permissions:` block = no emit, harness defaults apply.
+| Target | Output file | Note |
+|---|---|---|
+| `claude` | `.claude/settings.fragment.json` | Deep-merged into the existing fragment |
+| `codex` | `codex.config.toml` | Deep-merged into the in-memory TOML object before serialization |
+| `gemini` | `.gemini/settings.fragment.json` | Deep-merged into the existing fragment |
+| `pi` | `.pi/permissions.json` | New file written only when `permissions.pi` is non-empty; Pi today ignores it (forward-compat) |
 
-**Scope (v1):** outfits only. Cuts and accessories declaring `permissions:` will
-fail validation — composition semantics for layered permission merges are
-deferred to v2.
+Missing `permissions:` block, or missing target sub-block, = no emit and harness
+defaults apply.
+
+**Scope (v1):** outfits only. Cuts and accessories declaring `permissions:`
+fail validation; layered composition semantics are deferred to v2.
 ````
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add docs/HARNESS_INTEGRATION.md && \
-git commit -m "docs(harness): document permissions frontmatter field"
+git commit -m "docs(harness): document permissions frontmatter field (passthrough)"
 ```
 
 ---
 
-### Task 10: Push wardrobe canary PR + local CI `[slot: any]`
+### Task 11: Push wardrobe canary PR + local CI  `[slot: any]`
 
 **Files:** none modified — release workflow only.
 
@@ -902,45 +917,42 @@ git commit -m "docs(harness): document permissions frontmatter field"
 git push -u origin feat/permissions-canary-backend
 ```
 
-- [ ] **Step 2: Identify wardrobe CI**
+- [ ] **Step 2: Run local CI equivalents**
 
-Run: `ls .github/workflows/ 2>/dev/null && cat .github/workflows/*.yml 2>/dev/null | head -80`
-Note the CI surface (likely `npm run validate` for content checks).
-
-- [ ] **Step 3: Run local equivalents**
-
-Run whatever CI runs, locally. Common surface in wardrobe:
+Per wardrobe `.github/workflows/ci.yml`, the surface is `npm run validate` + `npm run build -- --target all --dry-run`. Run both locally:
 
 ```bash
 npm install
 npm run validate
+npm run build -- --target all --dry-run
 ```
 
 Expected: PASS.
 
-- [ ] **Step 4: Open PR**
+- [ ] **Step 3: Open PR**
 
 ```bash
-gh pr create --title "feat(outfit/backend): canary permissions block" --body "$(cat <<'EOF'
+gh pr create --title "feat(outfit/backend): canary permissions.claude block" --body "$(cat <<'EOF'
 ## Summary
 - First wardrobe outfit to author a `permissions:` block (depends on suit `feat/permissions-block` PR being merged + released)
 - Documents the new field in `docs/HARNESS_INTEGRATION.md`
-- Verified emission against all four harness targets
+- Emits Claude-only for the first canary; other harness sub-blocks can be added in follow-ups
 
 ## Test plan
 - [ ] `npm run validate` passes (suit's new schema accepts the block)
-- [ ] `suit show outfit backend --target=<t>` for t in {claude, codex, gemini, pi} emits expected artifacts
-- [ ] Gemini/Pi emit logs ignored-field warnings (expected behavior, not a regression)
+- [ ] `npm run build -- --target all --dry-run` passes
+- [ ] `suit show outfit backend --target=claude` shows the merged permissions block in the emitted settings fragment
+- [ ] `suit show outfit backend --target={codex,gemini,pi}` produces no permissions artifact (correct — no sub-blocks authored yet)
 EOF
 )"
 ```
 
-- [ ] **Step 5: Check remote CI status**
+- [ ] **Step 4: Check remote CI status**
 
 Run: `gh pr checks $(gh pr view --json number -q .number)`
-Expected: all green. Distinguish transient infra failures from real failures explicitly in the status report.
+Expected: all green. Surface any transient-vs-real distinction explicitly.
 
-- [ ] **Step 6: Hand off to human for merge**
+- [ ] **Step 5: Hand off to human for merge**
 
 Surface the PR URL and wait for manual merge per CLAUDE.md PR policy. After merge:
 
@@ -952,25 +964,40 @@ git remote prune origin
 
 ---
 
-## Self-Review Checklist (run before handoff)
+## Self-Review Checklist
 
-**1. Spec coverage** — every architectural decision from the design conversation:
+**1. Spec coverage** — every architectural decision:
 - [x] Outfit-only attachment (Task 2)
-- [x] LCD vocabulary = mode + bash_allow + mcp.* (Task 1)
-- [x] Per-target passthrough (Tasks 3–6)
-- [x] No emit when block absent (Task 1 schema makes optional; adapters early-return)
-- [x] Suit-first, wardrobe canary after (phase gate at end of Task 7)
-- [x] Backend as canary outfit (Task 8)
-- [x] Cross-repo PR discipline (Tasks 7 & 10)
-- [x] Local CI before "ready" (Tasks 7.5 & 10.3)
+- [x] Passthrough-only (no LCD) (Task 1)
+- [x] Four opaque target sub-blocks (Task 1)
+- [x] Shared deep-merge helper (Task 3)
+- [x] Per-target emit destinations (Tasks 4–7)
+- [x] No emit when block absent (helper's early-return)
+- [x] Suit-first, wardrobe canary after (phase gate at end of Task 8)
+- [x] Backend as canary outfit, Claude-only first (Task 9)
+- [x] Cross-repo PR discipline (Tasks 8 & 11)
+- [x] Local CI before "ready" (Tasks 8.4 & 11.2)
 
-**2. Placeholder scan** — none found. Every code block is concrete.
+**2. Placeholder scan** — none. Every code block is concrete and self-contained.
 
-**3. Type consistency** — `PermissionsBlock` defined once in suit `src/lib/schema.ts`, exported via `src/lib/types.ts`, consumed unchanged in all four adapters. Field names (`mode`, `bash_allow`, `mcp`, `claude`, `codex`, `gemini`, `pi`) used identically across tasks.
+**3. Type consistency** — `PermissionsBlock` defined once in `src/lib/schema.ts`, exported from `src/lib/types.ts`, consumed unchanged by `applyPassthroughPermissions` and all four adapters. The `Target` union type drives the helper's second parameter; no string-typed magic.
 
 **4. Risks not in tasks above:**
-- *Existing evolution detector* (`suit/src/lib/evolution/permissions.ts`) generates session-time diffs to `.claude/settings.json`. Its output could conflict with build-time emit. Not addressed in v1; flag for v2 review.
-- *Codex sandbox_mode interaction with `mode` LCD* — both write into `codex.config.toml` but represent orthogonal concepts. The compiler in Task 4 maps `mode` to `approval_policy` only; `sandbox_mode` is passthrough-only. Documented in Task 9.
+- *Existing evolution detector* (`suit/src/lib/evolution/permissions.ts`) generates session-time diffs to `.claude/settings.json` (not the `.fragment.json` we emit at build time). The output paths differ, but both touch the `permissions` key. Flag for v2 review — may want to teach the evolution detector to write into the outfit's `permissions.claude` block instead of the live settings file.
+- *Pi forward-compat emit* — writing `.pi/permissions.json` that Pi today ignores creates a documentation burden ("why is this here?"). The convention is consistent with existing `.pi/mcp.experimental.json`, but worth revisiting if Pi's permission model never materializes.
+
+---
+
+## Design log
+
+Earlier draft of this plan included an LCD vocabulary (`mode` / `bash_allow` / `mcp.<server>.*`) compiled per-harness, with passthrough as override. Rejected on Ousterhout review:
+
+- **Shallow abstraction**: 3 LCD verbs covered <20% of realistic permission semantics; passthrough was always the dominant authoring path.
+- **Leaky mapping**: Claude `defaultMode='default'` and Codex `approval_policy='on-request'` have different mechanical meanings. Any compile table would mislead authors.
+- **Surprise merge precedence**: writing both `bash_allow: [git]` and `claude.allow: ["Bash(npm:*)"]` produced an implicit-ordered `allow` list — conjoined methods between LCD and passthrough.
+- **Over-generalization**: zero outfits had ever authored permissions; the LCD was designed without data on which patterns would repeat.
+
+Passthrough-only is the smallest honest interface. LCD verbs are a v2 candidate, to be considered only after ≥3 outfits ship `permissions:` blocks and real repeat patterns emerge.
 
 ---
 

--- a/docs/plans/2026-05-11-permissions-system.md
+++ b/docs/plans/2026-05-11-permissions-system.md
@@ -1,0 +1,981 @@
+# Permissions System Implementation Plan
+
+> **For agentic workers:** Use `subagent-driven-development` (recommended) or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This plan spans two repos; respect the **phase gate** at the end of Phase 1.
+
+**Goal:** Let wardrobe outfits (and later cuts/accessories) author a `permissions:` block in frontmatter that suit composes and emits as harness-native permission config for Claude Code, Codex, Gemini, and Pi.
+
+**Architecture:** Hybrid schema — a thin LCD (`mode`, `bash_allow`, `mcp.<server>.{enabled,enabled_tools,disabled_tools}`) compiles per-harness; a per-target passthrough block (`permissions.claude.*`, `permissions.codex.*`, etc.) is emitted verbatim and deep-merged over the LCD output. Missing block = no emit (harness defaults apply). Suit ships the schema + 4 adapter emitters first; wardrobe adds the first canary outfit after suit releases.
+
+**Tech Stack:** TypeScript, Zod v4, Vitest (suit). YAML frontmatter, markdown (wardrobe).
+
+**Scope:** Outfits only in v1. Cuts/accessories declaring `permissions:` is a deliberate non-goal — schema validation will reject for now, to be lifted in v2 once the merge-precedence question is resolved.
+
+**Non-goals:**
+- Cut/accessory `permissions:` blocks (v2)
+- Migrating the existing evolution-detector (`suit/src/lib/evolution/permissions.ts`) into the new pipeline
+- Auto-translating Claude wildcards into Codex prefix rules — out of scope; passthrough handles that
+
+---
+
+## File Structure
+
+### suit repo (`/Users/dmestas/projects/suit`)
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/lib/schema.ts` | Zod schemas for component frontmatter | Modify — add `PermissionsBlockSchema`, attach to `OutfitSchema` only |
+| `src/lib/types.ts` | Type exports | Modify — export `PermissionsBlock` type |
+| `src/adapters/claude-code.ts` | Emit Claude Code artifacts | Modify — add `emitPermissions` helper, merge into `.claude/settings.fragment.json` |
+| `src/adapters/codex.ts` | Emit Codex artifacts | Modify — emit permissions into `codex.config.toml` |
+| `src/adapters/gemini.ts` | Emit Gemini artifacts | Modify — emit into `.gemini/settings.fragment.json` + warnings for unmapped LCD |
+| `src/adapters/pi.ts` | Emit Pi artifacts | Modify — emit `--tools` flag template into a new `.pi/permissions.json` + warnings |
+| `src/lib/resolution.ts` | Layer-merge outfit/cut/accessory | No change expected — verify `deepMerge` already covers `permissions` |
+| `src/tests/adapters/permissions/` | Test fixtures for permission emit | Create — one fixture per adapter, golden-file pattern |
+| `src/tests/adapters/claude-code.test.ts` | Existing tests | Modify — add permissions cases |
+| `src/tests/adapters/codex.test.ts` | Existing tests | Modify — add permissions cases |
+| `src/tests/adapters/gemini.test.ts` | Existing tests | Modify — add permissions cases |
+| `src/tests/adapters/pi.test.ts` | Existing tests | Modify — add permissions cases |
+
+### wardrobe repo (`/Users/dmestas/projects/wardrobe`)
+
+| File | Responsibility | Action |
+|---|---|---|
+| `outfits/backend/outfit.md` | Canary outfit with first `permissions:` block | Modify |
+| `docs/HARNESS_INTEGRATION.md` | Authoring docs for component frontmatter | Modify — add `permissions:` field documentation |
+| `docs/plans/2026-05-11-permissions-system.md` | This plan | Create |
+
+---
+
+## Phase 1 — suit: schema + adapters + tests
+
+> **Repo:** `/Users/dmestas/projects/suit`. Branch off `main`: `git checkout -b feat/permissions-block`.
+
+### Task 1: Define `PermissionsBlockSchema` in suit `[slot: any]`
+
+**Files:**
+- Modify: `src/lib/schema.ts` (insert before `ManifestBaseSchema` definition at line ~58)
+- Modify: `src/lib/types.ts` (add type export at end of file)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/schema.permissions.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { PermissionsBlockSchema } from '../lib/schema.js';
+
+describe('PermissionsBlockSchema', () => {
+  it('accepts a fully-populated LCD + passthrough block', () => {
+    const input = {
+      mode: 'default',
+      bash_allow: ['git', 'npm'],
+      mcp: {
+        signoz: { enabled: true, enabled_tools: ['signoz_search_logs'] },
+      },
+      claude: { allow: ['Bash(git status:*)'], deny: [] },
+      codex: { sandbox_mode: 'workspace-write' },
+      gemini: { security: { folderTrust: { enabled: true } } },
+      pi: { tools: ['read', 'bash'] },
+    };
+    expect(() => PermissionsBlockSchema.parse(input)).not.toThrow();
+  });
+
+  it('rejects unknown LCD mode values', () => {
+    expect(() => PermissionsBlockSchema.parse({ mode: 'nope' })).toThrow();
+  });
+
+  it('accepts an empty block', () => {
+    expect(() => PermissionsBlockSchema.parse({})).not.toThrow();
+  });
+
+  it('treats passthrough targets as opaque (accepts unknown keys)', () => {
+    expect(() =>
+      PermissionsBlockSchema.parse({ claude: { foo: { bar: 1 } } }),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/schema.permissions.test.ts`
+Expected: FAIL with "PermissionsBlockSchema is not exported"
+
+- [ ] **Step 3: Implement `PermissionsBlockSchema`**
+
+In `src/lib/schema.ts`, add before `ManifestBaseSchema`:
+
+```typescript
+const McpServerPermissionSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    enabled_tools: z.array(z.string()).optional(),
+    disabled_tools: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export const PermissionsBlockSchema = z
+  .object({
+    mode: z.enum(['default', 'accept-edits', 'plan', 'yolo']).optional(),
+    bash_allow: z.array(z.string()).optional(),
+    mcp: z.record(z.string(), McpServerPermissionSchema).optional(),
+    claude: z.record(z.string(), z.unknown()).optional(),
+    codex: z.record(z.string(), z.unknown()).optional(),
+    gemini: z.record(z.string(), z.unknown()).optional(),
+    pi: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export type PermissionsBlock = z.infer<typeof PermissionsBlockSchema>;
+```
+
+In `src/lib/types.ts`, add at the bottom:
+
+```typescript
+export type { PermissionsBlock } from './schema.js';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/schema.permissions.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/schema.ts src/lib/types.ts src/tests/schema.permissions.test.ts && \
+git commit -m "feat(schema): add PermissionsBlockSchema for outfit frontmatter"
+```
+
+---
+
+### Task 2: Attach `permissions:` to `OutfitSchema` only (reject on cut/accessory) `[slot: any]`
+
+**Files:**
+- Modify: `src/lib/schema.ts:122` (OutfitSchema), `src/lib/schema.ts:140` (CutSchema), `src/lib/schema.ts:155` (AccessorySchema)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tests/schema.permissions.test.ts`:
+
+```typescript
+import { OutfitSchema, CutSchema, AccessorySchema } from '../lib/schema.js';
+
+describe('Permissions attachment', () => {
+  const base = { name: 'x', version: '0.0.1', description: 'd', type: 'outfit' };
+
+  it('outfit accepts permissions block', () => {
+    expect(() =>
+      OutfitSchema.parse({ ...base, type: 'outfit', permissions: { mode: 'default' } }),
+    ).not.toThrow();
+  });
+
+  it('cut rejects permissions block in v1', () => {
+    expect(() =>
+      CutSchema.parse({ ...base, type: 'cut', permissions: { mode: 'default' } }),
+    ).toThrow();
+  });
+
+  it('accessory rejects permissions block in v1', () => {
+    expect(() =>
+      AccessorySchema.parse({ ...base, type: 'accessory', permissions: { mode: 'default' } }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/schema.permissions.test.ts`
+Expected: FAIL (outfit case fails — `permissions` not recognized)
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/schema.ts`, modify `OutfitSchema` (around line 122) to extend with `permissions`:
+
+```typescript
+export const OutfitSchema = ManifestBaseSchema.extend({
+  type: z.literal('outfit'),
+  // ...existing fields...
+  permissions: PermissionsBlockSchema.optional(),
+}).strict();
+```
+
+CutSchema and AccessorySchema remain unchanged — Zod's `.strict()` will reject unknown `permissions` keys.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/schema.permissions.test.ts`
+Expected: PASS (7 tests total)
+
+- [ ] **Step 5: Verify whole-repo validation still works**
+
+Run: `npm run validate`
+Expected: PASS (no regressions on existing components)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/schema.ts src/tests/schema.permissions.test.ts && \
+git commit -m "feat(schema): attach permissions block to outfit only (v1 scope)"
+```
+
+---
+
+### Task 3: Claude Code adapter — emit LCD + passthrough `[slot: any]`
+
+**Files:**
+- Modify: `src/adapters/claude-code.ts` (existing `emitSettings` around line ~99)
+- Create: `src/tests/adapters/permissions/claude-code-basic/outfit.md` (fixture)
+- Create: `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settings.fragment.json` (golden)
+- Modify: `src/tests/adapters/claude-code.test.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `src/tests/adapters/permissions/claude-code-basic/outfit.md`:
+
+```markdown
+---
+name: claude-perm-basic
+version: 0.0.1
+description: fixture
+type: outfit
+targets: [claude]
+permissions:
+  mode: default
+  bash_allow: [git, npm]
+  mcp:
+    signoz:
+      enabled: true
+      enabled_tools: [signoz_search_logs]
+  claude:
+    allow: ["Bash(go test:*)"]
+    deny: ["Bash(rm -rf:*)"]
+    additionalDirectories: ["~/src"]
+---
+```
+
+Create `src/tests/adapters/permissions/claude-code-basic/expected/.claude/settings.fragment.json`:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "default",
+    "allow": ["Bash(git:*)", "Bash(npm:*)", "mcp__signoz__signoz_search_logs", "Bash(go test:*)"],
+    "deny": ["Bash(rm -rf:*)"],
+    "additionalDirectories": ["~/src"]
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/tests/adapters/claude-code.test.ts`, add:
+
+```typescript
+it('emits permissions block — LCD compile + passthrough merge', async () => {
+  const result = await runGolden(
+    claudeCodeAdapter,
+    path.join(HERE, 'permissions/claude-code-basic'),
+  );
+  expect(result.diff).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions block"`
+Expected: FAIL (no permissions emitted)
+
+- [ ] **Step 4: Implement `compilePermissions` helper**
+
+In `src/adapters/claude-code.ts`, add before `emitSettings`:
+
+```typescript
+function compileClaudePermissions(p: PermissionsBlock | undefined): Record<string, unknown> | undefined {
+  if (!p) return undefined;
+  const allow: string[] = [];
+  const ask: string[] = [];
+  const deny: string[] = [];
+  const out: Record<string, unknown> = {};
+
+  if (p.mode) out.defaultMode = p.mode;
+  if (p.bash_allow) for (const cmd of p.bash_allow) allow.push(`Bash(${cmd}:*)`);
+  if (p.mcp) {
+    for (const [server, cfg] of Object.entries(p.mcp)) {
+      if (cfg.enabled === false) deny.push(`mcp__${server}`);
+      for (const tool of cfg.enabled_tools ?? []) allow.push(`mcp__${server}__${tool}`);
+      for (const tool of cfg.disabled_tools ?? []) deny.push(`mcp__${server}__${tool}`);
+    }
+  }
+  if (allow.length) out.allow = allow;
+  if (ask.length) out.ask = ask;
+  if (deny.length) out.deny = deny;
+
+  // Passthrough — deep-merge target-specific block on top
+  if (p.claude) {
+    const merged = deepMerge(out, p.claude) as Record<string, unknown>;
+    // additionalDirectories lives at the top level of permissions in Claude
+    return merged;
+  }
+  return out;
+}
+```
+
+In the `emitSettings` function, merge `compileClaudePermissions(component.manifest.permissions)` into the `permissions` key of the settings fragment.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/adapters/claude-code.test.ts -t "emits permissions block"`
+Expected: PASS
+
+- [ ] **Step 6: Run all Claude adapter tests for regressions**
+
+Run: `npx vitest run src/tests/adapters/claude-code.test.ts`
+Expected: PASS (all)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/claude-code.ts src/tests/adapters/claude-code.test.ts src/tests/adapters/permissions/claude-code-basic && \
+git commit -m "feat(adapter/claude): emit permissions block to settings fragment"
+```
+
+---
+
+### Task 4: Codex adapter — emit LCD + passthrough `[slot: any]`
+
+**Files:**
+- Modify: `src/adapters/codex.ts`
+- Create: `src/tests/adapters/permissions/codex-basic/{outfit.md, expected/codex.config.toml}`
+- Modify: `src/tests/adapters/codex.test.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `src/tests/adapters/permissions/codex-basic/outfit.md`:
+
+```markdown
+---
+name: codex-perm-basic
+version: 0.0.1
+description: fixture
+type: outfit
+targets: [codex]
+permissions:
+  mode: default
+  bash_allow: [git, npm]
+  mcp:
+    signoz:
+      enabled: true
+      enabled_tools: [signoz_search_logs]
+  codex:
+    sandbox_mode: workspace-write
+    approval_policy: on-request
+---
+```
+
+Create `src/tests/adapters/permissions/codex-basic/expected/codex.config.toml`:
+
+```toml
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[[rules.prefix_rules]]
+prefix = "git "
+
+[[rules.prefix_rules]]
+prefix = "npm "
+
+[mcp_servers.signoz]
+enabled = true
+enabled_tools = ["signoz_search_logs"]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/tests/adapters/codex.test.ts`, add:
+
+```typescript
+it('emits permissions block — bash_allow → prefix_rules, mcp passthrough', async () => {
+  const result = await runGolden(codexAdapter, path.join(HERE, 'permissions/codex-basic'));
+  expect(result.diff).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions block"`
+Expected: FAIL
+
+- [ ] **Step 4: Implement `compileCodexPermissions`**
+
+In `src/adapters/codex.ts`, add:
+
+```typescript
+function compileCodexPermissions(p: PermissionsBlock | undefined): Record<string, unknown> | undefined {
+  if (!p) return undefined;
+  const out: Record<string, unknown> = {};
+  const codexModeMap: Record<string, string> = {
+    'default': 'on-request',
+    'accept-edits': 'on-request',
+    'plan': 'untrusted',
+    'yolo': 'never',
+  };
+  if (p.mode) out.approval_policy = codexModeMap[p.mode];
+  if (p.bash_allow) {
+    out.rules = { prefix_rules: p.bash_allow.map((cmd) => ({ prefix: `${cmd} ` })) };
+  }
+  if (p.mcp) {
+    out.mcp_servers = Object.fromEntries(
+      Object.entries(p.mcp).map(([k, v]) => [k, { ...v }]),
+    );
+  }
+  // Codex passthrough deep-merged last (overrides LCD)
+  return p.codex ? (deepMerge(out, p.codex) as Record<string, unknown>) : out;
+}
+```
+
+Wire into the TOML emit path in `codex.ts` (look for `codex.config.toml` emission).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/adapters/codex.test.ts -t "emits permissions block"`
+Expected: PASS
+
+- [ ] **Step 6: Run all Codex adapter tests**
+
+Run: `npx vitest run src/tests/adapters/codex.test.ts`
+Expected: PASS (all)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/codex.ts src/tests/adapters/codex.test.ts src/tests/adapters/permissions/codex-basic && \
+git commit -m "feat(adapter/codex): emit permissions block to codex.config.toml"
+```
+
+---
+
+### Task 5: Gemini adapter — partial LCD + passthrough + warnings `[slot: any]`
+
+**Files:**
+- Modify: `src/adapters/gemini.ts`
+- Create: `src/tests/adapters/permissions/gemini-basic/{outfit.md, expected/.gemini/settings.fragment.json}`
+- Modify: `src/tests/adapters/gemini.test.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `src/tests/adapters/permissions/gemini-basic/outfit.md`:
+
+```markdown
+---
+name: gemini-perm-basic
+version: 0.0.1
+description: fixture
+type: outfit
+targets: [gemini]
+permissions:
+  mode: default
+  bash_allow: [git, npm]
+  mcp:
+    signoz:
+      enabled: false
+  gemini:
+    security:
+      folderTrust: { enabled: true }
+---
+```
+
+Create `src/tests/adapters/permissions/gemini-basic/expected/.gemini/settings.fragment.json`:
+
+```json
+{
+  "general": {
+    "defaultApprovalMode": "default"
+  },
+  "mcpServers": {
+    "signoz": {
+      "enabled": false
+    }
+  },
+  "security": {
+    "folderTrust": {
+      "enabled": true
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/tests/adapters/gemini.test.ts`, add:
+
+```typescript
+it('emits permissions — mode mapped, mcp passthrough, bash_allow warned', async () => {
+  const warnings: string[] = [];
+  const result = await runGolden(geminiAdapter, path.join(HERE, 'permissions/gemini-basic'), {
+    onWarn: (m: string) => warnings.push(m),
+  });
+  expect(result.diff).toEqual([]);
+  expect(warnings.some((w) => /bash_allow.*ignored/.test(w))).toBe(true);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions"`
+Expected: FAIL
+
+- [ ] **Step 4: Implement `compileGeminiPermissions`**
+
+In `src/adapters/gemini.ts`, add:
+
+```typescript
+function compileGeminiPermissions(
+  p: PermissionsBlock | undefined,
+  warn: (m: string) => void,
+): Record<string, unknown> | undefined {
+  if (!p) return undefined;
+  const out: Record<string, unknown> = {};
+  const modeMap: Record<string, string> = {
+    'default': 'default',
+    'accept-edits': 'auto_edit',
+    'plan': 'plan',
+    'yolo': 'yolo',
+  };
+  if (p.mode) out.general = { defaultApprovalMode: modeMap[p.mode] };
+  if (p.bash_allow?.length) {
+    warn(`gemini: bash_allow [${p.bash_allow.join(', ')}] ignored — Gemini has no per-command rule grammar`);
+  }
+  if (p.mcp) {
+    out.mcpServers = Object.fromEntries(
+      Object.entries(p.mcp).map(([k, v]) => [k, { enabled: v.enabled }]),
+    );
+    for (const [server, cfg] of Object.entries(p.mcp)) {
+      if (cfg.enabled_tools || cfg.disabled_tools) {
+        warn(`gemini: mcp.${server} tool-level allow/deny ignored — Gemini gates at server level only`);
+      }
+    }
+  }
+  return p.gemini ? (deepMerge(out, p.gemini) as Record<string, unknown>) : out;
+}
+```
+
+Thread the adapter's warning sink through `emit()`. If no warning sink exists yet, add one to `AdapterContext` (`src/lib/types.ts`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/adapters/gemini.test.ts -t "emits permissions"`
+Expected: PASS
+
+- [ ] **Step 6: Run all Gemini adapter tests**
+
+Run: `npx vitest run src/tests/adapters/gemini.test.ts`
+Expected: PASS (all)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/gemini.ts src/tests/adapters/gemini.test.ts src/tests/adapters/permissions/gemini-basic src/lib/types.ts && \
+git commit -m "feat(adapter/gemini): emit partial permissions + warn on unmappable LCD"
+```
+
+---
+
+### Task 6: Pi adapter — `--tools` template + warnings `[slot: any]`
+
+**Files:**
+- Modify: `src/adapters/pi.ts`
+- Create: `src/tests/adapters/permissions/pi-basic/{outfit.md, expected/.pi/permissions.json}`
+- Modify: `src/tests/adapters/pi.test.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `src/tests/adapters/permissions/pi-basic/outfit.md`:
+
+```markdown
+---
+name: pi-perm-basic
+version: 0.0.1
+description: fixture
+type: outfit
+targets: [pi]
+permissions:
+  mode: default
+  bash_allow: [git, npm]
+  pi:
+    tools: [read, bash, write]
+---
+```
+
+Create `src/tests/adapters/permissions/pi-basic/expected/.pi/permissions.json`:
+
+```json
+{
+  "tools": ["read", "bash", "write"]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/tests/adapters/pi.test.ts`, add:
+
+```typescript
+it('emits pi permissions as --tools template, warns on unmappable LCD', async () => {
+  const warnings: string[] = [];
+  const result = await runGolden(piAdapter, path.join(HERE, 'permissions/pi-basic'), {
+    onWarn: (m: string) => warnings.push(m),
+  });
+  expect(result.diff).toEqual([]);
+  expect(warnings.some((w) => /bash_allow.*--tools/.test(w))).toBe(true);
+  expect(warnings.some((w) => /mode.*ignored/.test(w))).toBe(true);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits pi permissions"`
+Expected: FAIL
+
+- [ ] **Step 4: Implement `compilePiPermissions`**
+
+In `src/adapters/pi.ts`, add:
+
+```typescript
+function compilePiPermissions(
+  p: PermissionsBlock | undefined,
+  warn: (m: string) => void,
+): Record<string, unknown> | undefined {
+  if (!p) return undefined;
+  if (p.mode) warn(`pi: mode '${p.mode}' ignored — Pi has no settings-level mode toggle`);
+  if (p.bash_allow?.length) {
+    warn(`pi: bash_allow [${p.bash_allow.join(', ')}] not declarative — pass via --tools at launch instead`);
+  }
+  if (p.mcp) warn(`pi: mcp tool-level gating not supported`);
+  return p.pi ?? undefined;
+}
+```
+
+Emit the returned object to `.pi/permissions.json` if non-undefined.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/tests/adapters/pi.test.ts -t "emits pi permissions"`
+Expected: PASS
+
+- [ ] **Step 6: Run all Pi adapter tests**
+
+Run: `npx vitest run src/tests/adapters/pi.test.ts`
+Expected: PASS (all)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/pi.ts src/tests/adapters/pi.test.ts src/tests/adapters/permissions/pi-basic && \
+git commit -m "feat(adapter/pi): emit permissions passthrough + warn on unmappable LCD"
+```
+
+---
+
+### Task 7: Suit-side integration sanity + PR `[slot: any]`
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run full validation + test suite**
+
+Run: `npm run validate && npx vitest run`
+Expected: PASS
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck` (or `tsc --noEmit` if no script exists)
+Expected: PASS
+
+- [ ] **Step 3: Manually emit a fixture and inspect**
+
+Run from suit repo root:
+
+```bash
+node dist/cli.js show outfit claude-perm-basic --emit /tmp/perm-test 2>&1
+ls -la /tmp/perm-test/.claude/
+cat /tmp/perm-test/.claude/settings.fragment.json
+```
+
+Expected: `.claude/settings.fragment.json` contains the merged permissions block matching the Task 3 golden.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin feat/permissions-block
+gh pr create --title "feat: permissions block for outfit frontmatter + 4-adapter emit" --body "$(cat <<'EOF'
+## Summary
+- Add `PermissionsBlockSchema` (LCD: mode / bash_allow / mcp.<server>.*, plus per-target passthrough)
+- Attach `permissions:` to OutfitSchema only (cuts/accessories rejected — v2 scope)
+- Emit per-harness: Claude Code settings fragment, Codex TOML, Gemini settings fragment (partial + warnings), Pi permissions.json (passthrough + warnings)
+- Golden-file tests for each adapter
+
+## Test plan
+- [ ] `npm run validate` passes
+- [ ] `npx vitest run` passes (all adapter + schema tests)
+- [ ] `npm run typecheck` passes
+- [ ] Manual emit smoke-tested on each fixture
+EOF
+)"
+```
+
+- [ ] **Step 5: Run local CI before declaring ready**
+
+Per project CLAUDE.md, identify what CI runs (read `.github/workflows/*.yml` in suit) and replicate locally. Common surface: `npm test`, `npm run validate`, `npm run typecheck`, `npm run build`.
+
+Expected: all local CI green before declaring PR ready. If any step depends on infra not reproducible locally, surface explicitly.
+
+- [ ] **Step 6: Wait for human merge and release**
+
+🛑 **PHASE GATE.** Do not proceed to Phase 2 until:
+1. The suit PR is merged to `main`.
+2. A new suit version is published to npm with this schema.
+3. Wardrobe's `suit.config.yaml` (or equivalent pin) is bumped to the new suit version.
+
+The wardrobe canary will fail validation otherwise.
+
+---
+
+## Phase 2 — wardrobe: canary outfit + docs
+
+> **Repo:** `/Users/dmestas/projects/wardrobe`. Branch off `main`: `git checkout -b feat/permissions-canary-backend`.
+
+### Task 8: Add `permissions:` block to `outfits/backend/outfit.md` `[slot: any]`
+
+**Files:**
+- Modify: `outfits/backend/outfit.md` (frontmatter)
+
+- [ ] **Step 1: Read existing frontmatter**
+
+Run: `head -30 outfits/backend/outfit.md`
+Note the current frontmatter shape.
+
+- [ ] **Step 2: Add `permissions:` block to frontmatter**
+
+Insert (preserving existing frontmatter fields):
+
+```yaml
+permissions:
+  mode: default
+  bash_allow:
+    - git
+    - npm
+    - go
+    - rg
+  mcp:
+    signoz:
+      enabled: true
+      enabled_tools:
+        - signoz_search_logs
+        - signoz_query_metrics
+        - signoz_search_traces
+    axiom:
+      enabled: true
+    doppler:
+      enabled: true
+      enabled_tools:
+        - doppler_secrets_get
+        - doppler_secrets_list
+  claude:
+    deny:
+      - "Bash(git push:main)"
+      - "Bash(rm -rf:*)"
+```
+
+Rationale (for plan reader, not the file): `backend` already loads signoz/axiom/doppler MCPs per its CLAUDE.md; this just narrows tool surface. The Claude `deny` block enforces the PR-policy rule at the permission layer rather than relying on the agent reading `pr-policy` accessory text.
+
+- [ ] **Step 3: Validate against suit schema**
+
+Run: `SUIT_CONTENT_PATH=$PWD npm run validate -- --filter backend`
+Expected: PASS
+
+- [ ] **Step 4: Emit and inspect each target**
+
+Run:
+
+```bash
+for t in claude codex gemini pi; do
+  echo "=== $t ==="
+  SUIT_CONTENT_PATH=$PWD suit show outfit backend --target=$t --emit=/tmp/canary-$t 2>&1 | tail -5
+done
+```
+
+Expected: each target produces a permissions artifact in its conventional path; Gemini and Pi log warnings about ignored `bash_allow` entries (this is correct, not a bug).
+
+- [ ] **Step 5: Diff against pre-change emit to confirm scope**
+
+Run:
+
+```bash
+git stash
+SUIT_CONTENT_PATH=$PWD suit show outfit backend --target=claude --emit=/tmp/canary-before
+git stash pop
+diff -ru /tmp/canary-before/.claude /tmp/canary-claude/.claude | head -40
+```
+
+Expected: the only diff is the new `permissions` key in `settings.fragment.json`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add outfits/backend/outfit.md && \
+git commit -m "feat(outfit/backend): add permissions block (canary for new schema)"
+```
+
+---
+
+### Task 9: Document `permissions:` field in HARNESS_INTEGRATION.md `[slot: any]`
+
+**Files:**
+- Modify: `docs/HARNESS_INTEGRATION.md`
+
+- [ ] **Step 1: Read current structure**
+
+Run: `head -120 docs/HARNESS_INTEGRATION.md`
+Note where frontmatter fields are documented (likely a table).
+
+- [ ] **Step 2: Add a `permissions:` section**
+
+Append (or insert in the appropriate frontmatter-fields location):
+
+````markdown
+### `permissions:` (outfit-only, v1)
+
+Authoring surface for harness permission/approval configs. Composed of a thin
+LCD (lowest-common-denominator) plus per-target passthrough.
+
+```yaml
+permissions:
+  # LCD — emitted per-harness via adapter translation
+  mode: default               # default | accept-edits | plan | yolo
+  bash_allow: [git, npm, go]  # exact command names
+  mcp:
+    <server-id>:
+      enabled: true | false
+      enabled_tools: [...]    # optional tool allowlist
+      disabled_tools: [...]   # optional tool denylist (applied after enabled_tools)
+
+  # Passthrough — emitted verbatim into the target's native config
+  claude: { allow: [...], ask: [...], deny: [...], additionalDirectories: [...] }
+  codex:  { approval_policy: ..., sandbox_mode: ..., rules: { prefix_rules: [...] } }
+  gemini: { security: { ... }, mcpServers: { ... } }
+  pi:     { tools: [...] }
+```
+
+**Per-harness coverage:**
+
+| Field | Claude Code | Codex | Gemini | Pi |
+|---|---|---|---|---|
+| `mode` | ✅ `defaultMode` | ✅ `approval_policy` | ✅ `general.defaultApprovalMode` | ⚠️ warn (no setting) |
+| `bash_allow` | ✅ `Bash(<cmd>:*)` | ✅ `rules.prefix_rules[]` | ⚠️ warn (no rule grammar) | ⚠️ warn (use CLI `--tools`) |
+| `mcp.*.enabled` | ✅ | ✅ | ✅ | ⚠️ warn |
+| `mcp.*.enabled_tools` / `disabled_tools` | ✅ | ✅ | ⚠️ warn (server-level only) | ⚠️ warn |
+| `<target>:` passthrough | ✅ | ✅ | ✅ | ✅ |
+
+Missing `permissions:` block = no emit, harness defaults apply.
+
+**Scope (v1):** outfits only. Cuts and accessories declaring `permissions:` will
+fail validation — composition semantics for layered permission merges are
+deferred to v2.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/HARNESS_INTEGRATION.md && \
+git commit -m "docs(harness): document permissions frontmatter field"
+```
+
+---
+
+### Task 10: Push wardrobe canary PR + local CI `[slot: any]`
+
+**Files:** none modified — release workflow only.
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/permissions-canary-backend
+```
+
+- [ ] **Step 2: Identify wardrobe CI**
+
+Run: `ls .github/workflows/ 2>/dev/null && cat .github/workflows/*.yml 2>/dev/null | head -80`
+Note the CI surface (likely `npm run validate` for content checks).
+
+- [ ] **Step 3: Run local equivalents**
+
+Run whatever CI runs, locally. Common surface in wardrobe:
+
+```bash
+npm install
+npm run validate
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "feat(outfit/backend): canary permissions block" --body "$(cat <<'EOF'
+## Summary
+- First wardrobe outfit to author a `permissions:` block (depends on suit `feat/permissions-block` PR being merged + released)
+- Documents the new field in `docs/HARNESS_INTEGRATION.md`
+- Verified emission against all four harness targets
+
+## Test plan
+- [ ] `npm run validate` passes (suit's new schema accepts the block)
+- [ ] `suit show outfit backend --target=<t>` for t in {claude, codex, gemini, pi} emits expected artifacts
+- [ ] Gemini/Pi emit logs ignored-field warnings (expected behavior, not a regression)
+EOF
+)"
+```
+
+- [ ] **Step 5: Check remote CI status**
+
+Run: `gh pr checks $(gh pr view --json number -q .number)`
+Expected: all green. Distinguish transient infra failures from real failures explicitly in the status report.
+
+- [ ] **Step 6: Hand off to human for merge**
+
+Surface the PR URL and wait for manual merge per CLAUDE.md PR policy. After merge:
+
+```bash
+git checkout main && git pull && git branch -d feat/permissions-canary-backend
+git push origin --delete feat/permissions-canary-backend
+git remote prune origin
+```
+
+---
+
+## Self-Review Checklist (run before handoff)
+
+**1. Spec coverage** — every architectural decision from the design conversation:
+- [x] Outfit-only attachment (Task 2)
+- [x] LCD vocabulary = mode + bash_allow + mcp.* (Task 1)
+- [x] Per-target passthrough (Tasks 3–6)
+- [x] No emit when block absent (Task 1 schema makes optional; adapters early-return)
+- [x] Suit-first, wardrobe canary after (phase gate at end of Task 7)
+- [x] Backend as canary outfit (Task 8)
+- [x] Cross-repo PR discipline (Tasks 7 & 10)
+- [x] Local CI before "ready" (Tasks 7.5 & 10.3)
+
+**2. Placeholder scan** — none found. Every code block is concrete.
+
+**3. Type consistency** — `PermissionsBlock` defined once in suit `src/lib/schema.ts`, exported via `src/lib/types.ts`, consumed unchanged in all four adapters. Field names (`mode`, `bash_allow`, `mcp`, `claude`, `codex`, `gemini`, `pi`) used identically across tasks.
+
+**4. Risks not in tasks above:**
+- *Existing evolution detector* (`suit/src/lib/evolution/permissions.ts`) generates session-time diffs to `.claude/settings.json`. Its output could conflict with build-time emit. Not addressed in v1; flag for v2 review.
+- *Codex sandbox_mode interaction with `mode` LCD* — both write into `codex.config.toml` but represent orthogonal concepts. The compiler in Task 4 maps `mode` to `approval_policy` only; `sandbox_mode` is passthrough-only. Documented in Task 9.
+
+---
+
+## Deviations from `writing-plans` skill defaults
+
+- **Plan location**: `docs/plans/` (wardrobe convention), not `docs/bones-powers/plans/`. Wardrobe doesn't use bones.
+- **No bones task materialization**: wardrobe and suit don't use the `bones` task graph. The plan is the executable artifact.
+- **No subagent-driven-development handoff prompt**: cross-repo work with explicit phase gate; the human operator picks execution mode after reviewing this doc.


### PR DESCRIPTION
## Summary

Drafts `docs/plans/2026-05-11-permissions-system.md` — a two-phase plan for adding a `permissions:` block to wardrobe outfit frontmatter, with per-harness emit handled in suit.

- **Phase 1 (suit, 7 tasks):** `PermissionsBlockSchema` (Zod) + 4 adapter emitters (Claude / Codex / Gemini / Pi) + golden-file tests per adapter. Hard phase gate at the end.
- **Phase 2 (wardrobe, 3 tasks):** `outfits/backend` lands the canary `permissions:` block, `docs/HARNESS_INTEGRATION.md` documents the field.

**Design calls baked into the plan:**
- LCD vocabulary: `mode` + `bash_allow` + `mcp.<server>.{enabled, enabled_tools, disabled_tools}`
- Per-target passthrough (`permissions.claude.*`, `.codex.*`, `.gemini.*`, `.pi.*`) deep-merged over LCD output (target wins)
- Outfit-only attachment in v1; cuts/accessories rejected by Zod `.strict()` — deferred to v2 once layered-merge precedence is settled
- Gemini/Pi emit non-fatal warnings for unmappable LCD fields (no Bash grammar / no settings-level mode)
- Existing `suit/src/lib/evolution/permissions.ts` untouched and flagged for v2 review

**Risks called out in self-review:**
- Build-time emit could conflict with the session-time evolution detector at the same JSON path
- Codex `sandbox_mode` and LCD `mode` both write to `codex.config.toml` but represent orthogonal concepts; sandbox_mode is passthrough-only

## Test plan

This PR is plan-doc only — wardrobe CI path-ignores `docs/**`, so no checks run remotely. Local sanity:

- [x] `npm run validate` passes (129 components, 3 pre-existing warnings unrelated to this change)
- [x] No code change in this PR; full validation handled in the suit + wardrobe PRs the plan describes