### PR TITLE
docs(subagent-driven-development): coordinator owns wakeups + monitors

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -150,6 +150,16 @@ Spec-compliance and code-quality reviewers are read-only — they inspect the im
 
 If a reviewer needs write access (e.g., to annotate or commit a finding), open a sibling slot session (e.g., `--slot=spec-review`, `--slot=code-review`) via a separate `bones swarm join`.
 
+## Subagent Boundaries: Coordinator Owns Scheduling
+
+The coordinator owns all wakeups, cron schedules, and Monitor lifecycles for the duration of a parallel-subagent run. Subagents must NOT call `ScheduleWakeup`, `CronCreate`, or arm Monitors of their own — not even as safety nets against their own slowness.
+
+**Why:** subagents finish their work and report back, but any wakeups they scheduled keep firing later against a coordinator that has moved on. The coordinator has no authoritative way to cancel a subagent's leaked schedule without paging through every subagent's task graph. Real-world observation: parallel worktree subagents scheduled "safety net" `/loop` wakeups in case they hung; they didn't hang, they finished cleanly, and the wakeups then fired hours later as stale no-ops at the coordinator — the coordinator had to spend turns confirming each one was a no-op against already-merged work.
+
+Bake the prohibition into every implementer prompt explicitly: *"do not call `ScheduleWakeup`, `CronCreate`, or arm Monitors; report back when done."* If a subagent genuinely needs to wait on an external event (CI finishing, deploy completing, log line matching), the coordinator arms the Monitor at the coordinator level after the subagent reports back — the subagent's job is to finish and exit, not to manage cadence.
+
+This applies to both `bones swarm join` flows and direct `Agent`-tool dispatches with `isolation: "worktree"`. The rule is about who owns the lifecycle, not about the dispatch mechanism.
+
 ## Model Selection
 
 Use the least powerful model that can handle each role to conserve cost and increase speed.
@@ -323,6 +333,7 @@ Done!
 - **Start code quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
 - **Mirror bones tasks into TodoWrite at coordinator level** (source of truth is bones tasks, not TodoWrite)
+- **Allow a subagent to call `ScheduleWakeup`, `CronCreate`, or arm a Monitor** (those belong to the coordinator — see "Subagent Boundaries" above)
 
 **If subagent asks questions:**
 - Answer clearly and completely

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -32,6 +32,13 @@ Task tool (general-purpose):
     bones swarm commit -m '<progress note>'
     ```
 
+    **Lifecycle constraint:** Do NOT call `ScheduleWakeup`, `CronCreate`, or arm Monitors —
+    those belong to the coordinator. Report back when your work is done; the coordinator
+    handles any follow-up cadence or external-event waiting. Even if you think "I'll
+    schedule a check-in just in case I get stuck" — don't. You typically finish faster
+    than that wakeup window, and the wakeup then fires later as a stale no-op against
+    a coordinator that has moved on.
+
     ---
 
     You are implementing Task N: [task name]


### PR DESCRIPTION
## Summary

Document the rule that subagents must NOT call `ScheduleWakeup`, `CronCreate`, or arm Monitors of their own — the coordinator owns all wakeup / cron / monitor lifecycles for the duration of a parallel-subagent run.

Two surfaces:
- **`SKILL.md`** — new "Subagent Boundaries: Coordinator Owns Scheduling" section + matching "Never" red flag bullet.
- **`implementer-prompt.md`** — lifecycle constraint paragraph so the rule is baked into every dispatched subagent's prompt.

## Why

Observed in production during a parallel-worktree AFK run (7 PRs against an external repo, 3 waves): two implementer subagents scheduled `/loop` "safety net" wakeups before completing, in case they got stuck. They didn't get stuck — they finished cleanly. The wakeups then fired hours later as stale no-ops at the coordinator, which had already shipped the work and moved on. Each one cost a coordinator turn to verify-and-dismiss.

The rule applies to both `bones swarm join` flows and direct `Agent`-tool dispatches with `isolation: \"worktree\"`. It's about who owns the lifecycle, not about the dispatch mechanism.

## Test plan

- [ ] Doc-only change; no code paths affected.
- [ ] Lint locally if a docs-lint exists in the repo.