### PR TITLE
feat(fit-axis): seniority-tier overlays + superpowers refresh + spec-kit

### DIFF
--- a/docs/plans/2026-05-14-fit-axis-seniority-tiers.md
+++ b/docs/plans/2026-05-14-fit-axis-seniority-tiers.md
@@ -1,0 +1,187 @@
+---
+title: Fit axis — seniority-tier component for the wardrobe
+status: Accepted
+date: 2026-05-14
+owner: dan
+---
+
+# Fit axis — seniority-tier component for the wardrobe
+
+## Summary
+
+Add a fourth wardrobe axis — `fit` — that expresses **seniority tier**, orthogonal to outfit (role), cut (work-shape), and accessory (context bundles). Ship four fits in this PR: `junior-engineer`, `engineer`, `senior-engineer`, `staff-engineer`. The fit composes with whatever outfit/cut/accessory the session already picked, layering tier-specific skill loadout and a posture prompt body.
+
+Architectural note: seniority is acknowledged as a semantic stretch on the wardrobe "fit" metaphor (clothes fit; engineers don't). Decision recorded in [open question 1](#composition-semantics) — kept for vocab consistency with outfit/cut/accessory.
+
+## Architectural decisions
+
+**Upstream (suit) change required — small.** `fit` is a new component type. Suit already runs set-algebra composition across outfit/cut/accessory; the ask is just to **register `fit` as a fourth input to the existing pipeline**. Concretely: parse `--fit <name>` CLI flag, resolve `fits/<name>/fit.md`, feed into the same compose-and-dedupe step. No new architecture in suit, just one more axis registered. Per upstream-fix policy, files at github.com/danmestas/suit first; wardrobe PR is blocked on suit landing.
+
+**Wardrobe schema.** Fit YAML frontmatter mirrors cut's shape:
+
+```yaml
+---
+name: senior-engineer
+version: 1.0.0
+type: fit                  # NEW component type
+description: Seniority overlay for fluent engineers — adds philosophy, language tooling, and design judgment.
+targets: [claude-code, codex, gemini, pi]
+categories: [economy, workflow, backpressure, evolution, context-management]
+enable:
+  plugins: [gopls-lsp]     # LSP loadout per tier
+  mcps: []
+  hooks: []
+skill_include: [...]
+skill_exclude: [...]
+include:
+  rules: []
+  hooks: []
+  agents: []
+  commands: []
+---
+```
+
+**Composition semantics — Option A (decided).** Fit is a strict overlay layered onto outfit/cut/accessory composition. Set-algebra dedup (already implemented in suit) handles overlap. `--outfit engineer --fit engineer` is allowed and harmlessly redundant. A fit alone (no outfit) is allowed but uncommon. B/C alternatives discussed in the prior revision are deferred indefinitely — revisit only if real friction emerges.
+
+## Skill loadout per fit
+
+### junior-engineer
+
+**Posture (prompt body):** Heavy guardrails. Ask before destructive ops. Run every verification rail. Default to test-first. Explain reasoning explicitly. Trust the model to call `ExitPlanMode` when it judges a plan helps (no meta-skill needed for plan-vs-no-plan).
+
+**Skills (in addition to core4 — writing-plans, brainstorming, subagent-driven-development, systematic-debugging):**
+- `test-driven-development` (rule-heavy, force learning)
+- `verification-before-completion` (don't claim done early — this is the "simple code verifier")
+- `stuck-detector` (off-ramp from doom loops)
+- `course-correct` (mid-task pivot)
+- `pocock-caveman` (terse, decisive — rule-heavy communication)
+- `pocock-handoff` (clean handoff structure — explicit reasoning trail)
+- `pocock-diagnose` (reproduce → minimize → hypothesize → fix → regression — rule-heavy debugging)
+- `pocock-git-guardrails` (only loads if git is present — fails closed otherwise)
+- `pocock-setup-pre-commit` (optional, only on TS/JS projects)
+
+**Explicitly skipped:** `ousterhout`, `hipp`, `tigerstyle`, `farley` — these demand mature taste-judgment. Wrong for a novice. Wardrobe-existing `tigerstyle` is the user's explicit "not tigerstyle" call.
+
+### engineer
+
+**Posture:** The standard. Apply rigor uniformly. Tighter than junior, less philosophy than senior.
+
+**Skills:** The full refreshed `obra/superpowers` set (no-git-scrubbed):
+- writing-plans, brainstorming, subagent-driven-development, systematic-debugging
+- executing-plans, dispatching-parallel-agents
+- test-driven-development, verification-before-completion
+- requesting-code-review, receiving-code-review
+- writing-skills (NEW from superpowers, not currently in wardrobe)
+- using-superpowers (NEW meta-skill that documents how the pack composes)
+
+**Dropped from superpowers entirely:** `using-git-worktrees`, `finishing-a-development-branch` (both built around git, 47/46 git-term hits respectively).
+
+**Explicitly skipped:** philosophy stack (ousterhout, tigerstyle, hipp, farley), LSPs, backpressure category. Those graduate the user to `senior-engineer`.
+
+**Sharp engineer→senior gap is intentional** — engineer = "executing well with the basics", senior = "starts thinking about design".
+
+### senior-engineer
+
+**Posture:** Trust convention. Design before code on non-trivial changes. Flag taste calls but decide implementation. Lean into parallel-agent dispatch and post-task reflection.
+
+**Skills:** Everything in `engineer` fit, plus:
+- BackPressure category (load via `categories: [backpressure]` or explicit `skill_include`):
+  - `course-correct`, `dx-audit`, `hipp`, `norman`, `ousterhout`, `stuck-detector`, `tigerstyle`, `verification-before-completion` (most already loaded; this completes the set)
+  - `golang-patterns` only via outfit (not auto-loaded by fit since fit is language-agnostic)
+- `farley` (continuous delivery / testing discipline)
+- `reflect` (post-task critique)
+
+**Tigerstyle/ousterhout/hipp usage notes** (per user — these load but trigger conditionally per their own descriptions):
+- `tigerstyle` triggers on low-level code review (its own description gate)
+- `ousterhout` triggers after spec/code review (deep-modules / cognitive-load lens)
+- `hipp` triggers when scoping a small, no-dependency stack
+
+**LSPs:** `enable.plugins: [gopls-lsp]` (currently the only LSP plugin). Other-language LSPs auto-pick-up if/when they exist.
+
+### staff-engineer
+
+**Posture:** Think in systems. Prioritize boundaries and cross-cutting concerns. Mentor through review. ADR-first on architectural forks.
+
+**Skills:** Everything in `senior-engineer` MINUS superpowers, PLUS:
+- `using-spec-kit` (NEW skill — see below) replacing the superpowers workflow scaffolds (writing-plans / executing-plans / etc. still load via core4 + senior inheritance)
+- All BackPressure category (same as senior)
+- `architect-review` agent (likely under `agents/` — verify exists; if not, defer)
+
+**Explicitly drops:** `course-correct` from skill_include — assumes self-correcting.
+
+**LSPs:** same as senior.
+
+## New skills to author / vendor
+
+### 1. `skills/using-spec-kit/SKILL.md` (NEW)
+
+Triggers on spec-driven workflow requests for staff-fit-flavored sessions. Body:
+- Sets `SPECIFY_FEATURE_DIRECTORY=.agent-config/specs/$slug` before invoking `/speckit.*` commands
+- Adds `.agent-config/specs/` to `.gitignore` if not already present
+- Documents the `/speckit.constitution` → `/speckit.specify` → `/speckit.plan` → `/speckit.tasks` → `/speckit.implement` chain
+- Lazy-initializes spec-kit: `uvx --from git+https://github.com/github/spec-kit.git specify-cli init . --integration claude` on first invocation, only if `.specify/` doesn't exist
+- Gotcha documented: `.specify/` (templates, constitution, integration.json) MUST live at repo root — it's the project marker
+
+Note: The user wanted specKit files in temp folders, NOT worktree. Resolution: artifacts (`.agent-config/specs/<slug>/spec.md`, plan.md, tasks.md) relocate cleanly via env var. The `.specify/` config directory is a hard repo-root requirement — gitignore it instead of relocating.
+
+### 2. `skills/pocock-{caveman,handoff,diagnose,git-guardrails,setup-pre-commit}/SKILL.md` (NEW × 5)
+
+Vendor from `mattpocock/skills` (MIT). Preserve LICENSE attribution in a top-level `skills/pocock-*/UPSTREAM.md` per skill or in the wardrobe `THIRD_PARTY.md`.
+
+Curation rationale: Pocock's repo is mostly senior-flavored (grill-with-docs, improve-codebase-architecture, zoom-out — taste-heavy). Junior subset is rule-heavy + process-focused.
+
+### 3. `skills/writing-skills/SKILL.md`, `skills/using-superpowers/SKILL.md` (NEW × 2)
+
+Vendor from obra/superpowers — these don't currently exist in wardrobe. Apply no-git scrub (writing-skills has 4 git mentions, using-superpowers has 6).
+
+## Refreshed (rewritten) existing wardrobe skills
+
+Replace these 10 wardrobe skills with no-git-scrubbed upstream versions of `obra/superpowers`:
+
+| Skill | Upstream git mentions | Patch scope |
+|---|---|---|
+| brainstorming | 0 | clean import |
+| dispatching-parallel-agents | 0 | clean import |
+| requesting-code-review | 0 | clean import |
+| test-driven-development | 0 | clean import |
+| executing-plans | 1 (worktree) | 1-line patch |
+| subagent-driven-development | 1 (worktree) | 1-line patch |
+| verification-before-completion | 1 (PR) | 1-line patch |
+| receiving-code-review | 1 (PR) | 1-line patch |
+| writing-plans | 3 (1 worktree + 1 commit + 1 add) | 3-line patch |
+| systematic-debugging | 3 (worktree) | 3-line patch |
+
+**Blast radius:** Every outfit currently using these skills (engineer, backend, code, implementer, planner, reviewer, quick — likely all) inherits the no-git rewrite. Most of these are skill-internal nudges ("commit your progress before...", "spawn a worktree to...") that can be made tool-agnostic ("checkpoint your progress", "spawn an isolated work area") without losing meaning.
+
+**Mitigation:** Run `npm run validate` after the rewrite; spot-check 2-3 outfits to confirm no regressions.
+
+## Composition semantics — Option A (decided)
+
+Fit composes as a strict overlay onto the existing set-algebra pipeline (suit already runs this across outfit/cut/accessory; fit becomes a fourth axis fed in). `--outfit code --fit senior` = code's skills ∪ senior fit's additions, dedupe. Redundancy on `--outfit engineer --fit engineer` is accepted as harmless. Fit-alone launches are allowed but uncommon — outfit remains the conventional base.
+
+## Tasks / sequence
+
+1. **Get plan sign-off** (this doc).
+2. **File suit issue** (upstream — github.com/danmestas/suit). Issue body includes the fit YAML schema and composition rules from this plan.
+3. **Create feature branch** `feat/fit-axis-seniority-tiers` in wardrobe.
+4. **Refresh superpowers** (10 existing skills replaced + 2 new + 2 dropped from upstream). Validate other outfits.
+5. **Vendor Pocock subset** (5 new skills, preserve MIT attribution).
+6. **Author using-spec-kit skill** (with env-var spec-storage trick).
+7. **Author 4 fit files** (junior-engineer, engineer, senior-engineer, staff-engineer).
+8. **Validate** — `npm run validate`, `npm run build --target claude-code`. Spot-check 2-3 affected outfits.
+9. **Open wardrobe PR.** Block on suit issue landing.
+10. **Cleanup** post-merge per pr-policy.
+
+## Risks
+
+- **Blast radius of superpowers refresh** — 10 existing skills rewritten. Mitigated by validation pass; could be staged into a separate refresh PR if too noisy.
+- **Pocock vendor naming conflict** — if Pocock has a skill named `tdd` and wardrobe already has `test-driven-development`, the import naming (`pocock-tdd` vs absorbing into existing) needs deciding. Plan currently uses `pocock-*` prefix to avoid collision.
+- **Fit-as-seniority semantic stretch** — accepted, but flag in README so future contributors know `fit` ≠ "fit for purpose" but seniority-tier.
+- **Suit-side change rate** — wardrobe PR is blocked until suit lands `--fit`. If suit dev capacity is constrained, wardrobe scaffolding can land first as orphan content (suit ignores it) with PR title flagged "blocked on suit#N".
+
+## Resolved decisions (2026-05-14 sign-off)
+
+1. **Composition semantics:** Option A (overlay-additive). Suit already does set algebra on outfit/cut/accessory — fit just registers as a fourth input.
+2. **Superpowers refresh blast radius:** single PR with validation pass; do not stage a separate refresh-first PR.
+3. **Pocock import naming:** `pocock-*` prefix on all imported skills (`pocock-caveman`, `pocock-diagnose`, etc.) to avoid collision and signal provenance.
+4. **Architect-review agent:** confirmed exists at `agents/architect-review/`. Staff fit wires it in via `include.agents`.

--- a/fits/engineer/fit.md
+++ b/fits/engineer/fit.md
@@ -1,0 +1,83 @@
+---
+name: engineer
+version: 1.0.0
+type: fit
+description: 'Standard engineering tier — the superpowers workflow scaffold (no-git): plan, execute, verify, review, dispatch. Use as default for fluent engineers shipping reasonably-scoped changes.'
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - economy
+enable:
+  plugins: []
+  mcps: []
+  hooks: []
+disable:
+  plugins: []
+  mcps: []
+  hooks: []
+skill_include: []
+skill_exclude:
+  - ousterhout
+  - tigerstyle
+  - hipp
+  - farley
+  - norman
+  - dx-audit
+include:
+  skills:
+    - writing-plans
+    - brainstorming
+    - subagent-driven-development
+    - systematic-debugging
+    - executing-plans
+    - dispatching-parallel-agents
+    - verification-before-completion
+    - test-driven-development
+    - requesting-code-review
+    - receiving-code-review
+    - using-superpowers
+    - writing-skills
+  rules: []
+  hooks: []
+  agents: []
+  commands: []
+---
+
+# Engineer Fit
+
+You are operating at engineer tier. Apply the superpowers workflow uniformly: plan, execute, verify, review.
+
+## Posture
+
+- **Plan before non-trivial code.** `writing-plans` produces the plan; `executing-plans` works it. For trivial changes, plan mentally and skip the plan doc.
+- **Test-first when there's a behavioral surface.** `test-driven-development` is the default loop; red-green-refactor.
+- **Verify before claiming done.** `verification-before-completion` is the gate.
+- **Dispatch subagents for parallelizable work.** Multi-file reads, mechanical refactors, broad searches — these batch well. `dispatching-parallel-agents` is the playbook.
+- **Trust convention on tooling/naming.** Decide implementation details unilaterally and state the decision in one sentence. Surface only taste/architecture/ethics/reversibility forks for user input.
+- **Self-correct on review.** `receiving-code-review` is how you process feedback; `requesting-code-review` is how you ask for it.
+
+## What's NOT loaded
+
+This fit deliberately excludes the philosophy stack (`ousterhout`, `tigerstyle`, `hipp`, `farley`) and `dx-audit`/`norman`. Those land at senior tier. The engineer tier is about *executing well with the basics*, not design judgment.
+
+If a task genuinely demands deep design thinking, the right move is to escalate the session to `--fit senior-engineer`, not to load philosophy ad-hoc.
+
+## Workflow scaffold
+
+Read `using-superpowers` once at session start — it documents how the pack composes. `writing-skills` is available for the rare case where a missing capability deserves its own skill.
+
+## Pairing
+
+| With | When |
+|---|---|
+| `--outfit code` | Default — light generalist + engineer rigor |
+| `--outfit backend` | Go-flavored backend work |
+| `--outfit frontend` | UI/UX work |
+| `--cut executing` | Working a known plan |
+| `--cut debugging` | Hunting a bug (re-adds observability MCPs) |
+| `--cut planning` | Designing before code |
+| `--accessory pr-policy` | Recommended default |

--- a/fits/junior-engineer/fit.md
+++ b/fits/junior-engineer/fit.md
@@ -1,0 +1,80 @@
+---
+name: junior-engineer
+version: 1.0.0
+type: fit
+description: 'Junior tier — heavy guardrails, rule-heavy discipline, ask-before-act. Use when the operator is a novice or the task is small/well-bounded and speed-with-rails beats judgment.'
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - backpressure
+enable:
+  plugins: []
+  mcps: []
+  hooks: []
+disable:
+  plugins: []
+  mcps: []
+  hooks: []
+skill_include: []
+skill_exclude:
+  - ousterhout
+  - tigerstyle
+  - hipp
+  - farley
+  - norman
+include:
+  skills:
+    - test-driven-development
+    - verification-before-completion
+    - stuck-detector
+    - course-correct
+    - pocock-caveman
+    - pocock-handoff
+    - pocock-diagnose
+    - pocock-git-guardrails
+    - pocock-setup-pre-commit
+  rules: []
+  hooks: []
+  agents: []
+  commands: []
+---
+
+# Junior Engineer Fit
+
+You are operating at junior-engineer tier. Run every guardrail; do not optimize for speed by skipping rails.
+
+## Posture
+
+- **Ask before destructive ops.** File deletion, branch deletion, force-push, schema migrations, anything that touches shared state — pause and confirm. Cost of a question is tiny; cost of an unwanted delete is large.
+- **Plan-or-no-plan, per task.** Trivial, well-bounded change (one file, one obvious edit): just do it. Ambiguous, multi-file, or design-shaped: enter plan mode (`ExitPlanMode`) and get plan approval before editing. When in doubt, plan.
+- **Default to test-first.** If the change has a behavioral surface, write the failing test first via `test-driven-development`. If you can't write the test, your understanding is too shallow — pause and explain.
+- **Run verification before claiming done.** `verification-before-completion` is the gate. Lint, type-check, tests, and a self-review of the diff. "Looks right" is not done.
+- **Off-ramp when stuck.** Three failed attempts at the same problem → invoke `stuck-detector` and produce a handoff summary instead of grinding.
+- **Explain reasoning.** Commit messages and PR descriptions should assume a reviewer with zero context. Why, not what.
+
+## Communication style
+
+- Lean on `pocock-caveman` for terse, decisive responses.
+- Use `pocock-handoff` when wrapping a session or context-shifting — leave a clean trail.
+
+## Debugging
+
+- `pocock-diagnose` is the debugging workflow: reproduce → minimize → hypothesize → fix → regression-test. Don't skip the minimize step.
+- `systematic-debugging` (from core4) provides the broader discipline; pocock-diagnose is the rule-heavy junior-friendly version.
+
+## Excluded skills
+
+The philosophy stack (`ousterhout`, `tigerstyle`, `hipp`, `farley`) is dropped at this tier — those demand mature taste judgment. Graduate to `senior-engineer` fit when ready.
+
+## Pairing
+
+| With | When |
+|---|---|
+| `--outfit code` | Lightweight generalist sessions |
+| `--outfit engineer` | Engineering work with extra rails (the engineer outfit's philosophy gets stripped by this fit) |
+| `--cut executing` | Working a plan that's already written |
+| `--accessory pr-policy` | Always recommended at this tier |

--- a/fits/senior-engineer/fit.md
+++ b/fits/senior-engineer/fit.md
@@ -1,0 +1,88 @@
+---
+name: senior-engineer
+version: 1.0.0
+type: fit
+description: 'Senior tier — superpowers stack + philosophy (ousterhout/tigerstyle/hipp/farley) + LSPs + backpressure rails. Use when design judgment, deep-modules thinking, and parallel-agent dispatch matter as much as execution.'
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - economy
+  - backpressure
+  - evolution
+enable:
+  plugins:
+    - gopls-lsp
+  mcps: []
+  hooks: []
+disable:
+  plugins: []
+  mcps: []
+  hooks: []
+skill_include: []
+skill_exclude: []
+include:
+  skills:
+    - writing-plans
+    - brainstorming
+    - subagent-driven-development
+    - systematic-debugging
+    - executing-plans
+    - dispatching-parallel-agents
+    - verification-before-completion
+    - test-driven-development
+    - requesting-code-review
+    - receiving-code-review
+    - using-superpowers
+    - writing-skills
+    - ousterhout
+    - tigerstyle
+    - hipp
+    - farley
+    - course-correct
+    - stuck-detector
+    - dx-audit
+    - norman
+    - reflect
+  rules: []
+  hooks: []
+  agents: []
+  commands: []
+---
+
+# Senior Engineer Fit
+
+You are operating at senior-engineer tier. Design before code on non-trivial work. Trust convention on the rest.
+
+## Posture
+
+- **Design first when the change has shape.** New module, new public API, multi-component refactor — author the plan and pause for `requesting-code-review` on the plan itself before writing code.
+- **Apply the philosophy lens situationally.** The skills below trigger on their own descriptions; this is when to actively lean into them:
+  - `tigerstyle` — low-level code (parsers, allocators, anything safety-critical). NASA Power-of-Ten lens.
+  - `ousterhout` — after spec/code review. Deep-modules / cognitive-load / "is this complexity earning its keep?"
+  - `hipp` — when scoping a small, no-dependency stack. "What if we just didn't add the dep?"
+  - `farley` — testing discipline + continuous delivery shape.
+- **Dispatch subagents heavily.** Multi-file edits, mechanical refactors, broad searches, comparative reads — all parallelize. `dispatching-parallel-agents` is the default, not the exception.
+- **Use the LSP for navigation/type-checking before grep.** `gopls-lsp` is enabled. Cross-references, type-resolution, "find all usages" — LSP first, regex as fallback.
+- **Reflect post-task.** `reflect` produces a structured critique. Run it after meaningful changes ship.
+- **Trust convention; surface only taste/architecture forks.** Decide implementation details. State 1-sentence rationale before continuing.
+
+## Backpressure rails
+
+`course-correct`, `stuck-detector`, `dx-audit`, `norman` — load and trigger per their own gates. Senior is expected to recognize when these fire and respond, not require explicit prompting.
+
+## Pairing
+
+| With | When |
+|---|---|
+| `--outfit backend` | Go-flavored backend; LSP + observability MCPs already in play |
+| `--outfit frontend` | UI/UX with design depth |
+| `--outfit code` | Lightweight generalist + senior depth |
+| `--cut executing` | Working a known plan |
+| `--cut planning` | Designing the next plan |
+| `--cut reviewing` | Running the review checklist |
+| `--accessory pr-policy` | Default |
+| `--accessory philosophy` | Adds Norman + Vitaly + architect-review agent (overlap with this fit's loadout — safe, set algebra dedupes) |

--- a/fits/staff-engineer/fit.md
+++ b/fits/staff-engineer/fit.md
@@ -1,0 +1,106 @@
+---
+name: staff-engineer
+version: 1.0.0
+type: fit
+description: 'Staff tier — spec-driven flow via spec-kit (replaces superpowers meta), cross-cutting design, architect-review agent. Use for system-design, ADRs, multi-component architectural change, and mentoring-through-review.'
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - economy
+  - backpressure
+  - evolution
+  - context-management
+enable:
+  plugins:
+    - gopls-lsp
+  mcps: []
+  hooks: []
+disable:
+  plugins: []
+  mcps: []
+  hooks: []
+skill_include: []
+skill_exclude:
+  - using-superpowers
+  - course-correct
+include:
+  skills:
+    - using-spec-kit
+    - writing-plans
+    - brainstorming
+    - subagent-driven-development
+    - systematic-debugging
+    - executing-plans
+    - dispatching-parallel-agents
+    - verification-before-completion
+    - test-driven-development
+    - requesting-code-review
+    - receiving-code-review
+    - writing-skills
+    - ousterhout
+    - tigerstyle
+    - hipp
+    - farley
+    - stuck-detector
+    - dx-audit
+    - norman
+    - reflect
+  rules: []
+  hooks: []
+  agents:
+    - architect-review
+  commands: []
+---
+
+# Staff Engineer Fit
+
+You are operating at staff-engineer tier. Think in systems. Spec-driven flow is the default scaffold; superpowers meta is dropped.
+
+## Posture
+
+- **Spec before plan, plan before tasks, tasks before code.** The `using-spec-kit` skill drives the flow:
+  - `/speckit.constitution` once per repo (or once per major direction shift) to establish principles
+  - `/speckit.specify` to author the spec for a feature
+  - `/speckit.plan` to derive an implementation plan from the spec
+  - `/speckit.tasks` to break the plan into tasks
+  - `/speckit.implement` to execute task-by-task
+- **Artifacts go to `.agent-config/specs/<slug>/`** via `SPECIFY_FEATURE_DIRECTORY` — keeps spec/plan/tasks out of the worktree.
+- **Think in systems.** Boundaries, contracts, cross-cutting concerns first. Implementation details are downstream. ADR-first on architectural forks.
+- **Engage `architect-review`** proactively on cross-cutting changes, public-API design, distributed-system shape, and any "is this the right architecture" question.
+- **Mentor via review.** `receiving-code-review` should produce teaching artifacts (why, not just what), not just gate-keeping.
+- **Self-correct without explicit rails.** `course-correct` is dropped at this tier — staff is expected to recognize off-track work and pivot without a prompt.
+
+## Philosophy lens (load + situational triggers)
+
+Same set as senior-engineer:
+- `tigerstyle` — low-level/safety-critical code
+- `ousterhout` — post-review deep-modules audit
+- `hipp` — scope-tight no-dep stacks
+- `farley` — testing + CD discipline
+- `norman`, `dx-audit` — backpressure category, situational
+
+## What's dropped
+
+- `using-superpowers` — staff uses spec-kit instead of the superpowers meta
+- `course-correct` — self-correcting at this tier
+
+Note: superpowers' workflow skills (writing-plans, executing-plans, etc.) are still loaded — spec-kit replaces the *meta-guide*, not the underlying workflow rails. Use spec-kit's slash commands as the primary entry point; fall through to writing-plans/executing-plans for tasks where a spec is overkill.
+
+## Pairing
+
+| With | When |
+|---|---|
+| `--outfit backend` | Backend systems work + architecture |
+| `--outfit engineer` | Language-agnostic systems work |
+| `--cut planning` | When you're in spec-driven design |
+| `--cut reviewing` | When teaching via review |
+| `--accessory pr-policy` | Default |
+| `--accessory philosophy` | Adds Norman + Vitaly + architect-review (architect-review already loaded by this fit — dedupe handles it) |
+
+## Setup gotcha
+
+`spec-kit` requires `uv` / `uvx` Python tooling installed. First invocation lazy-installs spec-kit itself, but `uv` must be present on the host. The `using-spec-kit` skill fails gracefully with an install message if missing.

--- a/skills/THIRD_PARTY_LICENSES.md
+++ b/skills/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,94 @@
+# Third-Party Licenses
+
+This file records the upstream provenance and license terms for skills vendored from external repositories. New attributions are appended; nothing here is overwritten.
+
+---
+
+## mattpocock/skills
+
+- **Source:** https://github.com/mattpocock/skills
+- **License:** MIT
+- **Copyright:** Copyright (c) 2026 Matt Pocock
+- **Vendored skills (with `pocock-` prefix):**
+  - `pocock-caveman` — from `skills/productivity/caveman/SKILL.md`
+  - `pocock-handoff` — from `skills/productivity/handoff/SKILL.md`
+  - `pocock-diagnose` — from `skills/engineering/diagnose/SKILL.md` (plus `scripts/hitl-loop.template.sh`)
+  - `pocock-git-guardrails` — from `skills/misc/git-guardrails-claude-code/SKILL.md` (plus `scripts/block-dangerous-git.sh`)
+  - `pocock-setup-pre-commit` — from `skills/misc/setup-pre-commit/SKILL.md`
+
+Adaptations applied: rewrote frontmatter to the wardrobe schema (added `version`, `targets`, `type`, `category`; rewrote `description` into "Use when..." triggering form), renamed the skills with the `pocock-` prefix, and lightly neutralised first-person / personal-directory references. Body content is otherwise as-published upstream.
+
+### MIT License Text
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## obra/superpowers
+
+- **Source:** https://github.com/obra/superpowers
+- **License:** MIT
+- **Copyright:** Copyright (c) 2025 Jesse Vincent
+- **Vendored skills (refreshed 2026-05-14):**
+  - `brainstorming/` — refreshed body from upstream
+  - `dispatching-parallel-agents/` — refreshed body from upstream
+  - `executing-plans/` — refreshed body from upstream
+  - `receiving-code-review/` — refreshed body from upstream
+  - `requesting-code-review/` — refreshed body from upstream
+  - `subagent-driven-development/` — refreshed body from upstream
+  - `systematic-debugging/` — refreshed body from upstream
+  - `test-driven-development/` — refreshed body from upstream
+  - `using-superpowers/` — new (vendored from upstream)
+  - `verification-before-completion/` — refreshed body from upstream
+  - `writing-plans/` — refreshed body from upstream
+  - `writing-skills/` — new (vendored from upstream)
+
+Adaptations applied: preserved wardrobe-schema YAML frontmatter (name, version, targets, type, category) on refreshed skills; bumped version 1.0.0 → 1.1.0 to mark the refresh. Two new skills (`using-superpowers`, `writing-skills`) were authored with the wardrobe schema. Performed a no-git scrub — replaced version-control-tool-specific terminology (worktrees, commits, PRs, push, branch, merge, rebase) with tool-agnostic equivalents (isolated work area, checkpoint, request review, publish, integrate) so skills work in harnesses without git. Two upstream skills (`using-git-worktrees`, `finishing-a-development-branch`) were intentionally dropped. Did NOT vendor the upstream skills' supporting files (templates, reference markdown, code samples) — only the SKILL.md bodies were refreshed.
+
+### MIT License Text
+
+```
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: brainstorming
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Help turn ideas into fully formed designs and specs through natural collaborative dialogue. Use when the user wants to design something, brainstorm a feature, or plan a project in a bones workspace.
+description: Help turn ideas into fully formed designs and specs through natural collaborative dialogue. Use when the user wants to design something, brainstorm a feature, or plan a project.
 category:
   primary: workflow
 ---
@@ -26,12 +26,12 @@ Every project goes through this process. A todo list, a single-function utility,
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Explore project context** — check files, docs, recent commits
+1. **Explore project context** — check files, docs, recent history
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/bones-powers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and checkpoint it
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -74,7 +74,7 @@ digraph brainstorming {
 
 **Understanding the idea:**
 
-- Check out the current project state first (files, docs, recent commits)
+- Check out the current project state first (files, docs, recent history)
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
@@ -113,10 +113,10 @@ digraph brainstorming {
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/bones-powers/specs/YYYY-MM-DD-<topic>-design.md`
+- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
-- Commit the design document: `bones repo add <spec> && bones repo ci -m 'docs: add <topic> design spec' <spec>`
+- Checkpoint the design document
 
 **Spec Self-Review:**
 After writing the spec document, look at it with fresh eyes:
@@ -131,7 +131,7 @@ Fix any issues inline. No need to re-review — just fix and move on.
 **User Review Gate:**
 After the spec review loop passes, ask the user to review the written spec before proceeding:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+> "Spec written and saved to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
 Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dispatching-parallel-agents
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Run N concurrent slot sessions in a bones workspace for parallel debugging or independent work. Discover ready work via bones swarm tasks --slot=X --json. Roll up cross-slot status via bones tasks aggregate. Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies.
+description: Run N concurrent subagent sessions for parallel debugging or independent work. Discover ready work from the task list; roll up cross-agent status by aggregating results when agents complete. Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies.
 category:
   primary: context-management
 ---
@@ -116,40 +116,17 @@ Return: Summary of what you found and what you fixed.
 
 ## Common Mistakes
 
-**❌ Too broad:** "Fix all the tests" - agent gets lost
-**✅ Specific:** "Fix agent-tool-abort.test.ts" - focused scope
+**Too broad:** "Fix all the tests" - agent gets lost
+**Specific:** "Fix agent-tool-abort.test.ts" - focused scope
 
-**❌ No context:** "Fix the race condition" - agent doesn't know where
-**✅ Context:** Paste the error messages and test names
+**No context:** "Fix the race condition" - agent doesn't know where
+**Context:** Paste the error messages and test names
 
-**❌ No constraints:** Agent might refactor everything
-**✅ Constraints:** "Do NOT change production code" or "Fix tests only"
+**No constraints:** Agent might refactor everything
+**Constraints:** "Do NOT change production code" or "Fix tests only"
 
-**❌ Vague output:** "Fix it" - you don't know what changed
-**✅ Specific:** "Return summary of root cause and changes"
-
-## Parallel = N concurrent slot sessions
-
-In bones, parallelism is expressed via slots. Each slot can hold one open swarm session (one leaf + one claimed task + one worktree). To run N agents in parallel:
-
-1. Pick N slot names (e.g. `alpha`, `beta`, `gamma`).
-2. For each slot, dispatch a fresh subagent that runs:
-   ```bash
-   READY_TASK=$(bones swarm tasks --slot="$SLOT" --json | jq -r '.[0].id')
-   bones swarm join --slot="$SLOT" --task-id="$READY_TASK"
-   # ... do the work ...
-   bones swarm close --result=success --summary='<note>'
-   ```
-
-The N sessions run independently, each in its own leaf/worktree.
-
-## Cross-slot status
-
-```bash
-bones tasks aggregate --json
-```
-
-Returns a per-slot summary: ready / claimed / closed counts. Use this to monitor parallel progress without polling each slot individually.
+**Vague output:** "Fix it" - you don't know what changed
+**Specific:** "Return summary of root cause and changes"
 
 ## When NOT to Use
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: executing-plans
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Execute a plan task-by-task in a single session inside a bones workspace. Coordinator enumerates tasks via bones tasks list, claims one at a time, and closes with --reason on completion. Use when running a plan inline (single agent, single session); use subagent-driven-development instead for parallel slot work.
+description: Execute a plan task-by-task in a single session. The coordinator enumerates tasks from the plan, claims one at a time, and marks each complete on finish. Use when running a plan inline (single agent, single session); use subagent-driven-development instead for parallel agent work.
 category:
   primary: workflow
   secondary: [context-management]
 ---
-
-> **Execution mode**: this skill is for **single-session inline execution** — one agent runs the whole plan in one session. For parallel slot sessions, use `bones-powers:subagent-driven-development` instead. (Per spec § 5 boundary.)
 
 # Executing Plans
 
@@ -19,31 +17,7 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Announce at start:** "I'm using the executing-plans skill to implement this plan."
 
-**Note:** Tell your human partner that bones-powers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use bones-powers:subagent-driven-development instead of this skill.
-
-## Source of truth: the bones task graph
-
-The plan was materialized into bones tasks by `writing-plans` (per spec § 4.4). The coordinator's source of truth is **NOT** TodoWrite — it is `bones tasks list --parent=<root_id>`.
-
-```bash
-ROOT_ID=<paste from writing-plans output>
-bones tasks list --parent="$ROOT_ID" --json | jq '.[] | {id, title, slot, status}'
-```
-
-Loop through pending tasks; for each:
-
-```bash
-TASK_ID=<id from list>
-bones tasks claim "$TASK_ID"
-
-# (do the work — see hybrid task model § 6: TodoWrite the in-task micro-steps here)
-
-bones tasks close "$TASK_ID" --reason="<short result note>"
-```
-
-Heartbeat during long work via `bones swarm commit -m '…'`.
-
-**Hybrid task model**: per spec § 6, the coordinator keeps NO TodoWrite of its own. TodoWrite is the worker's tool, used only for micro-steps inside one currently-claimed bones task; it is discarded when the bones task closes.
+**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
 ## The Process
 
@@ -51,22 +25,22 @@ Heartbeat during long work via `bones swarm commit -m '…'`.
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Enumerate tasks from `bones tasks list` and proceed
+4. If no concerns: Create TodoWrite and proceed
 
 ### Step 2: Execute Tasks
 
-For each task from `bones tasks list --parent="$ROOT_ID"`:
-1. Claim via `bones tasks claim "$TASK_ID"`
+For each task:
+1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Close via `bones tasks close "$TASK_ID" --reason="<result>"`
+4. Mark as completed
 
-### Step 3: Complete Development
+### Step 3: Wrap Up the Work
 
 After all tasks complete and verified:
-- Announce: "I'm using the finishing-a-bones-leaf skill to complete this work."
-- **REQUIRED SUB-SKILL:** Use bones-powers:finishing-a-bones-leaf
-- Follow that skill to verify tests, present options, execute choice
+- Verify the full test suite is green and the implementation matches the plan
+- Run any wrap-up steps the plan specifies
+- Hand control back to your human partner with a summary of what shipped
 
 ## When to Stop and Ask for Help
 
@@ -92,11 +66,9 @@ After all tasks complete and verified:
 - Don't skip verifications
 - Reference skills when plan says to
 - Stop when blocked, don't guess
-- Never start implementation on main/master branch without explicit user consent
+- Never start implementation on the shared mainline without explicit user consent
 
 ## Integration
 
 **Required workflow skills:**
-- **bones-powers:using-bones-powers** - REQUIRED: Set up isolated workspace before starting
-- **bones-powers:writing-plans** - Creates the plan this skill executes
-- **bones-powers:finishing-a-bones-leaf** - Complete development after all tasks
+- **superpowers:writing-plans** - Creates the plan this skill executes

--- a/skills/pocock-caveman/SKILL.md
+++ b/skills/pocock-caveman/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pocock-caveman
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user wants ultra-compressed responses — says "caveman mode",
+  "talk like caveman", "use caveman", "less tokens", "be brief", or invokes
+  /caveman. Cuts token usage ~75% by dropping filler, articles, and
+  pleasantries while keeping full technical accuracy.
+category:
+  primary: workflow
+---
+
+# Caveman Mode
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE once triggered. No revert after many turns. No filler drift. Still active if unsure. Off only when user says "stop caveman" or "normal mode".
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Abbreviate common terms (DB/auth/config/req/res/fn/impl). Strip conjunctions. Use arrows for causality (X -> Y). One word when one word enough.
+
+Technical terms stay exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+### Examples
+
+**"Why React component re-render?"**
+
+> Inline obj prop -> new ref -> re-render. `useMemo`.
+
+**"Explain database connection pooling."**
+
+> Pool = reuse DB conn. Skip handshake -> fast under load.
+
+## Auto-Clarity Exception
+
+Drop caveman temporarily for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+
+Example -- destructive op:
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+>
+> Caveman resume. Verify backup exist first.

--- a/skills/pocock-diagnose/SKILL.md
+++ b/skills/pocock-diagnose/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pocock-diagnose
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user says "diagnose this" / "debug this", reports a bug, says
+  something is broken/throwing/failing, or describes a performance regression.
+  Disciplined diagnosis loop: reproduce -> minimise -> hypothesise ->
+  instrument -> fix -> regression-test.
+category:
+  primary: backpressure
+---
+
+# Diagnose
+
+A discipline for hard bugs. Skip phases only when explicitly justified.
+
+When exploring the codebase, use the project's domain glossary to get a clear mental model of the relevant modules, and check ADRs in the area you're touching.
+
+## Phase 1 — Build a feedback loop
+
+**This is the skill.** Everything else is mechanical. If you have a fast, deterministic, agent-runnable pass/fail signal for the bug, you will find the cause — bisection, hypothesis-testing, and instrumentation all just consume that signal. If you don't have one, no amount of staring at code will save you.
+
+Spend disproportionate effort here. **Be aggressive. Be creative. Refuse to give up.**
+
+### Ways to construct one — try them in roughly this order
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
+5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
+7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
+8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
+9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
+10. **HITL bash script.** Last resort. If a human must click, drive _them_ with `scripts/hitl-loop.template.sh` so the loop is still structured. Captured output feeds back to you.
+
+Build the right feedback loop, and the bug is 90% fixed.
+
+### Iterate on the loop itself
+
+Treat the loop as a product. Once you have _a_ loop, ask:
+
+- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
+- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
+- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+
+A 30-second flaky loop is barely better than no loop. A 2-second deterministic loop is a debugging superpower.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100x, parallelise, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it's debuggable.
+
+### When you genuinely cannot build a loop
+
+Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesise without a loop.
+
+Do not proceed to Phase 2 until you have a loop you believe in.
+
+## Phase 2 — Reproduce
+
+Run the loop. Watch the bug appear.
+
+Confirm:
+
+- [ ] The loop produces the failure mode the **user** described — not a different failure that happens to be nearby. Wrong bug = wrong fix.
+- [ ] The failure is reproducible across multiple runs (or, for non-deterministic bugs, reproducible at a high enough rate to debug against).
+- [ ] You have captured the exact symptom (error message, wrong output, slow timing) so later phases can verify the fix actually addresses it.
+
+Do not proceed until you reproduce the bug.
+
+## Phase 3 — Hypothesise
+
+Generate **3-5 ranked hypotheses** before testing any of them. Single-hypothesis generation anchors on the first plausible idea.
+
+Each hypothesis must be **falsifiable**: state the prediction it makes.
+
+> Format: "If <X> is the cause, then <changing Y> will make the bug disappear / <changing Z> will make it worse."
+
+If you cannot state the prediction, the hypothesis is a vibe — discard or sharpen it.
+
+**Show the ranked list to the user before testing.** They often have domain knowledge that re-ranks instantly ("we just deployed a change to #3"), or know hypotheses they've already ruled out. Cheap checkpoint, big time saver. Don't block on it — proceed with your ranking if the user is AFK.
+
+## Phase 4 — Instrument
+
+Each probe must map to a specific prediction from Phase 3. **Change one variable at a time.**
+
+Tool preference:
+
+1. **Debugger / REPL inspection** if the env supports it. One breakpoint beats ten logs.
+2. **Targeted logs** at the boundaries that distinguish hypotheses.
+3. Never "log everything and grep".
+
+**Tag every debug log** with a unique prefix, e.g. `[DEBUG-a4f2]`. Cleanup at the end becomes a single grep. Untagged logs survive; tagged logs die.
+
+**Perf branch.** For performance regressions, logs are usually wrong. Instead: establish a baseline measurement (timing harness, `performance.now()`, profiler, query plan), then bisect. Measure first, fix second.
+
+## Phase 5 — Fix + regression test
+
+Write the regression test **before the fix** — but only if there is a **correct seam** for it.
+
+A correct seam is one where the test exercises the **real bug pattern** as it occurs at the call site. If the only available seam is too shallow (single-caller test when the bug needs multiple callers, unit test that can't replicate the chain that triggered the bug), a regression test there gives false confidence.
+
+**If no correct seam exists, that itself is the finding.** Note it. The codebase architecture is preventing the bug from being locked down. Flag this for the next phase.
+
+If a correct seam exists:
+
+1. Turn the minimised repro into a failing test at that seam.
+2. Watch it fail.
+3. Apply the fix.
+4. Watch it pass.
+5. Re-run the Phase 1 feedback loop against the original (un-minimised) scenario.
+
+## Phase 6 — Cleanup + post-mortem
+
+Required before declaring done:
+
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
+- [ ] Regression test passes (or absence of seam is documented)
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
+- [ ] Throwaway prototypes deleted (or moved to a clearly-marked debug location)
+- [ ] The hypothesis that turned out correct is stated in the commit / PR message — so the next debugger learns
+
+**Then ask: what would have prevented this bug?** If the answer involves architectural change (no good test seam, tangled callers, hidden coupling), flag the specifics in the commit / PR message and surface them to the user for follow-up. Make the recommendation **after** the fix is in, not before — you have more information now than when you started.

--- a/skills/pocock-diagnose/scripts/hitl-loop.template.sh
+++ b/skills/pocock-diagnose/scripts/hitl-loop.template.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Human-in-the-loop reproduction loop.
+# Copy this file, edit the steps below, and run it.
+# The agent runs the script; the user follows prompts in their terminal.
+#
+# Usage:
+#   bash hitl-loop.template.sh
+#
+# Two helpers:
+#   step "<instruction>"          -> show instruction, wait for Enter
+#   capture VAR "<question>"      -> show question, read response into VAR
+#
+# At the end, captured values are printed as KEY=VALUE for the agent to parse.
+
+set -euo pipefail
+
+step() {
+  printf '\n>>> %s\n' "$1"
+  read -r -p "    [Enter when done] " _
+}
+
+capture() {
+  local var="$1" question="$2" answer
+  printf '\n>>> %s\n' "$question"
+  read -r -p "    > " answer
+  printf -v "$var" '%s' "$answer"
+}
+
+# --- edit below ---------------------------------------------------------
+
+step "Open the app at http://localhost:3000 and sign in."
+
+capture ERRORED "Click the 'Export' button. Did it throw an error? (y/n)"
+
+capture ERROR_MSG "Paste the error message (or 'none'):"
+
+# --- edit above ---------------------------------------------------------
+
+printf '\n--- Captured ---\n'
+printf 'ERRORED=%s\n' "$ERRORED"
+printf 'ERROR_MSG=%s\n' "$ERROR_MSG"

--- a/skills/pocock-git-guardrails/SKILL.md
+++ b/skills/pocock-git-guardrails/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: pocock-git-guardrails
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when working in a git repo and the user wants to prevent destructive
+  git operations — says "add git safety hooks", "block git push/reset",
+  "set up git guardrails", or asks to protect against accidental
+  pushes/force-resets/branch deletes. Installs a PreToolUse hook that
+  blocks dangerous git commands (push, reset --hard, clean -f, branch -D,
+  checkout ., restore .) before they execute.
+category:
+  primary: tooling
+---
+
+# Setup Git Guardrails
+
+Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them.
+
+## What Gets Blocked
+
+- `git push` (all variants including `--force`)
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git branch -D`
+- `git checkout .` / `git restore .`
+
+When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+
+## Steps
+
+### 1. Ask scope
+
+Ask the user: install for **this project only** (`.claude/settings.json`) or **all projects** (`~/.claude/settings.json`)?
+
+### 2. Copy the hook script
+
+The bundled script is at: [scripts/block-dangerous-git.sh](scripts/block-dangerous-git.sh)
+
+Copy it to the target location based on scope:
+
+- **Project**: `.claude/hooks/block-dangerous-git.sh`
+- **Global**: `~/.claude/hooks/block-dangerous-git.sh`
+
+Make it executable with `chmod +x`.
+
+### 3. Add hook to settings
+
+Add to the appropriate settings file:
+
+**Project** (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Global** (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If the settings file already exists, merge the hook into existing `hooks.PreToolUse` array — don't overwrite other settings.
+
+### 4. Ask about customization
+
+Ask if user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
+
+### 5. Verify
+
+Run a quick test:
+
+```bash
+echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
+```
+
+Should exit with code 2 and print a BLOCKED message to stderr.

--- a/skills/pocock-git-guardrails/scripts/block-dangerous-git.sh
+++ b/skills/pocock-git-guardrails/scripts/block-dangerous-git.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+DANGEROUS_PATTERNS=(
+  "git push"
+  "git reset --hard"
+  "git clean -fd"
+  "git clean -f"
+  "git branch -D"
+  "git checkout \."
+  "git restore \."
+  "push --force"
+  "reset --hard"
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qE "$pattern"; then
+    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/skills/pocock-handoff/SKILL.md
+++ b/skills/pocock-handoff/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: pocock-handoff
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user wants to compact the current conversation into a handoff
+  document for another agent — says "handoff", "write a handoff", "summarize
+  this session for a fresh agent", or invokes /handoff. Produces a doc the
+  next session can pick up cold.
+category:
+  primary: workflow
+---
+
+# Handoff
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/skills/pocock-setup-pre-commit/SKILL.md
+++ b/skills/pocock-setup-pre-commit/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pocock-setup-pre-commit
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user wants to add pre-commit hooks to a JS/TS repo — says
+  "set up Husky", "add pre-commit hooks", "configure lint-staged", or
+  asks for commit-time formatting/typechecking/testing. Installs Husky +
+  lint-staged + Prettier with type-check and test wired into pre-commit.
+category:
+  primary: tooling
+---
+
+# Setup Pre-Commit Hooks
+
+## What This Sets Up
+
+- **Husky** pre-commit hook
+- **lint-staged** running Prettier on all staged files
+- **Prettier** config (if missing)
+- **typecheck** and **test** scripts in the pre-commit hook
+
+## Steps
+
+### 1. Detect package manager
+
+Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
+
+### 2. Install dependencies
+
+Install as devDependencies:
+
+```
+husky lint-staged prettier
+```
+
+### 3. Initialize Husky
+
+```bash
+npx husky init
+```
+
+This creates `.husky/` dir and adds `prepare: "husky"` to package.json.
+
+### 4. Create `.husky/pre-commit`
+
+Write this file (no shebang needed for Husky v9+):
+
+```
+npx lint-staged
+npm run typecheck
+npm run test
+```
+
+**Adapt**: Replace `npm` with detected package manager. If repo has no `typecheck` or `test` script in package.json, omit those lines and tell the user.
+
+### 5. Create `.lintstagedrc`
+
+```json
+{
+  "*": "prettier --ignore-unknown --write"
+}
+```
+
+### 6. Create `.prettierrc` (if missing)
+
+Only create if no Prettier config exists. Use these defaults:
+
+```json
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "semi": true,
+  "arrowParens": "always"
+}
+```
+
+### 7. Verify
+
+- [ ] `.husky/pre-commit` exists and is executable
+- [ ] `.lintstagedrc` exists
+- [ ] `prepare` script in package.json is `"husky"`
+- [ ] `prettier` config exists
+- [ ] Run `npx lint-staged` to verify it works
+
+### 8. Commit
+
+Stage all changed/created files and commit with message: `Add pre-commit hooks (husky + lint-staged + prettier)`
+
+This will run through the new pre-commit hooks — a good smoke test that everything works.
+
+## Notes
+
+- Husky v9+ doesn't need shebangs in hook files
+- `prettier --ignore-unknown` skips files Prettier can't parse (images, etc.)
+- The pre-commit runs lint-staged first (fast, staged-only), then full typecheck and tests

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: receiving-code-review
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when receiving code review feedback in a bones workspace, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
 category:
   primary: workflow
 ---
@@ -57,8 +57,8 @@ WHY: Items may be related. Partial understanding = wrong implementation.
 your human partner: "Fix 1-6"
 You understand 1,2,3,6. Unclear on 4,5.
 
-❌ WRONG: Implement 1,2,3,6 now, ask about 4,5 later
-✅ RIGHT: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
+WRONG: Implement 1,2,3,6 now, ask about 4,5 later
+RIGHT: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
 ```
 
 ## Source-Specific Handling
@@ -115,19 +115,6 @@ FOR multi-item feedback:
   4. Verify no regressions
 ```
 
-## Acting on feedback in a swarm session
-
-When the review fires while you're inside a swarm session (typical implementer path), the canonical re-dispatch loop is documented in `bones-powers:subagent-driven-development` § "Re-dispatch on Review Issues":
-
-1. **Close the current session as failed** — releases the claim, posts feedback to the task thread:
-   ```bash
-   bones swarm close --result=fail --summary='<one-line feedback summary>'
-   ```
-2. **Coordinator dispatches a fresh implementer** with the original task + the review feedback.
-3. **Fresh implementer re-claims** via `bones swarm join`, addresses the feedback, then `swarm close --result=success`.
-
-This ensures review-driven re-work is recorded in the task graph (as `--result=fail` followed by re-claim) rather than buried in an in-place edit.
-
 ## When To Push Back
 
 Push back when:
@@ -150,15 +137,16 @@ Push back when:
 
 When feedback IS correct:
 ```
-✅ "Fixed. [Brief description of what changed]"
-✅ "Good catch - [specific issue]. Fixed in [location]."
-✅ [Just fix it and show in the code]
+"Fixed. [Brief description of what changed]"
+"Good catch - [specific issue]. Fixed in [location]."
+[Just fix it and show in the code]
 
-❌ "You're absolutely right!"
-❌ "Great point!"
-❌ "Thanks for catching that!"
-❌ "Thanks for [anything]"
-❌ ANY gratitude expression
+NEVER:
+"You're absolutely right!"
+"Great point!"
+"Thanks for catching that!"
+"Thanks for [anything]"
+ANY gratitude expression
 ```
 
 **Why no thanks:** Actions speak. Just fix it. The code itself shows you heard the feedback.
@@ -169,12 +157,13 @@ When feedback IS correct:
 
 If you pushed back and were wrong:
 ```
-✅ "You were right - I checked [X] and it does [Y]. Implementing now."
-✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
+"You were right - I checked [X] and it does [Y]. Implementing now."
+"Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
 
-❌ Long apology
-❌ Defending why you pushed back
-❌ Over-explaining
+NEVER:
+Long apology
+Defending why you pushed back
+Over-explaining
 ```
 
 State the correction factually and move on.
@@ -196,31 +185,31 @@ State the correction factually and move on.
 **Performative Agreement (Bad):**
 ```
 Reviewer: "Remove legacy code"
-❌ "You're absolutely right! Let me remove that..."
+WRONG: "You're absolutely right! Let me remove that..."
 ```
 
 **Technical Verification (Good):**
 ```
 Reviewer: "Remove legacy code"
-✅ "Checking... build target is 10.15+, this API needs 13+. Need legacy for backward compat. Current impl has wrong bundle ID - fix it or drop pre-13 support?"
+RIGHT: "Checking... build target is 10.15+, this API needs 13+. Need legacy for backward compat. Current impl has wrong bundle ID - fix it or drop pre-13 support?"
 ```
 
 **YAGNI (Good):**
 ```
 Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
-✅ "Grepped codebase - nothing calls this endpoint. Remove it (YAGNI)? Or is there usage I'm missing?"
+RIGHT: "Grepped codebase - nothing calls this endpoint. Remove it (YAGNI)? Or is there usage I'm missing?"
 ```
 
 **Unclear Item (Good):**
 ```
 your human partner: "Fix items 1-6"
 You understand 1,2,3,6. Unclear on 4,5.
-✅ "Understand 1,2,3,6. Need clarification on 4 and 5 before implementing."
+RIGHT: "Understand 1,2,3,6. Need clarification on 4 and 5 before implementing."
 ```
 
-## GitHub Thread Replies
+## Inline Review Replies
 
-When replying to inline review comments on GitHub, reply in the comment thread (`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a top-level PR comment.
+When replying to inline review comments on a hosted review platform, reply in the comment thread itself, not as a top-level review comment. The threaded context is what makes the conversation legible to other reviewers later.
 
 ## The Bottom Line
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: requesting-code-review
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when completing tasks, implementing major features, or before fan-in to verify work meets requirements in a bones workspace
+description: Use when completing tasks, implementing major features, or before integrating changes to verify work meets requirements
 category:
   primary: workflow
 ---
 
 # Requesting Code Review
 
-Dispatch bones-powers:code-reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
 
 **Core principle:** Review early, review often.
 
@@ -19,7 +19,7 @@ Dispatch bones-powers:code-reviewer subagent to catch issues before they cascade
 **Mandatory:**
 - After each task in subagent-driven development
 - After completing major feature
-- Before merge to main
+- Before integrating back into the mainline
 
 **Optional but valuable:**
 - When stuck (fresh perspective)
@@ -28,38 +28,25 @@ Dispatch bones-powers:code-reviewer subagent to catch issues before they cascade
 
 ## How to Request
 
-**1. Get fossil revs:**
-```bash
-# Show recent timeline to find rev UUIDs
-bones repo timeline --limit 10
+**1. Identify the change boundary:**
 
-# Diff current work vs tip (trunk's latest committed state)
-bones repo diff
+Capture the before/after identifiers (snapshot IDs, change IDs — whatever your workspace uses) that mark the start and end of the work to review.
 
-# Diff current work vs a specific rev
-bones repo diff <BASE_REV>
-```
+**2. Dispatch code reviewer subagent:**
 
-**2. Dispatch code-reviewer subagent:**
-
-Use Task tool with bones-powers:code-reviewer type, fill template at `code-reviewer.md`
+Use Task tool with `general-purpose` type, fill template at `code-reviewer.md`
 
 **Placeholders:**
-- `{WHAT_WAS_IMPLEMENTED}` - What you just built
+- `{DESCRIPTION}` - Brief summary of what you built
 - `{PLAN_OR_REQUIREMENTS}` - What it should do
-- `{BASE_REV}` - Starting fossil rev (UUID prefix, tag, or `trunk`/`tip`)
-- `{HEAD_REV}` - Ending fossil rev (or omit to mean current working state)
-- `{DESCRIPTION}` - Brief summary
+- `{BASE_REF}` - Starting point of the change
+- `{HEAD_REF}` - Ending point of the change
 
 **3. Act on feedback:**
 - Fix Critical issues immediately
 - Fix Important issues before proceeding
 - Note Minor issues for later
 - Push back if reviewer is wrong (with reasoning)
-
-## Reviewer dispatch in bones
-
-**Reviewer dispatch in bones**: the reviewer subagent runs in a sibling slot (e.g., `slot=spec-review` or `slot=code-review`), separate from the implementer's slot. If the reviewer only reads (no commits expected), it doesn't need its own `swarm join` — it can read the implementer's leaf via `bones swarm cwd --slot=<implementer-slot>`. If the reviewer might write fixes, open its own slot session via `bones swarm join --slot=<reviewer-slot> --task-id=<task>`.
 
 ## Example
 
@@ -68,17 +55,14 @@ Use Task tool with bones-powers:code-reviewer type, fill template at `code-revie
 
 You: Let me request code review before proceeding.
 
-bones repo timeline --limit 10
-# → identifies base rev as a7981ec (after Task 1)
+[Capture BASE_REF as the checkpoint at end of Task 1]
+[Capture HEAD_REF as the checkpoint at end of Task 2]
 
-bones repo diff a7981ec
-# → shows all changes since that rev
-
-[Dispatch bones-powers:code-reviewer subagent]
-  WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
-  BASE_REV: a7981ec
+[Dispatch code reviewer subagent]
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  BASE_REF: <task-1 checkpoint id>
+  HEAD_REF: <task-2 checkpoint id>
 
 [Subagent returns]:
   Strengths: Clean architecture, real tests
@@ -99,11 +83,11 @@ You: [Fix progress indicators]
 - Fix before moving to next task
 
 **Executing Plans:**
-- Review after each batch (3 tasks)
+- Review after each task or at natural checkpoints
 - Get feedback, apply, continue
 
 **Ad-Hoc Development:**
-- Review before merge
+- Review before integrating
 - Review when stuck
 
 ## Red Flags

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: subagent-driven-development
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Execute a plan in parallel slot sessions. Each implementer subagent runs in its own bones swarm session (slot + claim + worktree atomic via bones swarm join). Two-stage review (spec compliance + code quality) per task. Use when the plan has independent tasks that can run concurrently; use executing-plans instead for single-session inline runs.
+description: Execute a plan in parallel by dispatching a fresh subagent per task. Each implementer subagent runs in isolated context (no inheritance from the controller). Two-stage review (spec compliance + code quality) per task. Use when the plan has independent tasks that can run concurrently; use executing-plans instead for single-session inline runs.
 category:
   primary: context-management
   secondary: [workflow]
 ---
 
-> **Execution mode**: this skill is for **parallel slot sessions** — multiple subagents claim and run plan steps concurrently, each in its own slot/leaf. For single-session inline runs, use `bones-powers:executing-plans` instead. (Per spec § 5 boundary.)
-
 # Subagent-Driven Development
 
-Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review. Each implementer runs in its own bones swarm session — isolated leaf, claimed task, dedicated worktree.
+Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
 
 **Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
 
-**Core principle:** Fresh subagent per task + bones swarm session (atomic claim) + two-stage review (spec then quality) = high quality, fast iteration
+**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
+
+**Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
 
 ## When to Use
 
@@ -45,15 +45,6 @@ digraph when_to_use {
 - Two-stage review after each task: spec compliance first, then code quality
 - Faster iteration (no human-in-loop between tasks)
 
-## Coordinator Setup
-
-```bash
-ROOT_ID=<paste from writing-plans output>
-bones tasks list --parent="$ROOT_ID" --json | jq '.[] | {id, title, slot, status}'
-```
-
-This is the source of truth. The coordinator does NOT mirror tasks into TodoWrite (per spec § 6). Tasks are claimed and closed atomically through the swarm session of each implementer subagent.
-
 ## The Process
 
 ```dot
@@ -65,100 +56,41 @@ digraph process {
         "Dispatch implementer subagent (./implementer-prompt.md)" [shape=box];
         "Implementer subagent asks questions?" [shape=diamond];
         "Answer questions, provide context" [shape=box];
-        "Implementer: swarm join + TodoWrite + implement + swarm close" [shape=box];
+        "Implementer subagent implements, tests, checkpoints, self-reviews" [shape=box];
         "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [shape=box];
         "Spec reviewer subagent confirms code matches spec?" [shape=diamond];
-        "Re-dispatch on spec failure (swarm close fail + fresh join)" [shape=box];
+        "Implementer subagent fixes spec gaps" [shape=box];
         "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
-        "Re-dispatch on quality failure (swarm close fail + fresh join)" [shape=box];
-        "Task closed success in bones tasks" [shape=box];
+        "Implementer subagent fixes quality issues" [shape=box];
+        "Mark task complete in TodoWrite" [shape=box];
     }
 
-    "bones tasks list --parent=ROOT_ID (source of truth)" [shape=box];
+    "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
-    "Use bones-powers:finishing-a-bones-leaf" [shape=box style=filled fillcolor=lightgreen];
+    "Wrap up the work" [shape=box style=filled fillcolor=lightgreen];
 
-    "bones tasks list --parent=ROOT_ID (source of truth)" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
-    "Implementer subagent asks questions?" -> "Implementer: swarm join + TodoWrite + implement + swarm close" [label="no"];
-    "Implementer: swarm join + TodoWrite + implement + swarm close" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
+    "Implementer subagent asks questions?" -> "Implementer subagent implements, tests, checkpoints, self-reviews" [label="no"];
+    "Implementer subagent implements, tests, checkpoints, self-reviews" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
     "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
-    "Spec reviewer subagent confirms code matches spec?" -> "Re-dispatch on spec failure (swarm close fail + fresh join)" [label="no"];
-    "Re-dispatch on spec failure (swarm close fail + fresh join)" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
+    "Spec reviewer subagent confirms code matches spec?" -> "Implementer subagent fixes spec gaps" [label="no"];
+    "Implementer subagent fixes spec gaps" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
     "Spec reviewer subagent confirms code matches spec?" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
     "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
-    "Code quality reviewer subagent approves?" -> "Re-dispatch on quality failure (swarm close fail + fresh join)" [label="no"];
-    "Re-dispatch on quality failure (swarm close fail + fresh join)" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Task closed success in bones tasks" [label="yes"];
-    "Task closed success in bones tasks" -> "More tasks remain?";
+    "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
+    "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
+    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
+    "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
-    "Dispatch final code reviewer subagent for entire implementation" -> "Use bones-powers:finishing-a-bones-leaf";
+    "Dispatch final code reviewer subagent for entire implementation" -> "Wrap up the work";
 }
 ```
-
-## For Each Task: Implementer Dispatch
-
-For each task in the bones task graph:
-
-1. **Coordinator dispatches a fresh implementer subagent** with:
-   - Task `id`, `slot`, full task title and body from `bones tasks show $TASK_ID`
-   - The plan path (from `--files`)
-   - Brief feedback context if this is a re-dispatch after review
-
-2. **Implementer's first action** (per spec § 5.5):
-   ```bash
-   bones swarm join --slot="$SLOT" --task-id="$TASK_ID"
-   ```
-   This atomically: opens a leaf, claims the task, prepares a worktree.
-
-3. **Implementer's second action**: TodoWrite a fresh checklist of the in-task micro-steps (per hybrid task model § 6).
-
-4. **Implementer does the work**, heartbeating via `bones swarm commit -m '…'`.
-
-5. **Implementer closes the swarm session**:
-   ```bash
-   bones swarm close --result=success --summary='<one-line result>'
-   ```
-
-## Re-dispatch on Review Issues
-
-If the spec-compliance reviewer or code-quality reviewer reports issues:
-
-1. **Implementer closes the swarm session as failed**:
-   ```bash
-   bones swarm close --result=fail --summary='<feedback summary>'
-   ```
-   This releases the claim. The task returns to the pending pool with the failure summary attached to its thread.
-
-2. **Coordinator dispatches a fresh implementer** with the original task + the review feedback as additional context.
-
-3. **New implementer joins via `bones swarm join`** (re-claims the same task), addresses the feedback, and re-runs the review loops.
-
-This loop continues until both reviews pass.
-
-## Reviewer Dispatch
-
-Spec-compliance and code-quality reviewers are read-only — they inspect the implementer's leaf directly without claiming a slot of their own. Dispatch them as fresh subagents with:
-- The task text
-- The implementer's report
-- The path to the implementer's worktree (from `bones swarm cwd --slot=$SLOT`)
-
-If a reviewer needs write access (e.g., to annotate or commit a finding), open a sibling slot session (e.g., `--slot=spec-review`, `--slot=code-review`) via a separate `bones swarm join`.
-
-## Subagent Boundaries: Coordinator Owns Scheduling
-
-The coordinator owns all wakeups, cron schedules, and Monitor lifecycles for the duration of a parallel-subagent run. Subagents must NOT call `ScheduleWakeup`, `CronCreate`, or arm Monitors of their own — not even as safety nets against their own slowness.
-
-**Why:** subagents finish their work and report back, but any wakeups they scheduled keep firing later against a coordinator that has moved on. The coordinator has no authoritative way to cancel a subagent's leaked schedule without paging through every subagent's task graph. Real-world observation: parallel worktree subagents scheduled "safety net" `/loop` wakeups in case they hung; they didn't hang, they finished cleanly, and the wakeups then fired hours later as stale no-ops at the coordinator — the coordinator had to spend turns confirming each one was a no-op against already-merged work.
-
-Bake the prohibition into every implementer prompt explicitly: *"do not call `ScheduleWakeup`, `CronCreate`, or arm Monitors; report back when done."* If a subagent genuinely needs to wait on an external event (CI finishing, deploy completing, log line matching), the coordinator arms the Monitor at the coordinator level after the subagent reports back — the subagent's job is to finish and exit, not to manage cadence.
-
-This applies to both `bones swarm join` flows and direct `Agent`-tool dispatches with `isolation: "worktree"`. The rule is about who owns the lifecycle, not about the dispatch mechanism.
 
 ## Model Selection
 
@@ -204,82 +136,73 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
 
-[bones tasks list --parent=ROOT_ID]
-→ [T1: Hook installation script | slot=alpha | status=pending]
-→ [T2: Recovery modes | slot=beta | status=pending]
-...
+[Read plan file once: docs/superpowers/plans/feature-plan.md]
+[Extract all 5 tasks with full text and context]
+[Create TodoWrite with all tasks]
 
 Task 1: Hook installation script
 
-[bones tasks show T1_ID → full task text]
-[Dispatch implementation subagent with task text + context]
-  Implementer first: bones swarm join --slot=alpha --task-id=T1_ID
-  Implementer second: TodoWrite [setup, tests, commit, self-review]
+[Get Task 1 text and context (already extracted)]
+[Dispatch implementation subagent with full task text + context]
 
 Implementer: "Before I begin - should the hook be installed at user or system level?"
 
-You: "User level (~/.config/bones-powers/hooks/)"
+You: "User level (~/.config/superpowers/hooks/)"
 
 Implementer: "Got it. Implementing now..."
 [Later] Implementer:
   - Implemented install-hook command
   - Added tests, 5/5 passing
   - Self-review: Found I missed --force flag, added it
-  - bones swarm close --result=success --summary='install-hook with --force, 5/5 tests'
+  - Checkpointed progress
 
-[Dispatch spec compliance reviewer with implementer's worktree path]
-Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
+[Dispatch spec compliance reviewer]
+Spec reviewer: Spec compliant - all requirements met, nothing extra
 
-[bones tasks show T1_ID — confirms closed:success]
+[Capture change identifiers, dispatch code quality reviewer]
+Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
+
+[Mark Task 1 complete]
 
 Task 2: Recovery modes
 
-[bones tasks show T2_ID → full task text]
-[Dispatch implementation subagent with task text + context]
-  Implementer first: bones swarm join --slot=beta --task-id=T2_ID
-  Implementer second: TodoWrite [verify mode, repair mode, tests, commit]
+[Get Task 2 text and context (already extracted)]
+[Dispatch implementation subagent with full task text + context]
 
 Implementer: [No questions, proceeds]
 Implementer:
   - Added verify/repair modes
   - 8/8 tests passing
   - Self-review: All good
-  - bones swarm close --result=success --summary='verify+repair modes, 8/8 tests'
+  - Checkpointed progress
 
 [Dispatch spec compliance reviewer]
-Spec reviewer: ❌ Issues:
+Spec reviewer: Issues:
   - Missing: Progress reporting (spec says "report every 100 items")
   - Extra: Added --json flag (not requested)
 
-[Coordinator dispatches fresh implementer with original task + review feedback]
-  New implementer: bones swarm close --result=fail --summary='missing progress reporting, extra --json flag'
-  New implementer: bones swarm join --slot=beta --task-id=T2_ID  (re-claim)
-  New implementer: TodoWrite [remove --json, add progress reporting, re-test]
-
 [Implementer fixes issues]
 Implementer: Removed --json flag, added progress reporting
-  bones swarm close --result=success --summary='progress reporting added, --json removed'
 
 [Spec reviewer reviews again]
-Spec reviewer: ✅ Spec compliant now
+Spec reviewer: Spec compliant now
 
 [Dispatch code quality reviewer]
 Code reviewer: Strengths: Solid. Issues (Important): Magic number (100)
 
-[Re-dispatch implementer with quality feedback]
-  bones swarm close --result=fail --summary='magic number 100 needs PROGRESS_INTERVAL constant'
-  bones swarm join --slot=beta --task-id=T2_ID
-  Implementer: Extracted PROGRESS_INTERVAL constant
-  bones swarm close --result=success --summary='PROGRESS_INTERVAL constant extracted'
+[Implementer fixes]
+Implementer: Extracted PROGRESS_INTERVAL constant
 
 [Code reviewer reviews again]
-Code reviewer: ✅ Approved
+Code reviewer: Approved
+
+[Mark Task 2 complete]
 
 ...
 
 [After all tasks]
 [Dispatch final code-reviewer]
-Final reviewer: All requirements met, ready to merge
+Final reviewer: All requirements met, ready to wrap up
 
 Done!
 ```
@@ -289,7 +212,7 @@ Done!
 **vs. Manual execution:**
 - Subagents follow TDD naturally
 - Fresh context per task (no confusion)
-- Parallel-safe (subagents each hold their own slot)
+- Parallel-safe (subagents don't interfere)
 - Subagent can ask questions (before AND during work)
 
 **vs. Executing Plans:**
@@ -298,11 +221,10 @@ Done!
 - Review checkpoints automatic
 
 **Efficiency gains:**
-- Coordinator queries bones tasks list (no file reading overhead)
-- Controller curates exactly what context is needed via `bones tasks show`
+- No file reading overhead (controller provides full text)
+- Controller curates exactly what context is needed
 - Subagent gets complete information upfront
 - Questions surfaced before work begins (not after)
-- Atomic claim via `bones swarm join` prevents double-work
 
 **Quality gates:**
 - Self-review catches issues before handoff
@@ -313,27 +235,25 @@ Done!
 
 **Cost:**
 - More subagent invocations (implementer + 2 reviewers per task)
-- Controller does more prep work (querying bones task graph)
+- Controller does more prep work (extracting all tasks upfront)
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
 
 ## Red Flags
 
 **Never:**
-- Start implementation on main/master branch without explicit user consent
+- Start implementation on the shared mainline without explicit user consent
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues
-- Dispatch multiple implementation subagents for the same slot (conflicts)
-- Make subagent read plan file (provide full text via `bones tasks show` instead)
+- Dispatch multiple implementation subagents in parallel (conflicts)
+- Make subagent read plan file (provide full text instead)
 - Skip scene-setting context (subagent needs to understand where task fits)
 - Ignore subagent questions (answer before letting them proceed)
 - Accept "close enough" on spec compliance (spec reviewer found issues = not done)
-- Skip review loops (reviewer found issues = implementer closes fail + fresh join = review again)
+- Skip review loops (reviewer found issues = implementer fixes = review again)
 - Let implementer self-review replace actual review (both are needed)
-- **Start code quality review before spec compliance is ✅** (wrong order)
+- **Start code quality review before spec compliance is approved** (wrong order)
 - Move to next task while either review has open issues
-- **Mirror bones tasks into TodoWrite at coordinator level** (source of truth is bones tasks, not TodoWrite)
-- **Allow a subagent to call `ScheduleWakeup`, `CronCreate`, or arm a Monitor** (those belong to the coordinator — see "Subagent Boundaries" above)
 
 **If subagent asks questions:**
 - Answer clearly and completely
@@ -341,9 +261,7 @@ Done!
 - Don't rush them into implementation
 
 **If reviewer finds issues:**
-- Implementer closes swarm session as failed (`bones swarm close --result=fail`)
-- Coordinator dispatches fresh implementer with feedback
-- New implementer re-joins via `bones swarm join`
+- Implementer (same subagent) fixes them
 - Reviewer reviews again
 - Repeat until approved
 - Don't skip the re-review
@@ -355,13 +273,11 @@ Done!
 ## Integration
 
 **Required workflow skills:**
-- **bones-powers:using-bones-swarm** - REQUIRED: understand slot sessions before starting
-- **bones-powers:writing-plans** - Creates the plan this skill executes
-- **bones-powers:requesting-code-review** - Code review template for reviewer subagents
-- **bones-powers:finishing-a-bones-leaf** - Complete development after all tasks
+- **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:requesting-code-review** - Code review template for reviewer subagents
 
 **Subagents should use:**
-- **bones-powers:test-driven-development** - Subagents follow TDD for each task
+- **superpowers:test-driven-development** - Subagents follow TDD for each task
 
 **Alternative workflow:**
-- **bones-powers:executing-plans** - Use for single-session inline execution instead of parallel slot sessions
+- **superpowers:executing-plans** - Use for parallel session instead of same-session execution

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: systematic-debugging
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when encountering any bug, test failure, or unexpected behavior in a bones workspace, before proposing fixes
+description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 category:
   primary: workflow
   secondary: [backpressure]
@@ -71,7 +71,7 @@ You MUST complete each phase before proceeding to the next.
 
 3. **Check Recent Changes**
    - What changed that could cause this?
-   - Git diff, recent commits
+   - Inspect recent diffs and the change history
    - New dependencies, config changes
    - Environmental differences
 
@@ -182,7 +182,7 @@ You MUST complete each phase before proceeding to the next.
    - Automated test if possible
    - One-off test script if no framework
    - MUST have before fixing
-   - Use the `bones-powers:test-driven-development` skill for writing proper failing tests
+   - Use the `superpowers:test-driven-development` skill for writing proper failing tests
 
 2. **Implement Single Fix**
    - Address the root cause identified
@@ -217,15 +217,6 @@ You MUST complete each phase before proceeding to the next.
    **Discuss with your human partner before attempting more fixes**
 
    This is NOT a failed hypothesis - this is a wrong architecture.
-
-## Bones context
-
-When debugging in a bones workspace:
-
-- **Workspace state checks**: use `bones repo status` (not `git status`) to confirm a clean working tree during phase 1 (root-cause investigation).
-- **Log inspection**: bones swarm sessions log to `.bones/leaves/<slot>/leaf.log`. Tail this for trace data during phase 2 (pattern analysis).
-- **Reproduction in isolation**: open a fresh swarm session in a sibling slot (`bones swarm join --slot=debug-<id> --task-id=<id>`) to reproduce a bug without polluting the main workspace.
-- **Artifact preservation**: if you need to keep failed-test output across debugging iterations, commit the artifact via `bones swarm commit -m 'debug snapshot'` so it's recorded on the leaf — `swarm close --result=fail` does not lose committed work.
 
 ## Red Flags - STOP and Follow Process
 
@@ -299,8 +290,8 @@ These techniques are part of systematic debugging and available in this director
 - **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
 
 **Related skills:**
-- **bones-powers:test-driven-development** - For creating failing test case (Phase 4, Step 1)
-- **bones-powers:verification-before-completion** - Verify fix worked before claiming success
+- **superpowers:test-driven-development** - For creating failing test case (Phase 4, Step 1)
+- **superpowers:verification-before-completion** - Verify fix worked before claiming success
 
 ## Real-World Impact
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: test-driven-development
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when implementing any feature or bugfix in a bones workspace, before writing implementation code
+description: Use when implementing any feature or bugfix, before writing implementation code
 category:
   primary: workflow
 ---
@@ -241,7 +241,7 @@ The "waste" is keeping code you can't trust. Working code without real tests is 
 **"TDD is dogmatic, being pragmatic means adapting"**
 
 TDD IS pragmatic:
-- Finds bugs before commit (faster than debugging after)
+- Finds bugs before checkpoint (faster than debugging after)
 - Prevents regressions (tests catch breaks immediately)
 - Documents behavior (tests show how to use code)
 - Enables refactoring (change freely, tests catch breaks)
@@ -361,7 +361,7 @@ Never fix bugs without a test.
 
 ## Testing Anti-Patterns
 
-When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+When adding mocks or test utilities, watch for common pitfalls:
 - Testing mock behavior instead of real behavior
 - Adding test-only methods to production classes
 - Mocking without understanding dependencies

--- a/skills/using-spec-kit/SKILL.md
+++ b/skills/using-spec-kit/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: using-spec-kit
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: Use when the user wants spec-driven development on a non-trivial change (e.g. "let's spec this", "write a constitution", "/speckit.*", or any staff-tier workflow starting from "what should this be" rather than "what should this do"). Drives spec → plan → tasks → impl via GitHub spec-kit, with artifacts in .agent-config/specs/.
+category:
+  primary: workflow
+---
+
+# Using Spec-Kit
+
+## Overview
+
+Spec-kit (github.com/github/spec-kit) is GitHub's spec-driven development toolkit. The philosophy: write the spec before the plan, the plan before the tasks, the tasks before the code — and treat each artifact as a reviewable hand-off, not a throwaway scratchpad. Reach for spec-kit when the change is large enough that "what is this, exactly?" is a question worth answering on paper first.
+
+**Announce at start:** "I'm using the using-spec-kit skill — running spec-driven workflow."
+
+## Trigger conditions
+
+Activate when any of the following hold:
+
+- User invokes a `/speckit.*` slash command directly
+- Session is staff-tier and the task involves architectural decisions, system design, public API shape, or cross-cutting changes
+- User says "let's spec this", "write a constitution for X", "draft a PRD", "spec-driven this", or asks for the spec → plan → tasks flow by name
+- The brief is fuzzy enough that authoring the spec is itself part of the work
+
+Do **not** activate for tight, well-scoped changes where a plan or direct execution is sufficient. Spec-kit is heavy; reserve it for work where the upfront artifact pays for itself.
+
+## Fit check (push back if mismatched)
+
+If the session is in a junior or general `engineer` fit, push back gently before proceeding — spec-kit is meant for staff-flavored work where the agent owns the spec-shape decisions. Surface the mismatch in one sentence and let the user redirect or override.
+
+## First-time setup (lazy)
+
+If `.specify/` does not exist at the repo root, install the toolkit before invoking any `/speckit.*` command:
+
+```bash
+uvx --from git+https://github.com/github/spec-kit.git specify-cli init . --integration claude
+```
+
+This installs `.claude/commands/speckit.*.md` (the slash commands) plus the `.specify/` scaffolding (templates, constitution, integration.json, bash helpers). Verify success by checking for `.specify/integration.json`.
+
+If `uv` / `uvx` is not installed, fail fast with a clear message — point the user at https://docs.astral.sh/uv/ and stop. Do not try to work around it.
+
+## Artifact location override
+
+Spec-kit defaults to `<repo_root>/specs/<NNN-slug>/`. Wardrobe wants spec artifacts gitignored. **Always** set `SPECIFY_FEATURE_DIRECTORY` before invoking specify commands:
+
+```bash
+FEATURE_SLUG="<descriptive-kebab-slug>"
+export SPECIFY_FEATURE_DIRECTORY=".agent-config/specs/$(echo "$FEATURE_SLUG" | tr ' ' '-' | tr 'A-Z' 'a-z')"
+mkdir -p "$SPECIFY_FEATURE_DIRECTORY"
+```
+
+The env var takes precedence over spec-kit's auto-numbering. Confirm `.agent-config/specs/` is in `.gitignore`; add it if not.
+
+`.specify/` itself (templates, constitution, integration.json) **must** stay at the repo root — it is spec-kit's project marker and cannot be relocated. Gitignore it if you don't want it tracked.
+
+## The five-step flow
+
+Run these in order. Each writes its artifact into `$SPECIFY_FEATURE_DIRECTORY` (or `.specify/memory/` for the constitution).
+
+- `/speckit.constitution` — establish project-wide principles (rules the agent should always honor). One-time per repo. Skip if the constitution already exists and still reflects the project.
+- `/speckit.specify` — author the spec for this feature (problem, goals, non-goals, requirements, acceptance criteria). Required.
+- `/speckit.plan` — derive an implementation plan from the spec (architecture, file structure, sequencing). Required.
+- `/speckit.tasks` — break the plan into individually-executable tasks. Required for any non-trivial feature; skip only when the plan is a single small task.
+- `/speckit.implement` — execute task-by-task. Optional — the user may prefer to hand tasks off to a different execution skill (e.g. `executing-plans`, `subagent-driven-development`) or run them manually.
+
+Optional: `/speckit.taskstoissues` if the user wants tasks materialized as GitHub issues for a separate execution flow.
+
+## Caveats
+
+- **Do not wrap or shadow the `/speckit.*` slash commands.** They're well-designed and self-describing. This skill teaches *when* and *how* to use them, not what they do internally. Invoke them directly.
+- **`.specify/` must live at repo root.** Project marker; not relocatable. Gitignore it (and `.agent-config/specs/`) rather than fight it.
+- **`uv` / `uvx` required.** Spec-kit is Python-tooled. Fail with a clear message if absent; do not silently degrade.
+- **Spec-kit assumes one feature in flight per slug.** If the user is iterating on multiple features in parallel, give each its own `SPECIFY_FEATURE_DIRECTORY`.
+- **The agent authors the artifacts; the bundled scripts handle plumbing** (numbering, branching, path conventions). Trust the scripts — don't second-guess paths or filenames they emit.
+- **Don't conflate spec-kit's plan with wardrobe's `writing-plans` skill.** Spec-kit's plan is the architectural shape derived from the spec; `writing-plans` produces a bite-sized task graph for bones execution. They can compose (spec-kit plan → wardrobe plan), but they are not the same artifact.
+
+## Handoff
+
+After `/speckit.tasks` produces the task list, the user may want to execute via:
+
+1. `/speckit.implement` — spec-kit's built-in execution loop
+2. `executing-plans` / `subagent-driven-development` — wardrobe's execution skills, if the tasks have been materialized into bones
+3. Manual execution by the user
+
+Ask which mode they want; default to `/speckit.implement` if no preference.

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: using-superpowers
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+category:
+  primary: workflow
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Superpowers skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+2. **Superpowers skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
+
+**In Copilot CLI:** Use the `skill` tool. Skills are auto-discovered from installed plugins. The `skill` tool works the same as Claude Code's `Skill` tool.
+
+**In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Platform Adaptation
+
+Skills use Claude Code tool names. Non-CC platforms (Copilot CLI, Codex, Gemini CLI) typically provide tool mappings via their own platform documentation or harness config files (AGENTS.md, GEMINI.md, etc.). Read the harness's local documentation if a referenced tool name doesn't resolve.
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: verification-before-completion
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when about to claim work is complete, fixed, or passing in a bones workspace, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: Use when about to claim work is complete, fixed, or passing, before checkpointing or requesting review — requires running verification commands and confirming output before making any success claims; evidence before assertions always
 category:
   primary: backpressure
 ---
@@ -51,14 +51,14 @@ Skip any step = lying, not verifying
 | Build succeeds | Build command: exit 0 | Linter passing, logs look good |
 | Bug fixed | Test original symptom: passes | Code changed, assumed fixed |
 | Regression test works | Red-green cycle verified | Test passes once |
-| Agent completed | `bones repo status` shows changes | Agent reports "success" |
+| Agent completed | Workspace diff shows changes | Agent reports "success" |
 | Requirements met | Line-by-line checklist | Tests passing |
 
 ## Red Flags - STOP
 
 - Using "should", "probably", "seems to"
 - Expressing satisfaction before verification ("Great!", "Perfect!", "Done!", etc.)
-- About to commit/push/PR without verification
+- About to checkpoint/publish/request review without verification
 - Trusting agent success reports
 - Relying on partial verification
 - Thinking "just this once"
@@ -106,7 +106,7 @@ Skip any step = lying, not verifying
 
 **Agent delegation:**
 ```
-✅ Agent reports success → bones repo status → Verify changes → Report actual state
+✅ Agent reports success → Inspect the actual workspace state → Verify changes → Report actual state
 ❌ Trust agent report
 ```
 
@@ -125,7 +125,7 @@ From 24 failure memories:
 - ANY variation of success/completion claims
 - ANY expression of satisfaction
 - ANY positive statement about work state
-- Committing, PR creation, task completion
+- Checkpointing, requesting review, task completion
 - Moving to next task
 - Delegating to agents
 
@@ -142,11 +142,3 @@ From 24 failure memories:
 Run the command. Read the output. THEN claim the result.
 
 This is non-negotiable.
-
-## Bones context
-
-When verifying in a bones workspace:
-
-- **Workspace cleanliness**: use `bones repo status` (not `git status`) to confirm a clean working tree before claiming work is committed or staged.
-- **Inside a swarm session**: run verification commands from `cd "$(bones swarm cwd --slot=$SLOT)"` to ensure you're in the leaf's worktree, not the main checkout.
-- **Test isolation**: swarm sessions each have their own worktree; running tests from the wrong cwd produces results for a different checkout state — always anchor to the leaf before claiming tests pass.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: writing-plans
-version: 1.0.0
+version: 1.1.0
 targets: [claude-code]
 type: skill
-description: Use when you have a spec or requirements for a multi-step task in a bones workspace, before touching code — produces a bones task graph plan with slot assignments and leaf-level steps
+description: Use when you have a spec or requirements for a multi-step task, before touching code — produces a structured task plan with assignments and leaf-level steps
 category:
   primary: workflow
 ---
@@ -12,15 +12,15 @@ category:
 
 ## Overview
 
-Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent checkpoints.
 
 Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
-**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+**Context:** If working in an isolated work area, it should have been set up during brainstorming.
 
-**Save plans to:** `docs/bones-powers/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -45,7 +45,7 @@ This structure informs the task decomposition. Each task should produce self-con
 - "Run it to make sure it fails" - step
 - "Implement the minimal code to make the test pass" - step
 - "Run the tests and make sure they pass" - step
-- "Commit" - step
+- "Checkpoint your progress" - step
 
 ## Plan Document Header
 
@@ -54,7 +54,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use bones-powers:subagent-driven-development (recommended) or bones-powers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -68,7 +68,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ## Task Structure
 
 ````markdown
-### Task N: [Component Name]  `[slot: <slot-name>]`
+### Task N: [Component Name]
 
 **Files:**
 - Create: `exact/path/to/file.py`
@@ -100,18 +100,10 @@ def function(input):
 Run: `pytest tests/path/test.py::test_name -v`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Checkpoint your progress**
 
-```bash
-bones repo add tests/path/test.py src/path/file.py && bones repo ci -m "feat: add specific feature" tests/path/test.py src/path/file.py
-```
+Stage and save a snapshot of `tests/path/test.py` and `src/path/file.py` with a clear message ("feat: add specific feature").
 ````
-
-### Slot annotation
-
-Each task carries a `[slot: <name>]` tag matching the bones swarm slot that should claim it. Slots group tasks by worker type (e.g. `infra`, `frontend`, `data`). One slot per task; tasks without a natural slot use `[slot: any]`.
-
-Slot names become `--slot=<name>` arguments when the plan is materialized into bones tasks at the end of this skill (see "## Plan → bones tasks" below).
 
 ## No Placeholders
 
@@ -127,7 +119,7 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Exact file paths always
 - Complete code in every step — if a step changes code, show the code
 - Exact commands with expected output
-- DRY, YAGNI, TDD, frequent commits
+- DRY, YAGNI, TDD, frequent checkpoints
 
 ## Self-Review
 
@@ -139,43 +131,24 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
 
-If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
-
-## Plan → bones tasks
-
-After the plan is saved AND user-reviewed, materialize it into the bones task graph (per spec § 4.4 of `docs/superpowers/specs/2026-04-29-bones-powers-design.md`):
-
-```bash
-PLAN=docs/bones-powers/plans/<filename>.md
-bones repo add "$PLAN"
-bones repo ci -m "add <feature> plan" "$PLAN"
-
-# Root task (no slot, no parent)
-ROOT_ID=$(bones tasks create "<feature>" --files="$PLAN" --json | jq -r .id)
-echo "Root task: $ROOT_ID"
-
-# One child per plan task — repeat for each [slot: X] task in the plan
-bones tasks create "<task-1-title>" --parent="$ROOT_ID" --slot="<slot>" --files="$PLAN"
-bones tasks create "<task-2-title>" --parent="$ROOT_ID" --slot="<slot>" --files="$PLAN"
-# ... (one per task in the plan)
-```
-
-Children inherit no fields automatically — be explicit. Reuse `--files="$PLAN"` on every child so `bones tasks show <id>` always surfaces the source-of-truth plan.
+If you find issues, fix them inline. No need to re-review — just fix and move on.
 
 ## Execution Handoff
 
-After tasks are emitted, offer execution choice:
+After saving the plan, offer execution choice:
 
-> "Plan materialized. Root task `<ROOT_ID>` with N children. Two execution modes (per spec § 5):
->
-> 1. **`subagent-driven-development` (recommended for parallel work)** — dispatches a fresh implementer subagent per child task, each in its own slot/leaf via `bones swarm join`. Two-stage review between tasks.
->
-> 2. **`executing-plans` (single-session inline)** — coordinator loops through `bones tasks list --parent=<ROOT_ID>`, claiming and closing each task in this session.
->
-> Which mode?"
+**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
 
-If `subagent-driven-development` chosen:
-- **REQUIRED SUB-SKILL:** Use `bones-powers:subagent-driven-development`.
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 
-If `executing-plans` chosen:
-- **REQUIRED SUB-SKILL:** Use `bones-powers:executing-plans`.
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Fresh subagent per task + two-stage review
+
+**If Inline Execution chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- Batch execution with checkpoints for review

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,0 +1,654 @@
+---
+name: writing-skills
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+category:
+  primary: evolution
+---
+
+# Writing Skills
+
+## Overview
+
+**Writing skills IS Test-Driven Development applied to process documentation.**
+
+**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)** 
+
+You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
+
+**Core principle:** If you didn't watch an agent fail without the skill, you don't know if the skill teaches the right thing.
+
+**REQUIRED BACKGROUND:** You MUST understand superpowers:test-driven-development before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill adapts TDD to documentation.
+
+**Official guidance:** For Anthropic's official skill authoring best practices, see anthropic-best-practices.md. This document provides additional patterns and guidelines that complement the TDD-focused approach in this skill.
+
+## What is a Skill?
+
+A **skill** is a reference guide for proven techniques, patterns, or tools. Skills help future Claude instances find and apply effective approaches.
+
+**Skills are:** Reusable techniques, patterns, tools, reference guides
+
+**Skills are NOT:** Narratives about how you solved a problem once
+
+## TDD Mapping for Skills
+
+| TDD Concept | Skill Creation |
+|-------------|----------------|
+| **Test case** | Pressure scenario with subagent |
+| **Production code** | Skill document (SKILL.md) |
+| **Test fails (RED)** | Agent violates rule without skill (baseline) |
+| **Test passes (GREEN)** | Agent complies with skill present |
+| **Refactor** | Close loopholes while maintaining compliance |
+| **Write test first** | Run baseline scenario BEFORE writing skill |
+| **Watch it fail** | Document exact rationalizations agent uses |
+| **Minimal code** | Write skill addressing those specific violations |
+| **Watch it pass** | Verify agent now complies |
+| **Refactor cycle** | Find new rationalizations → plug → re-verify |
+
+The entire skill creation process follows RED-GREEN-REFACTOR.
+
+## When to Create a Skill
+
+**Create when:**
+- Technique wasn't intuitively obvious to you
+- You'd reference this again across projects
+- Pattern applies broadly (not project-specific)
+- Others would benefit
+
+**Don't create for:**
+- One-off solutions
+- Standard practices well-documented elsewhere
+- Project-specific conventions (put in CLAUDE.md)
+- Mechanical constraints (if it's enforceable with regex/validation, automate it—save documentation for judgment calls)
+
+## Skill Types
+
+### Technique
+Concrete method with steps to follow (condition-based-waiting, root-cause-tracing)
+
+### Pattern
+Way of thinking about problems (flatten-with-flags, test-invariants)
+
+### Reference
+API docs, syntax guides, tool documentation (office docs)
+
+## Directory Structure
+
+
+```
+skills/
+  skill-name/
+    SKILL.md              # Main reference (required)
+    supporting-file.*     # Only if needed
+```
+
+**Flat namespace** - all skills in one searchable namespace
+
+**Separate files for:**
+1. **Heavy reference** (100+ lines) - API docs, comprehensive syntax
+2. **Reusable tools** - Scripts, utilities, templates
+
+**Keep inline:**
+- Principles and concepts
+- Code patterns (< 50 lines)
+- Everything else
+
+## SKILL.md Structure
+
+**Frontmatter (YAML):**
+- Two required fields: `name` and `description` (see [agentskills.io/specification](https://agentskills.io/specification) for all supported fields)
+- Max 1024 characters total
+- `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
+- `description`: Third-person, describes ONLY when to use (NOT what it does)
+  - Start with "Use when..." to focus on triggering conditions
+  - Include specific symptoms, situations, and contexts
+  - **NEVER summarize the skill's process or workflow** (see CSO section for why)
+  - Keep under 500 characters if possible
+
+```markdown
+---
+name: Skill-Name-With-Hyphens
+description: Use when [specific triggering conditions and symptoms]
+---
+
+# Skill Name
+
+## Overview
+What is this? Core principle in 1-2 sentences.
+
+## When to Use
+[Small inline flowchart IF decision non-obvious]
+
+Bullet list with SYMPTOMS and use cases
+When NOT to use
+
+## Core Pattern (for techniques/patterns)
+Before/after code comparison
+
+## Quick Reference
+Table or bullets for scanning common operations
+
+## Implementation
+Inline code for simple patterns
+Link to file for heavy reference or reusable tools
+
+## Common Mistakes
+What goes wrong + fixes
+
+## Real-World Impact (optional)
+Concrete results
+```
+
+
+## Claude Search Optimization (CSO)
+
+**Critical for discovery:** Future Claude needs to FIND your skill
+
+### 1. Rich Description Field
+
+**Purpose:** Claude reads description to decide which skills to load for a given task. Make it answer: "Should I read this skill right now?"
+
+**Format:** Start with "Use when..." to focus on triggering conditions
+
+**CRITICAL: Description = When to Use, NOT What the Skill Does**
+
+The description should ONLY describe triggering conditions. Do NOT summarize the skill's process or workflow in the description.
+
+**Why this matters:** Testing revealed that when a description summarizes the skill's workflow, Claude may follow the description instead of reading the full skill content. A description saying "code review between tasks" caused Claude to do ONE review, even though the skill's flowchart clearly showed TWO reviews (spec compliance then code quality).
+
+When the description was changed to just "Use when executing implementation plans with independent tasks" (no workflow summary), Claude correctly read the flowchart and followed the two-stage review process.
+
+**The trap:** Descriptions that summarize workflow create a shortcut Claude will take. The skill body becomes documentation Claude skips.
+
+```yaml
+# BAD: Summarizes workflow - Claude may follow this instead of reading skill
+description: Use when executing plans - dispatches subagent per task with code review between tasks
+
+# BAD: Too much process detail
+description: Use for TDD - write test first, watch it fail, write minimal code, refactor
+
+# GOOD: Just triggering conditions, no workflow summary
+description: Use when executing implementation plans with independent tasks in the current session
+
+# GOOD: Triggering conditions only
+description: Use when implementing any feature or bugfix, before writing implementation code
+```
+
+**Content:**
+- Use concrete triggers, symptoms, and situations that signal this skill applies
+- Describe the *problem* (race conditions, inconsistent behavior) not *language-specific symptoms* (setTimeout, sleep)
+- Keep triggers technology-agnostic unless the skill itself is technology-specific
+- If skill is technology-specific, make that explicit in the trigger
+- Write in third person (injected into system prompt)
+- **NEVER summarize the skill's process or workflow**
+
+```yaml
+# BAD: Too abstract, vague, doesn't include when to use
+description: For async testing
+
+# BAD: First person
+description: I can help you with async tests when they're flaky
+
+# BAD: Mentions technology but skill isn't specific to it
+description: Use when tests use setTimeout/sleep and are flaky
+
+# GOOD: Starts with "Use when", describes problem, no workflow
+description: Use when tests have race conditions, timing dependencies, or pass/fail inconsistently
+
+# GOOD: Technology-specific skill with explicit trigger
+description: Use when using React Router and handling authentication redirects
+```
+
+### 2. Keyword Coverage
+
+Use words Claude would search for:
+- Error messages: "Hook timed out", "ENOTEMPTY", "race condition"
+- Symptoms: "flaky", "hanging", "zombie", "pollution"
+- Synonyms: "timeout/hang/freeze", "cleanup/teardown/afterEach"
+- Tools: Actual commands, library names, file types
+
+### 3. Descriptive Naming
+
+**Use active voice, verb-first:**
+- `creating-skills` not `skill-creation`
+- `condition-based-waiting` not `async-test-helpers`
+
+### 4. Token Efficiency (Critical)
+
+**Problem:** getting-started and frequently-referenced skills load into EVERY conversation. Every token counts.
+
+**Target word counts:**
+- getting-started workflows: <150 words each
+- Frequently-loaded skills: <200 words total
+- Other skills: <500 words (still be concise)
+
+**Techniques:**
+
+**Move details to tool help:**
+```bash
+# BAD: Document all flags in SKILL.md
+search-conversations supports --text, --both, --after DATE, --before DATE, --limit N
+
+# GOOD: Reference --help
+search-conversations supports multiple modes and filters. Run --help for details.
+```
+
+**Use cross-references:**
+```markdown
+# BAD: Repeat workflow details
+When searching, dispatch subagent with template...
+[20 lines of repeated instructions]
+
+# GOOD: Reference other skill
+Always use subagents (50-100x context savings). REQUIRED: Use [other-skill-name] for workflow.
+```
+
+**Compress examples:**
+```markdown
+# BAD: Verbose example (42 words)
+your human partner: "How did we handle authentication errors in React Router before?"
+You: I'll search past conversations for React Router authentication patterns.
+[Dispatch subagent with search query: "React Router authentication error handling 401"]
+
+# GOOD: Minimal example (20 words)
+Partner: "How did we handle auth errors in React Router?"
+You: Searching...
+[Dispatch subagent → synthesis]
+```
+
+**Eliminate redundancy:**
+- Don't repeat what's in cross-referenced skills
+- Don't explain what's obvious from command
+- Don't include multiple examples of same pattern
+
+**Verification:**
+```bash
+wc -w skills/path/SKILL.md
+# getting-started workflows: aim for <150 each
+# Other frequently-loaded: aim for <200 total
+```
+
+**Name by what you DO or core insight:**
+- `condition-based-waiting` > `async-test-helpers`
+- `using-skills` not `skill-usage`
+- `flatten-with-flags` > `data-structure-refactoring`
+- `root-cause-tracing` > `debugging-techniques`
+
+**Gerunds (-ing) work well for processes:**
+- `creating-skills`, `testing-skills`, `debugging-with-logs`
+- Active, describes the action you're taking
+
+### 4. Cross-Referencing Other Skills
+
+**When writing documentation that references other skills:**
+
+Use skill name only, with explicit requirement markers:
+- Good: `**REQUIRED SUB-SKILL:** Use superpowers:test-driven-development`
+- Good: `**REQUIRED BACKGROUND:** You MUST understand superpowers:systematic-debugging`
+- Bad: `See skills/testing/test-driven-development` (unclear if required)
+- Bad: `@skills/testing/test-driven-development/SKILL.md` (force-loads, burns context)
+
+**Why no @ links:** `@` syntax force-loads files immediately, consuming 200k+ context before you need them.
+
+## Flowchart Usage
+
+```dot
+digraph when_flowchart {
+    "Need to show information?" [shape=diamond];
+    "Decision where I might go wrong?" [shape=diamond];
+    "Use markdown" [shape=box];
+    "Small inline flowchart" [shape=box];
+
+    "Need to show information?" -> "Decision where I might go wrong?" [label="yes"];
+    "Decision where I might go wrong?" -> "Small inline flowchart" [label="yes"];
+    "Decision where I might go wrong?" -> "Use markdown" [label="no"];
+}
+```
+
+**Use flowcharts ONLY for:**
+- Non-obvious decision points
+- Process loops where you might stop too early
+- "When to use A vs B" decisions
+
+**Never use flowcharts for:**
+- Reference material → Tables, lists
+- Code examples → Markdown blocks
+- Linear instructions → Numbered lists
+- Labels without semantic meaning (step1, helper2)
+
+Keep graphviz styling simple: `shape=diamond` for decisions, `shape=box` for actions, `shape=ellipse` for terminal states. Avoid color unless it carries semantic meaning. One flowchart per concept; don't pack multiple flows into a single graph.
+
+## Code Examples
+
+**One excellent example beats many mediocre ones**
+
+Choose most relevant language:
+- Testing techniques → TypeScript/JavaScript
+- System debugging → Shell/Python
+- Data processing → Python
+
+**Good example:**
+- Complete and runnable
+- Well-commented explaining WHY
+- From real scenario
+- Shows pattern clearly
+- Ready to adapt (not generic template)
+
+**Don't:**
+- Implement in 5+ languages
+- Create fill-in-the-blank templates
+- Write contrived examples
+
+You're good at porting - one great example is enough.
+
+## File Organization
+
+### Self-Contained Skill
+```
+defense-in-depth/
+  SKILL.md    # Everything inline
+```
+When: All content fits, no heavy reference needed
+
+### Skill with Reusable Tool
+```
+condition-based-waiting/
+  SKILL.md    # Overview + patterns
+  example.ts  # Working helpers to adapt
+```
+When: Tool is reusable code, not just narrative
+
+### Skill with Heavy Reference
+```
+pptx/
+  SKILL.md       # Overview + workflows
+  pptxgenjs.md   # 600 lines API reference
+  ooxml.md       # 500 lines XML structure
+  scripts/       # Executable tools
+```
+When: Reference material too large for inline
+
+## The Iron Law (Same as TDD)
+
+```
+NO SKILL WITHOUT A FAILING TEST FIRST
+```
+
+This applies to NEW skills AND EDITS to existing skills.
+
+Write skill before testing? Delete it. Start over.
+Edit skill without testing? Same violation.
+
+**No exceptions:**
+- Not for "simple additions"
+- Not for "just adding a section"
+- Not for "documentation updates"
+- Don't keep untested changes as "reference"
+- Don't "adapt" while running tests
+- Delete means delete
+
+**REQUIRED BACKGROUND:** The superpowers:test-driven-development skill explains why this matters. Same principles apply to documentation.
+
+## Testing All Skill Types
+
+Different skill types need different test approaches:
+
+### Discipline-Enforcing Skills (rules/requirements)
+
+**Examples:** TDD, verification-before-completion, designing-before-coding
+
+**Test with:**
+- Academic questions: Do they understand the rules?
+- Pressure scenarios: Do they comply under stress?
+- Multiple pressures combined: time + sunk cost + exhaustion
+- Identify rationalizations and add explicit counters
+
+**Success criteria:** Agent follows rule under maximum pressure
+
+### Technique Skills (how-to guides)
+
+**Examples:** condition-based-waiting, root-cause-tracing, defensive-programming
+
+**Test with:**
+- Application scenarios: Can they apply the technique correctly?
+- Variation scenarios: Do they handle edge cases?
+- Missing information tests: Do instructions have gaps?
+
+**Success criteria:** Agent successfully applies technique to new scenario
+
+### Pattern Skills (mental models)
+
+**Examples:** reducing-complexity, information-hiding concepts
+
+**Test with:**
+- Recognition scenarios: Do they recognize when pattern applies?
+- Application scenarios: Can they use the mental model?
+- Counter-examples: Do they know when NOT to apply?
+
+**Success criteria:** Agent correctly identifies when/how to apply pattern
+
+### Reference Skills (documentation/APIs)
+
+**Examples:** API documentation, command references, library guides
+
+**Test with:**
+- Retrieval scenarios: Can they find the right information?
+- Application scenarios: Can they use what they found correctly?
+- Gap testing: Are common use cases covered?
+
+**Success criteria:** Agent finds and correctly applies reference information
+
+## Common Rationalizations for Skipping Testing
+
+| Excuse | Reality |
+|--------|---------|
+| "Skill is obviously clear" | Clear to you ≠ clear to other agents. Test it. |
+| "It's just a reference" | References can have gaps, unclear sections. Test retrieval. |
+| "Testing is overkill" | Untested skills have issues. Always. 15 min testing saves hours. |
+| "I'll test if problems emerge" | Problems = agents can't use skill. Test BEFORE deploying. |
+| "Too tedious to test" | Testing is less tedious than debugging bad skill in production. |
+| "I'm confident it's good" | Overconfidence guarantees issues. Test anyway. |
+| "Academic review is enough" | Reading ≠ using. Test application scenarios. |
+| "No time to test" | Deploying untested skill wastes more time fixing it later. |
+
+**All of these mean: Test before deploying. No exceptions.**
+
+## Bulletproofing Skills Against Rationalization
+
+Skills that enforce discipline (like TDD) need to resist rationalization. Agents are smart and will find loopholes when under pressure.
+
+**Psychology note:** Understanding WHY persuasion techniques work helps you apply them systematically. See persuasion-principles.md for research foundation (Cialdini, 2021; Meincke et al., 2025) on authority, commitment, scarcity, social proof, and unity principles.
+
+### Close Every Loophole Explicitly
+
+Don't just state the rule - forbid specific workarounds:
+
+<Bad>
+```markdown
+Write code before test? Delete it.
+```
+</Bad>
+
+<Good>
+```markdown
+Write code before test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+```
+</Good>
+
+### Address "Spirit vs Letter" Arguments
+
+Add foundational principle early:
+
+```markdown
+**Violating the letter of the rules is violating the spirit of the rules.**
+```
+
+This cuts off entire class of "I'm following the spirit" rationalizations.
+
+### Build Rationalization Table
+
+Capture rationalizations from baseline testing (see Testing section below). Every excuse agents make goes in the table:
+
+```markdown
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+```
+
+### Create Red Flags List
+
+Make it easy for agents to self-check when rationalizing:
+
+```markdown
+## Red Flags - STOP and Start Over
+
+- Code before test
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+```
+
+### Update CSO for Violation Symptoms
+
+Add to description: symptoms of when you're ABOUT to violate the rule:
+
+```yaml
+description: use when implementing any feature or bugfix, before writing implementation code
+```
+
+## RED-GREEN-REFACTOR for Skills
+
+Follow the TDD cycle:
+
+### RED: Write Failing Test (Baseline)
+
+Run pressure scenario with subagent WITHOUT the skill. Document exact behavior:
+- What choices did they make?
+- What rationalizations did they use (verbatim)?
+- Which pressures triggered violations?
+
+This is "watch the test fail" - you must see what agents naturally do before writing the skill.
+
+### GREEN: Write Minimal Skill
+
+Write skill that addresses those specific rationalizations. Don't add extra content for hypothetical cases.
+
+Run same scenarios WITH skill. Agent should now comply.
+
+### REFACTOR: Close Loopholes
+
+Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
+
+**Testing methodology:** run pressure scenarios:
+- Write scenarios that stress the skill (real-world friction, not synthetic checks)
+- Pressure types: time, sunk cost, authority, exhaustion
+- Plug holes systematically — every rationalization an agent makes gets an explicit counter in the skill body
+- Meta-test by combining pressures (e.g., time + sunk cost)
+
+## Anti-Patterns
+
+### Narrative Example
+"In session 2025-10-03, we found empty projectDir caused..."
+**Why bad:** Too specific, not reusable
+
+### Multi-Language Dilution
+example-js.js, example-py.py, example-go.go
+**Why bad:** Mediocre quality, maintenance burden
+
+### Code in Flowcharts
+```dot
+step1 [label="import fs"];
+step2 [label="read file"];
+```
+**Why bad:** Can't copy-paste, hard to read
+
+### Generic Labels
+helper1, helper2, step3, pattern4
+**Why bad:** Labels should have semantic meaning
+
+## STOP: Before Moving to Next Skill
+
+**After writing ANY skill, you MUST STOP and complete the deployment process.**
+
+**Do NOT:**
+- Create multiple skills in batch without testing each
+- Move to next skill before current one is verified
+- Skip testing because "batching is more efficient"
+
+**The deployment checklist below is MANDATORY for EACH skill.**
+
+Deploying untested skills = deploying untested code. It's a violation of quality standards.
+
+## Skill Creation Checklist (TDD Adapted)
+
+**IMPORTANT: Use TodoWrite to create todos for EACH checklist item below.**
+
+**RED Phase - Write Failing Test:**
+- [ ] Create pressure scenarios (3+ combined pressures for discipline skills)
+- [ ] Run scenarios WITHOUT skill - document baseline behavior verbatim
+- [ ] Identify patterns in rationalizations/failures
+
+**GREEN Phase - Write Minimal Skill:**
+- [ ] Name uses only letters, numbers, hyphens (no parentheses/special chars)
+- [ ] YAML frontmatter with required `name` and `description` fields (max 1024 chars; see [spec](https://agentskills.io/specification))
+- [ ] Description starts with "Use when..." and includes specific triggers/symptoms
+- [ ] Description written in third person
+- [ ] Keywords throughout for search (errors, symptoms, tools)
+- [ ] Clear overview with core principle
+- [ ] Address specific baseline failures identified in RED
+- [ ] Code inline OR link to separate file
+- [ ] One excellent example (not multi-language)
+- [ ] Run scenarios WITH skill - verify agents now comply
+
+**REFACTOR Phase - Close Loopholes:**
+- [ ] Identify NEW rationalizations from testing
+- [ ] Add explicit counters (if discipline skill)
+- [ ] Build rationalization table from all test iterations
+- [ ] Create red flags list
+- [ ] Re-test until bulletproof
+
+**Quality Checks:**
+- [ ] Small flowchart only if decision non-obvious
+- [ ] Quick reference table
+- [ ] Common mistakes section
+- [ ] No narrative storytelling
+- [ ] Supporting files only for tools or heavy reference
+
+**Deployment:**
+- [ ] Checkpoint the skill into your workspace and publish it where future Claude instances can find it
+- [ ] Consider contributing back upstream (if broadly useful)
+
+## Discovery Workflow
+
+How future Claude finds your skill:
+
+1. **Encounters problem** ("tests are flaky")
+3. **Finds SKILL** (description matches)
+4. **Scans overview** (is this relevant?)
+5. **Reads patterns** (quick reference table)
+6. **Loads example** (only when implementing)
+
+**Optimize for this flow** - put searchable terms early and often.
+
+## The Bottom Line
+
+**Creating skills IS TDD for process documentation.**
+
+Same Iron Law: No skill without failing test first.
+Same cycle: RED (baseline) → GREEN (write skill) → REFACTOR (close loopholes).
+Same benefits: Better quality, fewer surprises, bulletproof results.
+
+If you follow TDD for code, follow it for skills. It's the same discipline applied to documentation.


### PR DESCRIPTION
## Summary

- Add fit axis (4th wardrobe component): `junior-engineer`, `engineer`, `senior-engineer`, `staff-engineer`. Composes as overlay on outfit/cut/accessory via existing set-algebra pipeline.
- Refresh 10 superpowers skills from obra/superpowers with no-git scrub (worktree/commit/PR language genericized; "bones workspace" frontmatter dropped). Drop `using-git-worktrees` + `finishing-a-development-branch` upstream skills.
- Add 2 new superpowers skills (`writing-skills`, `using-superpowers`), 5 vendored Pocock skills (`pocock-*` prefix) for junior tier, and `using-spec-kit` for staff tier (artifacts redirect to `.agent-config/specs/<slug>` via `SPECIFY_FEATURE_DIRECTORY`).
- Plan doc at `docs/plans/2026-05-14-fit-axis-seniority-tiers.md`.

## Blocked on

**danmestas/suit#60** — adds `--fit` flag + fit component registration to suit's resolution pipeline. Wardrobe content lands here; suit-side support lands there. Mark this PR ready when #60 merges.

## Test plan

- [x] `npm run validate` → OK (141 components, 3 pre-existing warnings)
- [x] `npm run build -- --target all --dry-run` → 145 files across 4 targets, no errors
- [x] Verify no bones-workspace references remain in superpowers-refreshed frontmatter
- [x] Verify no broken `@<file>` markdown references in refreshed skill bodies
- [ ] After suit#60 lands: confirm `suit claude --outfit code --fit senior-engineer` composes correctly
- [ ] After suit#60 lands: confirm `--outfit engineer --fit junior-engineer` strips philosophy via skill_exclude

## Follow-ups (out of scope)

- `cuts/executing/cut.md` still enables `superpowers` plugin via `enable.plugins`. With vendored no-git'd skills now in `skills/`, sessions using `--cut executing` may double-load. Resolve in a separate PR once we observe runtime behavior.
- Future: split `pocock-git-guardrails` activation by detecting git presence in the harness, fail-closed for git-free environments.