### PR TITLE
feat(outfit/backend): canary permissions.claude-code + docs

### DIFF
--- a/docs/HARNESS_INTEGRATION.md
+++ b/docs/HARNESS_INTEGRATION.md
@@ -33,6 +33,7 @@ Every authored component has YAML frontmatter on a manifest file (`SKILL.md`, `A
 | `skill_include` / `skill_exclude` | string[] | Outfit/cut: skill manifest. |
 | `include` | object | Accessory: `{ skills?, rules?, hooks?, agents?, commands? }`. |
 | `overrides` | object | Per-target field overrides: `{ <target>: { ...harness-specific... } }`. |
+| `permissions` | object | Outfit-only (v1). Per-target passthrough emitted into the harness's native permission config. Four opaque sub-fields keyed by `Target` enum: `claude-code`, `codex`, `gemini`, `pi`. See "Permissions emit" below. |
 
 The canonical schema (Zod, with full validation) lives in [`suit/src/lib/schema.ts`](https://github.com/danmestas/suit/blob/main/src/lib/schema.ts) and the composition algorithm in [`suit/src/lib/rules.ts`](https://github.com/danmestas/suit/blob/main/src/lib/rules.ts). When in doubt, read those — this doc enumerates the fields wardrobe authors actually fill in, not every field the schema permits.
 
@@ -64,6 +65,46 @@ This is what suit emits today for the kept harnesses. A new adapter mirrors the 
 | `pi` | `.pi/AGENTS.md`, `.pi/skills/<name>/SKILL.md`, `.pi/extensions/<name>/...` for runtime extensions |
 
 The tracked source in this repo lives under `outfits/`, `cuts/`, `accessories/`, `skills/`, `agents/`, `rules/`, `hooks/`, `commands/`. Everything at the repo root that names a harness (`CLAUDE.md`, `GEMINI.md`, `.claude/`, `.gemini/`, `.pi/`, `AGENTS.md`) is *emitted* by suit, not authored. Don't hand-edit those files in this repo — your edits get clobbered the next build.
+
+### Permissions emit (suit ≥ 0.14)
+
+Outfits may carry a `permissions:` frontmatter block to author harness-native
+permission config. The block has four opaque sub-fields, one per target. Each
+sub-block is emitted verbatim into the target's native permission file via
+deep-merge — no cross-harness translation, no LCD vocabulary.
+
+```yaml
+permissions:
+  claude-code:
+    allow: ["Bash(git status:*)", "mcp__signoz__signoz_search_logs"]
+    deny:  ["Bash(rm -rf:*)"]
+  codex:
+    approval_policy: on-request
+    sandbox_mode: workspace-write
+  gemini:
+    general: { defaultApprovalMode: default }
+    security: { folderTrust: { enabled: true } }
+  pi:
+    tools: [read, bash, write]
+```
+
+| Target | Output file | Note |
+|--------|-------------|------|
+| `claude-code` | `.claude/settings.local.json` (`permissions` key) | Wrapped under a `permissions:` key, matching Claude's settings shape. Merged with hook fragments at the same path. |
+| `codex` | `codex.config.toml` | Top-level merge. Coexists with MCP emit at the same path via TOML deep-merge in `suit/lib/merge.ts`. |
+| `gemini` | `.gemini/settings.fragment.json` | Top-level merge. |
+| `pi` | `.pi/permissions.json` | Forward-compat marker. Pi today has no declarative permission surface — file is consistent with the existing `.pi/mcp.experimental.json` convention. |
+
+Missing block, or missing target sub-block, = no emit and harness defaults apply.
+
+**Scope (v1):** outfits only. Cuts and accessories declaring `permissions:`
+fail validation (Zod `.strict()`); layered composition semantics for
+permission merges across the resolution stack are deferred to v2.
+
+Each target's sub-block is written in that harness's native syntax — there is
+no cross-harness rule translation in v1. Authoring `bash_allow: [git]` once and
+expecting it to populate all four targets won't work; declare the rule in each
+target sub-block where you want it.
 
 ## DIY playbook
 

--- a/docs/plans/2026-05-11-permissions-system.md
+++ b/docs/plans/2026-05-11-permissions-system.md
@@ -1,5 +1,7 @@
 # Permissions System Implementation Plan
 
+> **STATUS — landed.** Phase 1 (suit) shipped as `@agent-ops/suit@0.14.0` (suit PR #59); Phase 2 (wardrobe canary + docs) shipped via this plan's same branch. The implementation is the source of truth — read [`suit/src/lib/schema.ts`](https://github.com/danmestas/suit/blob/main/src/lib/schema.ts) for the canonical schema. See "Implementation notes — post-merge" at the end of this doc for the deviations encountered during execution.
+
 > **For agentic workers:** Use `subagent-driven-development` (recommended) or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This plan spans two repos; respect the **phase gate** at the end of Phase 1.
 
 **Goal:** Let wardrobe outfits author a `permissions:` block in frontmatter that suit emits verbatim into each target harness's native permission config file.
@@ -1006,3 +1008,39 @@ Passthrough-only is the smallest honest interface. LCD verbs are a v2 candidate,
 - **Plan location**: `docs/plans/` (wardrobe convention), not `docs/bones-powers/plans/`. Wardrobe doesn't use bones.
 - **No bones task materialization**: wardrobe and suit don't use the `bones` task graph. The plan is the executable artifact.
 - **No subagent-driven-development handoff prompt**: cross-repo work with explicit phase gate; the human operator picks execution mode after reviewing this doc.
+
+---
+
+## Implementation notes — post-merge
+
+Deviations between the plan as written and what actually shipped. Recorded so future agents reading this doc don't re-make the same assumptions.
+
+### Schema key naming: `claude-code`, not `claude`
+
+The plan's YAML examples used `permissions.claude.*` everywhere. Implementation uses `permissions.claude-code.*` to match suit's existing `Target` enum (`['claude-code', 'codex', 'gemini', 'pi']`), the same name authors already write in `targets:`. Eliminates an internal mapping in `applyPassthroughPermissions` (just indexes by `Target` directly). The wardrobe canary in `outfits/backend/outfit.md` reflects the final shape.
+
+### TOML merge support added to `lib/merge.ts` (scope expansion)
+
+The plan did not anticipate that `codex.config.toml` would already be a multi-source emit path. The existing `emitMcp` in `suit/src/adapters/codex.ts` writes there; an outfit's `permissions.codex` emit would collide at `compose.ts#dedupeByPath` because `isJsonMergeable('codex.config.toml')` is false. Added during Phase 1 Task 5:
+
+- `isTomlMergeable(filepath)` / `mergeTomlBuffers(a, b)` — TOML parse → deepMerge → re-stringify via `@iarna/toml`
+- `isMergeable(filepath)` / `mergeBuffers(filepath, a, b)` dispatcher (handles both JSON and TOML)
+- `compose.ts` updated to use the dispatcher
+
+10 new merge tests cover this. The change is API-additive: existing `isJsonMergeable` / `mergeJsonBuffers` still export.
+
+### Suit local CI is `typecheck + build + test`, not `npm run validate`
+
+The plan's Task 7 step 5 instructs `npm run validate` for suit. That script doesn't exist in suit — it's a wardrobe-only script. Suit's CI (`.github/workflows/ci.yml`) runs `npm run typecheck` (`tsc --noEmit`), `npm run build` (`tsc + postbuild`), `npm link`, and `npm test` (`vitest run`). The Phase 1 PR mirrored all four locally before push.
+
+### Outfit case in adapters: previously `[]`, now emits per-target
+
+The plan implicitly assumed adapters had a `permissions` emit slot to extend. They didn't — every adapter's outfit case returned `[]` with the comment "Outfits are harness-agnostic, consumed by `ac` at resolution time. Not emitted per-target." The Phase 1 implementation changed that contract for outfits (cuts/accessories still emit `[]`). Each adapter's outfit case now routes to an `emitOutfit(component)` function that calls `applyPassthroughPermissions` and writes the target-native file.
+
+### `Bash(git push:main)` doesn't match Claude's rule grammar
+
+The plan's canary suggested denying `Bash(git push:main)`. Claude's rule grammar treats `:<suffix>` as a prefix match on args, so this rule would match `git push main` (no remote argument) but NOT `git push origin main`. There's no way to express "deny push specifically to the main branch" with the rule grammar alone — that's a hooks job. The actual canary in `outfits/backend/outfit.md` denies `Bash(git push --force:*)` and `Bash(git push -f:*)` instead; the "no push to main" intent is enforced via the `pr-policy` accessory's prose rules.
+
+### Files committed as `.fragment.json`, runtime resolves to `.local.json`
+
+The plan referenced `.claude/settings.fragment.json` as the Claude destination. That's the *adapter-level* emit name; `compose.ts` then merges all fragments and `up.ts` (or the prepare workflow) writes the runtime-visible `.claude/settings.local.json` (or `.claude/settings.json`, depending on flags). Both names are accurate at different layers. `HARNESS_INTEGRATION.md` references the user-visible `.local.json` since that's what authors interact with; this plan retains the `.fragment.json` references since they describe the adapter contract.

--- a/outfits/backend/outfit.md
+++ b/outfits/backend/outfit.md
@@ -37,6 +37,29 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+permissions:
+  claude-code:
+    allow:
+      - "Bash(git status:*)"
+      - "Bash(git diff:*)"
+      - "Bash(git log:*)"
+      - "Bash(git branch:*)"
+      - "Bash(git fetch:*)"
+      - "Bash(go test:*)"
+      - "Bash(go build:*)"
+      - "Bash(go vet:*)"
+      - "Bash(go fmt:*)"
+      - "Bash(go run:*)"
+      - "Bash(npm run test:*)"
+      - "Bash(npm run validate:*)"
+      - "mcp__signoz__signoz_search_logs"
+      - "mcp__signoz__signoz_query_metrics"
+      - "mcp__signoz__signoz_search_traces"
+      - "mcp__signoz__signoz_list_services"
+    deny:
+      - "Bash(rm -rf:*)"
+      - "Bash(git push --force:*)"
+      - "Bash(git push -f:*)"
 ---
 
 # Backend Outfit


### PR DESCRIPTION
## Summary

First wardrobe outfit to author a `permissions:` block, using the new `@agent-ops/suit@0.14.0` schema. Three commits:

1. **`outfits/backend/outfit.md`** — Claude-only `permissions:` block:
   - **allow**: common safe git reads, Go test/build/run, npm test+validate, signoz read-only MCP tools
   - **deny**: `Bash(rm -rf:*)`, `Bash(git push --force:*)`, `Bash(git push -f:*)`
2. **`docs/HARNESS_INTEGRATION.md`** — adds `permissions` row to the frontmatter table and a "Permissions emit" subsection documenting per-target output files and v1 scope.
3. **`docs/plans/2026-05-11-permissions-system.md`** — appends a post-merge implementation-notes section recording the actual divergences from the plan (schema key naming, TOML merge addition, CI surface mismatch, etc.).

## End-to-end verification

Ran `suit prepare --outfit backend --target claude-code` against this branch. Output at `.claude/settings.local.json`:

```json
{
  "hooks": { ... existing hook fragments ... },
  "permissions": {
    "allow": ["Bash(git status:*)", "Bash(go test:*)", "mcp__signoz__signoz_search_logs", ...],
    "deny":  ["Bash(rm -rf:*)", "Bash(git push --force:*)", "Bash(git push -f:*)"]
  }
}
```

Hook fragments and the new permissions block coexist via the deep-merge pipeline. Other targets (codex/gemini/pi) produce no permission artifact since the outfit has no sub-block for them.

## Test plan

- [x] `npm run validate` — 129 components OK, 3 pre-existing unrelated warnings
- [x] `npm run build -- --target all --dry-run` — 129 files across 4 targets
- [x] `suit prepare --outfit backend --target claude-code` smoke test — permissions block emitted under settings.local.json `permissions` key, merged with existing hook fragments

## Notes on grammar limitations

The canary intentionally omits `Bash(git push:main)` (which would only match `git push main`, not `git push origin main`). The "no push to main" intent is enforced via the `pr-policy` accessory's prose rules, not the rule grammar. The deny list catches `--force` / `-f` push variants since those are real footguns.

## Out of scope

- Adding `permissions.codex` / `.gemini` / `.pi` sub-blocks — deferred until per-harness authoring patterns settle
- Touching other outfits — backend is the first canary; expansion is a follow-up