### PR TITLE
feat(tooling): universal cost-saving skills + caveman pack

### DIFF
--- a/accessories/rtk-tooling/accessory.md
+++ b/accessories/rtk-tooling/accessory.md
@@ -26,6 +26,7 @@ include:
   hooks:
     - rtk-suggest
     - rtk-rewrite
+    - rtk-pre-commit-format
   agents:
     - rtk-testing-specialist
     - rtk-rust-expert

--- a/outfits/aviation/outfit.md
+++ b/outfits/aviation/outfit.md
@@ -13,6 +13,9 @@ categories:
   - workflow
   - memory-management
   - integrations
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -38,6 +41,25 @@ skill_include:
   - obsidian-markdown
   - vault-autoresearch
   - apple-contacts
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - golang-patterns
   - datastar

--- a/outfits/backend/outfit.md
+++ b/outfits/backend/outfit.md
@@ -15,6 +15,9 @@ categories:
   - evolution
   - integrations
   - context-management
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -32,6 +35,25 @@ skill_include:
   - tigerstyle
   - ousterhout
   - verification-before-completion
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - datastar
   - datastar-tao

--- a/outfits/bones/outfit.md
+++ b/outfits/bones/outfit.md
@@ -14,6 +14,9 @@ categories:
   - backpressure
   - evolution
   - integrations
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -31,6 +34,25 @@ skill_include:
   - landing
   - golang-patterns
   - dispatching-parallel-agents
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - datastar
   - datastar-tao

--- a/outfits/code/outfit.md
+++ b/outfits/code/outfit.md
@@ -5,6 +5,9 @@ type: outfit
 description: Generic coding work — language-agnostic baseline for any code project.
 targets: [claude-code, codex, gemini, pi]
 categories: [economy, workflow, backpressure, evolution]
+enable:
+  mcps:
+    - context-mode
 skill_include:
   - writing-plans
   - brainstorming
@@ -14,6 +17,25 @@ skill_include:
   - tigerstyle
   - verification-before-completion
   - executing-plans
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/outfits/engineer/outfit.md
+++ b/outfits/engineer/outfit.md
@@ -14,6 +14,9 @@ categories:
   - backpressure
   - evolution
   - context-management
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -40,6 +43,25 @@ skill_include:
   - receiving-code-review
   - test-driven-development
   - dx-audit
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - datastar
   - datastar-tao

--- a/outfits/frontend/outfit.md
+++ b/outfits/frontend/outfit.md
@@ -14,6 +14,9 @@ categories:
   - backpressure
   - evolution
   - tooling
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - gopls-lsp
@@ -36,6 +39,25 @@ skill_include:
   - shadcn-forms
   - obsidian-markdown
   - norman
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - golang-patterns
 ---

--- a/outfits/implementer/outfit.md
+++ b/outfits/implementer/outfit.md
@@ -12,6 +12,9 @@ categories:
   - workflow
   - evolution
   - backpressure
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -26,6 +29,25 @@ skill_include:
   - finishing-a-bones-leaf
   - subagent-driven-development
   - verification-before-completion
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/outfits/kb/outfit.md
+++ b/outfits/kb/outfit.md
@@ -13,6 +13,9 @@ categories:
   - workflow
   - memory-management
   - context-management
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -45,6 +48,25 @@ skill_include:
   - vault-autoresearch
   - defuddle
   - knowledge-base-overview
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - golang-patterns
   - datastar

--- a/outfits/meta/outfit.md
+++ b/outfits/meta/outfit.md
@@ -13,6 +13,9 @@ categories:
   - workflow
   - evolution
   - tooling
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -36,6 +39,25 @@ skill_include:
   - suit-build
   - verification-before-completion
   - executing-plans
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/outfits/orchestrator/outfit.md
+++ b/outfits/orchestrator/outfit.md
@@ -11,6 +11,9 @@ targets:
 categories:
   - workflow
   - evolution
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -21,6 +24,18 @@ disable:
 skill_include:
   - dispatching-parallel-agents
   - subagent-driven-development
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
 skill_exclude:
   - test-driven-development
   - executing-plans

--- a/outfits/personal/outfit.md
+++ b/outfits/personal/outfit.md
@@ -12,6 +12,9 @@ categories:
   - economy
   - workflow
   - memory-management
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - code-review
@@ -39,6 +42,25 @@ skill_include:
   - obsidian-markdown
   - career-interview
   - memorize
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - golang-patterns
   - datastar

--- a/outfits/planner/outfit.md
+++ b/outfits/planner/outfit.md
@@ -11,6 +11,9 @@ targets:
 categories:
   - workflow
   - evolution
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -24,6 +27,25 @@ skill_include:
   - dispatching-parallel-agents
   - subagent-driven-development
   - verification-before-completion
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude:
   - executing-plans
 ---

--- a/outfits/quick/outfit.md
+++ b/outfits/quick/outfit.md
@@ -12,6 +12,9 @@ categories:
   - workflow
   - evolution
   - backpressure
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -19,7 +22,26 @@ disable:
     - swift-lsp
   mcps: []
   hooks: []
-skill_include: []
+skill_include:
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 compose:
   - implementer + planner + reviewer

--- a/outfits/reviewer/outfit.md
+++ b/outfits/reviewer/outfit.md
@@ -12,6 +12,9 @@ categories:
   - workflow
   - backpressure
   - evolution
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -26,6 +29,25 @@ skill_include:
   - ousterhout
   - norman
   - verification-before-completion
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/outfits/spy/outfit.md
+++ b/outfits/spy/outfit.md
@@ -12,6 +12,9 @@ categories:
   - evolution
   - backpressure
   - integrations
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -22,6 +25,25 @@ disable:
 skill_include:
   - spy-on-session
   - investigating-agent-sessions
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/outfits/stasi/outfit.md
+++ b/outfits/stasi/outfit.md
@@ -13,6 +13,9 @@ categories:
   - workflow
   - evolution
   - context-management
+enable:
+  mcps:
+    - context-mode
 disable:
   plugins:
     - frontend-design
@@ -44,6 +47,25 @@ skill_include:
   - stuck-detector
   - course-correct
   - monitoring-the-operator
+  - rtk-triage
+  - rtk-tdd
+  - rtk-tdd-rust
+  - rtk-issue-triage
+  - rtk-pr-triage
+  - rtk-pr-review
+  - rtk-security-guardian
+  - rtk-code-simplifier
+  - rtk-design-patterns
+  - rtk-performance
+  - rtk-ship
+  - rtk-repo-recap
+  - caveman
+  - caveman-commit
+  - caveman-compress
+  - caveman-help
+  - caveman-review
+  - caveman-stats
+  - cavecrew
 skill_exclude: []
 ---
 

--- a/skills/THIRD_PARTY_LICENSES.md
+++ b/skills/THIRD_PARTY_LICENSES.md
@@ -153,3 +153,56 @@ Adaptations applied:
 ```
 
 Full Apache-2.0 license text is preserved at the upstream source: https://github.com/rtk-ai/rtk/blob/main/LICENSE
+
+---
+
+## JuliusBrussee/caveman
+
+- **Source:** https://github.com/JuliusBrussee/caveman
+- **License:** MIT
+- **Copyright:** Copyright (c) 2026 Julius Brussee
+- **Upstream commit:** `63a91ec`
+- **Vendored skills (under `skills/`):**
+  - `caveman/SKILL.md` — from `skills/caveman/SKILL.md`
+  - `caveman-commit/SKILL.md` — from `skills/caveman-commit/SKILL.md`
+  - `caveman-review/SKILL.md` — from `skills/caveman-review/SKILL.md`
+  - `caveman-help/SKILL.md` — from `skills/caveman-help/SKILL.md`
+  - `caveman-stats/SKILL.md` — from `skills/caveman-stats/SKILL.md`
+  - `cavecrew/SKILL.md` — from `skills/cavecrew/SKILL.md`
+  - `caveman-compress/SKILL.md` plus `caveman-compress/SECURITY.md` and `caveman-compress/scripts/*.py` (`__init__.py`, `__main__.py`, `benchmark.py`, `cli.py`, `compress.py`, `detect.py`, `validate.py`) — from `skills/caveman-compress/`
+
+Naming: upstream skill names were already prefixed `caveman-` (with one bare `caveman` and the orchestrator skill `cavecrew`), and none collide with the existing `pocock-caveman` (different upstream — Matt Pocock's pack). Skills are vendored with their upstream names unchanged.
+
+Adaptations applied:
+- **Frontmatter**: rewrote the upstream Anthropic-style frontmatter (`name`, `description`) into the wardrobe schema (`name`, `version`, `targets`, `type`, `category`, `license`). Descriptions were rewritten into directive "Use when..." triggering form. All `category.primary` values are `economy` — these skills exist to cut token usage.
+- **Body content**: largely as-published upstream. Light edits: removed emoji severity prefixes in `caveman-review` (replaced with bare `bug:` / `risk:` / `nit:` / `q:` so the skill works in emoji-free contexts) and used plain "Bad:" / "Good:" labels instead of red-X / green-check emoji on the examples; otherwise the caveman voice and rules are preserved intact.
+- **AI-attribution policy**: the upstream `caveman-commit` skill already forbids "Generated with Claude Code" trailers in commit messages — that rule was preserved and generalised to "Any AI-attribution trailer". No upstream files contained Claude/Anthropic co-author trailers that needed stripping.
+- **Subagent companions**: the `cavecrew` skill orchestrates three subagents (`cavecrew-investigator`, `cavecrew-builder`, `cavecrew-reviewer`) that live as agent components in the upstream `agents/` directory. Those agents were NOT vendored here — only the orchestrator skill. The skill body references the upstream source for callers who want the agent specs.
+- **Supporting files**: the `caveman-compress` scripts are vendored verbatim. They call the Anthropic Python SDK (or fall back to the `claude` CLI) to do the actual compression — these are operational dependencies, not AI attribution, and remain as-is.
+- **No-git scrub**: not applied to this pack. Caveman skills target Conventional Commits and PR review workflows, so git-specific language is part of the substance.
+
+### MIT License Text
+
+```
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/cavecrew/SKILL.md
+++ b/skills/cavecrew/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: cavecrew
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user says "delegate to subagent", "use cavecrew", "spawn
+  investigator/builder/reviewer", "save context", or "compressed agent
+  output". Decision guide for delegating to caveman-style subagents
+  (`cavecrew-investigator`, `cavecrew-builder`, `cavecrew-reviewer`)
+  whose tool-results return ~60% smaller than vanilla equivalents, so
+  the main context lasts longer across long sessions.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/cavecrew/SKILL.md
+---
+
+# Cavecrew
+
+Cavecrew = three subagent presets that emit caveman output. Same job as Anthropic defaults (`Explore`, edit-style agents, reviewer); difference is the tool-result they return is compressed, so main context shrinks per delegation.
+
+## When to use cavecrew vs alternatives
+
+| Task | Use |
+|---|---|
+| "Where is X defined / what calls Y / list uses of Z" | `cavecrew-investigator` |
+| Same but you also want suggestions/architecture commentary | `Explore` (vanilla) |
+| Surgical edit, ≤2 files, scope obvious | `cavecrew-builder` |
+| New feature / 3+ files / cross-cutting refactor | Main thread or `feature-dev:code-architect` |
+| Review diff, branch, or file for bugs | `cavecrew-reviewer` |
+| Deep code review with rationale + alternatives | `Code Reviewer` (vanilla) |
+| One-line answer you already know | Main thread, no subagent |
+
+Rule of thumb: **if you'd want the subagent's output in 1/3 the tokens, pick cavecrew. If you'd want prose, pick vanilla.**
+
+## Why this exists (the real win)
+
+Subagent tool results get injected into main context verbatim. A vanilla `Explore` that returns 2k tokens of prose costs 2k tokens of main-context budget every time. The same finding from `cavecrew-investigator` returns ~700 tokens. Across 20 delegations in one session that's the difference between context exhaustion and finishing the task.
+
+## Output contracts
+
+What the main thread can rely on per agent:
+
+**`cavecrew-investigator`**
+```
+<Header>:
+- path:line — `symbol` — short note
+totals: <counts>.
+```
+Or `No match.` Always file-path-first, line-number-attached, backticked symbols. Safe to grep with `path:\d+`.
+
+**`cavecrew-builder`**
+```
+<path:line-range> — <change ≤10 words>.
+verified: <re-read OK | mismatch @ path:line>.
+```
+Or one of: `too-big.` / `needs-confirm.` / `ambiguous.` / `regressed.` (terminal first token).
+
+**`cavecrew-reviewer`**
+```
+path:line: <emoji> <severity>: <problem>. <fix>.
+totals: N🔴 N🟡 N🔵 N❓
+```
+Or `No issues.` Findings sorted file → line ascending.
+
+## Chaining patterns
+
+**Locate → fix → verify** (most common):
+1. `cavecrew-investigator` returns site list.
+2. Main thread picks 1-2 sites, hands paths to `cavecrew-builder`.
+3. `cavecrew-reviewer` audits the diff.
+
+**Parallel scout** (when investigation is broad):
+Spawn 2-3 `cavecrew-investigator` calls in one message (different angles: defs vs callers vs tests). Aggregate in main thread.
+
+**Single-shot edit** (when site is already known):
+Skip investigator. Hand exact path:line to `cavecrew-builder` directly.
+
+## What NOT to do
+
+- Don't use `cavecrew-builder` when the file isn't already known. Spawn investigator first or the main thread will eat tokens passing context.
+- Don't chain `cavecrew-investigator → cavecrew-builder` for a 5-file refactor. Builder will return `too-big.` and a turn is wasted.
+- Don't ask `cavecrew-reviewer` for "general feedback" — it returns findings only, no architecture opinions. Use `Code Reviewer` for that.
+- Don't expect prose. Cavecrew output is structured, sometimes terse to the point of cryptic. If a human will read it directly, paraphrase.
+
+## Auto-clarity (inherited)
+
+Subagents drop caveman → normal English for security warnings, irreversible-action confirmations, and any output where fragment ambiguity could be misread. Resume caveman after.
+
+## Subagent companions
+
+The three subagents this skill orchestrates are bundled separately in the wardrobe (agent components, not part of this skill directory). See the upstream repo for the original agent specs:
+https://github.com/JuliusBrussee/caveman/tree/main/agents

--- a/skills/caveman-commit/SKILL.md
+++ b/skills/caveman-commit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: caveman-commit
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user says "write a commit", "commit message", "generate commit",
+  "/commit", or invokes /caveman-commit, or when staging changes. Generates
+  ultra-compressed Conventional Commits messages — subject ≤50 chars, body
+  only when "why" isn't obvious. Cuts noise while preserving intent.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman-commit/SKILL.md
+---
+
+# Caveman Commit
+
+Write commit messages terse and exact. Conventional Commits format. No fluff. Why over what.
+
+## Rules
+
+**Subject line:**
+- `<type>(<scope>): <imperative summary>` — `<scope>` optional
+- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
+- Imperative mood: "add", "fix", "remove" — not "added", "adds", "adding"
+- ≤50 chars when possible, hard cap 72
+- No trailing period
+- Match project convention for capitalization after the colon
+
+**Body (only if needed):**
+- Skip entirely when subject is self-explanatory
+- Add body only for: non-obvious *why*, breaking changes, migration notes, linked issues
+- Wrap at 72 chars
+- Bullets `-` not `*`
+- Reference issues/PRs at end: `Closes #42`, `Refs #17`
+
+**What NEVER goes in:**
+- "This commit does X", "I", "we", "now", "currently" — the diff says what
+- "As requested by..." — use Co-authored-by trailer
+- Any AI-attribution trailer ("Generated with ...", "Co-Authored-By: <AI>")
+- Emoji (unless project convention requires)
+- Restating the file name when scope already says it
+
+## Examples
+
+Diff: new endpoint for user profile with body explaining the why
+- Bad: "feat: add a new endpoint to get user profile information from the database"
+- Good:
+  ```
+  feat(api): add GET /users/:id/profile
+
+  Mobile client needs profile data without the full user payload
+  to reduce LTE bandwidth on cold-launch screens.
+
+  Closes #128
+  ```
+
+Diff: breaking API change
+- Good:
+  ```
+  feat(api)!: rename /v1/orders to /v1/checkout
+
+  BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+  before 2026-06-01. Old route returns 410 after that date.
+  ```
+
+## Auto-Clarity
+
+Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
+
+## Boundaries
+
+Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.

--- a/skills/caveman-compress/SECURITY.md
+++ b/skills/caveman-compress/SECURITY.md
@@ -1,0 +1,31 @@
+# Security
+
+## Snyk High Risk Rating
+
+`caveman-compress` receives a Snyk High Risk rating due to static analysis heuristics. This document explains what the skill does and does not do.
+
+### What triggers the rating
+
+1. **subprocess usage**: The skill calls the `claude` CLI via `subprocess.run()` as a fallback when `ANTHROPIC_API_KEY` is not set. The subprocess call uses a fixed argument list — no shell interpolation occurs. User file content is passed via stdin, not as a shell argument.
+
+2. **File read/write**: The skill reads the file the user explicitly points it at, compresses it, and writes the result back to the same path. A `.original.md` backup is saved alongside it. No files outside the user-specified path are read or written.
+
+### What the skill does NOT do
+
+- Does not execute user file content as code
+- Does not make network requests except to Anthropic's API (via SDK or CLI)
+- Does not access files outside the path the user provides
+- Does not use shell=True or string interpolation in subprocess calls
+- Does not collect or transmit any data beyond the file being compressed
+
+### Auth behavior
+
+If `ANTHROPIC_API_KEY` is set, the skill uses the Anthropic Python SDK directly (no subprocess). If not set, it falls back to the `claude` CLI, which uses the user's existing Claude desktop authentication.
+
+### File size limit
+
+Files larger than 500KB are rejected before any API call is made.
+
+### Reporting a vulnerability
+
+If you believe you've found a genuine security issue, please open a GitHub issue with the label `security`.

--- a/skills/caveman-compress/SKILL.md
+++ b/skills/caveman-compress/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: caveman-compress
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user invokes /caveman-compress FILEPATH, says "compress memory
+  file", or otherwise asks to compress natural-language memory files
+  (CLAUDE.md, todos, preferences). Rewrites the file into caveman format to
+  save input tokens, preserving all technical substance, code, URLs, and
+  structure. The compressed version overwrites the original; a human-readable
+  backup is saved as FILE.original.md.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman-compress/SKILL.md
+---
+
+# Caveman Compress
+
+## Purpose
+
+Compress natural language files (CLAUDE.md, todos, preferences) into caveman-speak to reduce input tokens. The compressed version overwrites the original. A human-readable backup is saved as `<filename>.original.md`.
+
+## Trigger
+
+`/caveman-compress <filepath>` or when the user asks to compress a memory file.
+
+## Process
+
+1. The compression scripts live in `scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `scripts/__main__.py` next to this SKILL.md.
+
+2. From the directory containing this SKILL.md, run:
+
+```
+python3 -m scripts <absolute_filepath>
+```
+
+3. The CLI will:
+- detect file type (no tokens)
+- call Claude to compress
+- validate output (no tokens)
+- if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
+- retry up to 2 times
+- if still failing after 2 retries: report the error to the user, leave the original file untouched
+
+4. Return the result to the user.
+
+## Compression Rules
+
+### Remove
+- Articles: a, an, the
+- Filler: just, really, basically, actually, simply, essentially, generally
+- Pleasantries: "sure", "certainly", "of course", "happy to", "I'd recommend"
+- Hedging: "it might be worth", "you could consider", "it would be good to"
+- Redundant phrasing: "in order to" → "to", "make sure to" → "ensure", "the reason is because" → "because"
+- Connective fluff: "however", "furthermore", "additionally", "in addition"
+
+### Preserve EXACTLY (never modify)
+- Code blocks (fenced ``` and indented)
+- Inline code (`backtick content`)
+- URLs and links (full URLs, markdown links)
+- File paths (`/src/components/...`, `./config.yaml`)
+- Commands (`npm install`, `git commit`, `docker build`)
+- Technical terms (library names, API names, protocols, algorithms)
+- Proper nouns (project names, people, companies)
+- Dates, version numbers, numeric values
+- Environment variables (`$HOME`, `NODE_ENV`)
+
+### Preserve Structure
+- All markdown headings (keep exact heading text, compress body below)
+- Bullet point hierarchy (keep nesting level)
+- Numbered lists (keep numbering)
+- Tables (compress cell text, keep structure)
+- Frontmatter/YAML headers in markdown files
+
+### Compress
+- Use short synonyms: "big" not "extensive", "fix" not "implement a solution for", "use" not "utilize"
+- Fragments OK: "Run tests before commit" not "You should always run tests before committing"
+- Drop "you should", "make sure to", "remember to" — just state the action
+- Merge redundant bullets that say the same thing differently
+- Keep one example where multiple examples show the same pattern
+
+CRITICAL RULE:
+Anything inside ``` ... ``` must be copied EXACTLY.
+Do not:
+- remove comments
+- remove spacing
+- reorder lines
+- shorten commands
+- simplify anything
+
+Inline code (`...`) must be preserved EXACTLY.
+Do not modify anything inside backticks.
+
+If a file contains code blocks:
+- Treat code blocks as read-only regions
+- Only compress text outside them
+- Do not merge sections around code
+
+## Pattern
+
+Original:
+> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
+
+Compressed:
+> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
+
+Original:
+> The application uses a microservices architecture with the following components. The API gateway handles all incoming requests and routes them to the appropriate service. The authentication service is responsible for managing user sessions and JWT tokens.
+
+Compressed:
+> Microservices architecture. API gateway route all requests to services. Auth service manage user sessions + JWT tokens.
+
+## Boundaries
+
+- ONLY compress natural language files (.md, .txt, .typ, .typst, .tex, extensionless)
+- NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
+- If a file has mixed content (prose + code), compress ONLY the prose sections
+- If unsure whether something is code or prose, leave it unchanged
+- The original file is backed up as FILE.original.md before overwriting
+- Never compress FILE.original.md (skip it)

--- a/skills/caveman-compress/scripts/__init__.py
+++ b/skills/caveman-compress/scripts/__init__.py
@@ -1,0 +1,9 @@
+"""Caveman compress scripts.
+
+This package provides tools to compress natural language markdown files
+into caveman format to save input tokens.
+"""
+
+__all__ = ["cli", "compress", "detect", "validate"]
+
+__version__ = "1.0.0"

--- a/skills/caveman-compress/scripts/__main__.py
+++ b/skills/caveman-compress/scripts/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/skills/caveman-compress/scripts/benchmark.py
+++ b/skills/caveman-compress/scripts/benchmark.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+# Support both direct execution and module import
+try:
+    from .validate import validate
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from validate import validate
+
+try:
+    import tiktoken
+    _enc = tiktoken.get_encoding("o200k_base")
+except ImportError:
+    _enc = None
+
+
+def count_tokens(text):
+    if _enc is None:
+        return len(text.split())  # fallback: word count
+    return len(_enc.encode(text))
+
+
+def benchmark_pair(orig_path: Path, comp_path: Path):
+    orig_text = orig_path.read_text()
+    comp_text = comp_path.read_text()
+
+    orig_tokens = count_tokens(orig_text)
+    comp_tokens = count_tokens(comp_text)
+    saved = 100 * (orig_tokens - comp_tokens) / orig_tokens if orig_tokens > 0 else 0.0
+    result = validate(orig_path, comp_path)
+
+    return (comp_path.name, orig_tokens, comp_tokens, saved, result.is_valid)
+
+
+def print_table(rows):
+    print("\n| File | Original | Compressed | Saved % | Valid |")
+    print("|------|----------|------------|---------|-------|")
+    for r in rows:
+        print(f"| {r[0]} | {r[1]} | {r[2]} | {r[3]:.1f}% | {'✅' if r[4] else '❌'} |")
+
+
+def main():
+    # Direct file pair: python3 benchmark.py original.md compressed.md
+    if len(sys.argv) == 3:
+        orig = Path(sys.argv[1]).resolve()
+        comp = Path(sys.argv[2]).resolve()
+        if not orig.exists():
+            print(f"❌ Not found: {orig}")
+            sys.exit(1)
+        if not comp.exists():
+            print(f"❌ Not found: {comp}")
+            sys.exit(1)
+        print_table([benchmark_pair(orig, comp)])
+        return
+
+    # Glob mode: repo_root/tests/caveman-compress/
+    # __file__ lives at <repo_root>/skills/caveman-compress/scripts/benchmark.py
+    # Walk up four dirs: scripts → caveman-compress → skills → repo_root.
+    tests_dir = Path(__file__).resolve().parents[3] / "tests" / "caveman-compress"
+    if not tests_dir.exists():
+        print(f"❌ Tests dir not found: {tests_dir}")
+        sys.exit(1)
+
+    rows = []
+    for orig in sorted(tests_dir.glob("*.original.md")):
+        comp = orig.with_name(orig.stem.removesuffix(".original") + ".md")
+        if comp.exists():
+            rows.append(benchmark_pair(orig, comp))
+
+    if not rows:
+        print("No compressed file pairs found.")
+        return
+
+    print_table(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/caveman-compress/scripts/cli.py
+++ b/skills/caveman-compress/scripts/cli.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Caveman Compress CLI
+
+Usage:
+    caveman <filepath>
+"""
+
+import sys
+
+# Force UTF-8 on stdout/stderr before any code can print. Windows consoles
+# default to cp1252 and crash on the ❌ glyphs in error/validation branches,
+# masking the real error and leaving the user with a half-compressed file.
+for _stream in (sys.stdout, sys.stderr):
+    reconfigure = getattr(_stream, "reconfigure", None)
+    if callable(reconfigure):
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+from pathlib import Path
+
+from .compress import compress_file
+from .detect import detect_file_type, should_compress
+
+
+def print_usage():
+    print("Usage: caveman <filepath>")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print_usage()
+        sys.exit(1)
+
+    filepath = Path(sys.argv[1])
+
+    # Check file exists
+    if not filepath.exists():
+        print(f"❌ File not found: {filepath}")
+        sys.exit(1)
+
+    if not filepath.is_file():
+        print(f"❌ Not a file: {filepath}")
+        sys.exit(1)
+
+    filepath = filepath.resolve()
+
+    # Detect file type
+    file_type = detect_file_type(filepath)
+
+    print(f"Detected: {file_type}")
+
+    # Check if compressible
+    if not should_compress(filepath):
+        print("Skipping: file is not natural language (code/config)")
+        sys.exit(0)
+
+    print("Starting caveman compression...\n")
+
+    try:
+        success = compress_file(filepath)
+
+        if success:
+            print("\nCompression completed successfully")
+            backup_path = filepath.with_name(filepath.stem + ".original.md")
+            print(f"Compressed: {filepath}")
+            print(f"Original:   {backup_path}")
+            sys.exit(0)
+        else:
+            print("\n❌ Compression failed after retries")
+            sys.exit(2)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        sys.exit(130)
+
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/caveman-compress/scripts/compress.py
+++ b/skills/caveman-compress/scripts/compress.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Caveman Memory Compression Orchestrator
+
+Usage:
+    python scripts/compress.py <filepath>
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import List
+
+OUTER_FENCE_REGEX = re.compile(
+    r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL
+)
+
+# Filenames and paths that almost certainly hold secrets or PII. Compressing
+# them ships raw bytes to the Anthropic API — a third-party data boundary that
+# developers on sensitive codebases cannot cross. detect.py already skips .env
+# by extension, but credentials.md / secrets.txt / ~/.aws/credentials would
+# slip through the natural-language filter. This is a hard refuse before read.
+SENSITIVE_BASENAME_REGEX = re.compile(
+    r"(?ix)^("
+    r"\.env(\..+)?"
+    r"|\.netrc"
+    r"|credentials(\..+)?"
+    r"|secrets?(\..+)?"
+    r"|passwords?(\..+)?"
+    r"|id_(rsa|dsa|ecdsa|ed25519)(\.pub)?"
+    r"|authorized_keys"
+    r"|known_hosts"
+    r"|.*\.(pem|key|p12|pfx|crt|cer|jks|keystore|asc|gpg)"
+    r")$"
+)
+
+SENSITIVE_PATH_COMPONENTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+
+SENSITIVE_NAME_TOKENS = (
+    "secret", "credential", "password", "passwd",
+    "apikey", "accesskey", "token", "privatekey",
+)
+
+
+def is_sensitive_path(filepath: Path) -> bool:
+    """Heuristic denylist for files that must never be shipped to a third-party API."""
+    name = filepath.name
+    if SENSITIVE_BASENAME_REGEX.match(name):
+        return True
+    lowered_parts = {p.lower() for p in filepath.parts}
+    if lowered_parts & SENSITIVE_PATH_COMPONENTS:
+        return True
+    # Normalize separators so "api-key" and "api_key" both match "apikey".
+    lower = re.sub(r"[_\-\s.]", "", name.lower())
+    return any(tok in lower for tok in SENSITIVE_NAME_TOKENS)
+
+
+def strip_llm_wrapper(text: str) -> str:
+    """Strip outer ```markdown ... ``` fence when it wraps the entire output."""
+    m = OUTER_FENCE_REGEX.match(text)
+    if m:
+        return m.group(2)
+    return text
+
+from .detect import should_compress
+from .validate import validate
+
+MAX_RETRIES = 2
+
+
+# ---------- Claude Calls ----------
+
+
+def call_claude(prompt: str) -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        try:
+            import anthropic
+
+            client = anthropic.Anthropic(api_key=api_key)
+            msg = client.messages.create(
+                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
+                max_tokens=8192,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return strip_llm_wrapper(msg.content[0].text.strip())
+        except ImportError:
+            pass  # anthropic not installed, fall back to CLI
+    # Fallback: use claude CLI (handles desktop auth)
+    try:
+        result = subprocess.run(
+            ["claude", "--print"],
+            input=prompt,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return strip_llm_wrapper(result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Claude call failed:\n{e.stderr}")
+
+
+def build_compress_prompt(original: str) -> str:
+    return f"""
+Compress this markdown into caveman format.
+
+STRICT RULES:
+- Do NOT modify anything inside ``` code blocks
+- Do NOT modify anything inside inline backticks
+- Preserve ALL URLs exactly
+- Preserve ALL headings exactly
+- Preserve file paths and commands
+- Return ONLY the compressed markdown body — do NOT wrap the entire output in a ```markdown fence or any other fence. Inner code blocks from the original stay as-is; do not add a new outer fence around the whole file.
+
+Only compress natural language.
+
+TEXT:
+{original}
+"""
+
+
+def build_fix_prompt(original: str, compressed: str, errors: List[str]) -> str:
+    errors_str = "\n".join(f"- {e}" for e in errors)
+    return f"""You are fixing a caveman-compressed markdown file. Specific validation errors were found.
+
+CRITICAL RULES:
+- DO NOT recompress or rephrase the file
+- ONLY fix the listed errors — leave everything else exactly as-is
+- The ORIGINAL is provided as reference only (to restore missing content)
+- Preserve caveman style in all untouched sections
+
+ERRORS TO FIX:
+{errors_str}
+
+HOW TO FIX:
+- Missing URL: find it in ORIGINAL, restore it exactly where it belongs in COMPRESSED
+- Code block mismatch: find the exact code block in ORIGINAL, restore it in COMPRESSED
+- Heading mismatch: restore the exact heading text from ORIGINAL into COMPRESSED
+- Do not touch any section not mentioned in the errors
+
+ORIGINAL (reference only):
+{original}
+
+COMPRESSED (fix this):
+{compressed}
+
+Return ONLY the fixed compressed file. No explanation.
+"""
+
+
+# ---------- Core Logic ----------
+
+
+def compress_file(filepath: Path) -> bool:
+    # Resolve and validate path
+    filepath = filepath.resolve()
+    MAX_FILE_SIZE = 500_000  # 500KB
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+    if filepath.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError(f"File too large to compress safely (max 500KB): {filepath}")
+
+    # Refuse files that look like they contain secrets or PII. Compressing ships
+    # the raw bytes to the Anthropic API — a third-party boundary — so we fail
+    # loudly rather than silently exfiltrate credentials or keys. Override is
+    # intentional: the user must rename the file if the heuristic is wrong.
+    if is_sensitive_path(filepath):
+        raise ValueError(
+            f"Refusing to compress {filepath}: filename looks sensitive "
+            "(credentials, keys, secrets, or known private paths). "
+            "Compression sends file contents to the Anthropic API. "
+            "Rename the file if this is a false positive."
+        )
+
+    print(f"Processing: {filepath}")
+
+    if not should_compress(filepath):
+        print("Skipping (not natural language)")
+        return False
+
+    original_text = filepath.read_text(errors="ignore")
+    backup_path = filepath.with_name(filepath.stem + ".original.md")
+
+    if not original_text.strip():
+        print("❌ Refusing to compress: file is empty or whitespace-only.")
+        return False
+
+    # Check if backup already exists to prevent accidental overwriting
+    if backup_path.exists():
+        print(f"⚠️ Backup file already exists: {backup_path}")
+        print("The original backup may contain important content.")
+        print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
+        return False
+
+    # Step 1: Compress
+    print("Compressing with Claude...")
+    compressed = call_claude(build_compress_prompt(original_text))
+
+    if compressed is None or not compressed.strip():
+        print("❌ Compression aborted: Claude returned an empty response.")
+        print("   Original file is untouched (no backup created).")
+        return False
+
+    if compressed.strip() == original_text.strip():
+        print("❌ Compression aborted: output is identical to input.")
+        print("   Likely causes: Claude refused, returned the prompt verbatim, or the file is")
+        print("   already in caveman form. Original file is untouched (no backup created).")
+        return False
+
+    # Save original as backup, then verify the backup readback before
+    # touching the input file. If the filesystem dropped bytes (encoding,
+    # antivirus, disk full), unlink the bad backup and abort instead of
+    # leaving the user with a corrupt backup + compressed primary.
+    backup_path.write_text(original_text)
+    backup_readback = backup_path.read_text(errors="ignore")
+    if backup_readback != original_text:
+        print(f"❌ Backup write verification failed: {backup_path}")
+        print("   In-memory original differs from on-disk backup. Aborting before touching the input file.")
+        try:
+            backup_path.unlink()
+        except OSError:
+            pass
+        return False
+    filepath.write_text(compressed)
+
+    # Step 2: Validate + Retry
+    for attempt in range(MAX_RETRIES):
+        print(f"\nValidation attempt {attempt + 1}")
+
+        result = validate(backup_path, filepath)
+
+        if result.is_valid:
+            print("Validation passed")
+            break
+
+        print("❌ Validation failed:")
+        for err in result.errors:
+            print(f"   - {err}")
+
+        if attempt == MAX_RETRIES - 1:
+            # Restore original on failure
+            filepath.write_text(original_text)
+            backup_path.unlink(missing_ok=True)
+            print("❌ Failed after retries — original restored")
+            return False
+
+        print("Fixing with Claude...")
+        compressed = call_claude(
+            build_fix_prompt(original_text, compressed, result.errors)
+        )
+        filepath.write_text(compressed)
+
+    return True

--- a/skills/caveman-compress/scripts/detect.py
+++ b/skills/caveman-compress/scripts/detect.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Detect whether a file is natural language (compressible) or code/config (skip)."""
+
+import json
+import re
+from pathlib import Path
+
+# Extensions that are natural language and compressible
+COMPRESSIBLE_EXTENSIONS = {".md", ".txt", ".markdown", ".rst", ".typ", ".typst", ".tex"}
+
+# Extensions that are code/config and should be skipped
+SKIP_EXTENSIONS = {
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".json", ".yaml", ".yml",
+    ".toml", ".env", ".lock", ".css", ".scss", ".html", ".xml",
+    ".sql", ".sh", ".bash", ".zsh", ".go", ".rs", ".java", ".c",
+    ".cpp", ".h", ".hpp", ".rb", ".php", ".swift", ".kt", ".lua",
+    ".dockerfile", ".makefile", ".csv", ".ini", ".cfg",
+}
+
+# Patterns that indicate a line is code
+CODE_PATTERNS = [
+    re.compile(r"^\s*(import |from .+ import |require\(|const |let |var )"),
+    re.compile(r"^\s*(def |class |function |async function |export )"),
+    re.compile(r"^\s*(if\s*\(|for\s*\(|while\s*\(|switch\s*\(|try\s*\{)"),
+    re.compile(r"^\s*[\}\]\);]+\s*$"),  # closing braces/brackets
+    re.compile(r"^\s*@\w+"),  # decorators/annotations
+    re.compile(r'^\s*"[^"]+"\s*:\s*'),  # JSON-like key-value
+    re.compile(r"^\s*\w+\s*=\s*[{\[\(\"']"),  # assignment with literal
+]
+
+
+def _is_code_line(line: str) -> bool:
+    """Check if a line looks like code."""
+    return any(p.match(line) for p in CODE_PATTERNS)
+
+
+def _is_json_content(text: str) -> bool:
+    """Check if content is valid JSON."""
+    try:
+        json.loads(text)
+        return True
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+
+def _is_yaml_content(lines: list[str]) -> bool:
+    """Heuristic: check if content looks like YAML."""
+    yaml_indicators = 0
+    for line in lines[:30]:
+        stripped = line.strip()
+        if stripped.startswith("---"):
+            yaml_indicators += 1
+        elif re.match(r"^\w[\w\s]*:\s", stripped):
+            yaml_indicators += 1
+        elif stripped.startswith("- ") and ":" in stripped:
+            yaml_indicators += 1
+    # If most non-empty lines look like YAML
+    non_empty = sum(1 for l in lines[:30] if l.strip())
+    return non_empty > 0 and yaml_indicators / non_empty > 0.6
+
+
+def detect_file_type(filepath: Path) -> str:
+    """Classify a file as 'natural_language', 'code', 'config', or 'unknown'.
+
+    Returns:
+        One of: 'natural_language', 'code', 'config', 'unknown'
+    """
+    ext = filepath.suffix.lower()
+
+    # Extension-based classification
+    if ext in COMPRESSIBLE_EXTENSIONS:
+        return "natural_language"
+    if ext in SKIP_EXTENSIONS:
+        return "code" if ext not in {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".env"} else "config"
+
+    # Extensionless files (like CLAUDE.md, TODO) — check content
+    if not ext:
+        try:
+            text = filepath.read_text(errors="ignore")
+        except (OSError, PermissionError):
+            return "unknown"
+
+        lines = text.splitlines()[:50]
+
+        if _is_json_content(text[:10000]):
+            return "config"
+        if _is_yaml_content(lines):
+            return "config"
+
+        code_lines = sum(1 for l in lines if l.strip() and _is_code_line(l))
+        non_empty = sum(1 for l in lines if l.strip())
+        if non_empty > 0 and code_lines / non_empty > 0.4:
+            return "code"
+
+        return "natural_language"
+
+    return "unknown"
+
+
+def should_compress(filepath: Path) -> bool:
+    """Return True if the file is natural language and should be compressed."""
+    if not filepath.is_file():
+        return False
+    # Skip backup files
+    if filepath.name.endswith(".original.md"):
+        return False
+    return detect_file_type(filepath) == "natural_language"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python detect.py <file1> [file2] ...")
+        sys.exit(1)
+
+    for path_str in sys.argv[1:]:
+        p = Path(path_str).resolve()
+        file_type = detect_file_type(p)
+        compress = should_compress(p)
+        print(f"  {p.name:30s} type={file_type:20s} compress={compress}")

--- a/skills/caveman-compress/scripts/validate.py
+++ b/skills/caveman-compress/scripts/validate.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+import re
+from collections import Counter
+from pathlib import Path
+
+URL_REGEX = re.compile(r"https?://[^\s)]+")
+FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
+HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
+BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
+
+# crude but effective path detection
+# Requires either a path prefix (./ ../ / or drive letter) or a slash/backslash within the match
+PATH_REGEX = re.compile(r"(?:\./|\.\./|/|[A-Za-z]:\\)[\w\-/\\\.]+|[\w\-\.]+[/\\][\w\-/\\\.]+")
+
+
+class ValidationResult:
+    def __init__(self):
+        self.is_valid = True
+        self.errors = []
+        self.warnings = []
+
+    def add_error(self, msg):
+        self.is_valid = False
+        self.errors.append(msg)
+
+    def add_warning(self, msg):
+        self.warnings.append(msg)
+
+
+def read_file(path: Path) -> str:
+    return path.read_text(errors="ignore")
+
+
+# ---------- Extractors ----------
+
+
+def extract_headings(text):
+    return [(level, title.strip()) for level, title in HEADING_REGEX.findall(text)]
+
+
+def extract_code_blocks(text):
+    """Line-based fenced code block extractor.
+
+    Handles ``` and ~~~ fences with variable length (CommonMark: closing
+    fence must use same char and be at least as long as opening). Supports
+    nested fences (e.g. an outer 4-backtick block wrapping inner 3-backtick
+    content).
+    """
+    blocks = []
+    lines = text.split("\n")
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = FENCE_OPEN_REGEX.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        fence_char = m.group(2)[0]
+        fence_len = len(m.group(2))
+        open_line = lines[i]
+        block_lines = [open_line]
+        i += 1
+        closed = False
+        while i < n:
+            close_m = FENCE_OPEN_REGEX.match(lines[i])
+            if (
+                close_m
+                and close_m.group(2)[0] == fence_char
+                and len(close_m.group(2)) >= fence_len
+                and close_m.group(3).strip() == ""
+            ):
+                block_lines.append(lines[i])
+                closed = True
+                i += 1
+                break
+            block_lines.append(lines[i])
+            i += 1
+        if closed:
+            blocks.append("\n".join(block_lines))
+        # Unclosed fences are silently skipped — they indicate malformed markdown
+        # and including them would cause false-positive validation failures.
+    return blocks
+
+
+def extract_urls(text):
+    return set(URL_REGEX.findall(text))
+
+
+def extract_paths(text):
+    return set(PATH_REGEX.findall(text))
+
+
+def count_bullets(text):
+    return len(BULLET_REGEX.findall(text))
+
+
+def extract_inline_codes(text):
+    text_without_fences = re.sub(r"^```[\s\S]*?^```", "", text, flags=re.MULTILINE)
+    text_without_fences = re.sub(r"^~~~[\s\S]*?^~~~", "", text_without_fences, flags=re.MULTILINE)
+    return re.findall(r"`([^`]+)`", text_without_fences)
+
+
+# ---------- Validators ----------
+
+
+def validate_headings(orig, comp, result):
+    h1 = extract_headings(orig)
+    h2 = extract_headings(comp)
+
+    if len(h1) != len(h2):
+        result.add_error(f"Heading count mismatch: {len(h1)} vs {len(h2)}")
+
+    if h1 != h2:
+        result.add_warning("Heading text/order changed")
+
+
+def validate_code_blocks(orig, comp, result):
+    c1 = extract_code_blocks(orig)
+    c2 = extract_code_blocks(comp)
+
+    if c1 != c2:
+        result.add_error("Code blocks not preserved exactly")
+
+
+def validate_urls(orig, comp, result):
+    u1 = extract_urls(orig)
+    u2 = extract_urls(comp)
+
+    if u1 != u2:
+        result.add_error(f"URL mismatch: lost={u1 - u2}, added={u2 - u1}")
+
+
+def validate_paths(orig, comp, result):
+    p1 = extract_paths(orig)
+    p2 = extract_paths(comp)
+
+    if p1 != p2:
+        result.add_warning(f"Path mismatch: lost={p1 - p2}, added={p2 - p1}")
+
+
+def validate_bullets(orig, comp, result):
+    b1 = count_bullets(orig)
+    b2 = count_bullets(comp)
+
+    if b1 == 0:
+        return
+
+    diff = abs(b1 - b2) / b1
+
+    if diff > 0.15:
+        result.add_warning(f"Bullet count changed too much: {b1} -> {b2}")
+
+
+def validate_inline_codes(orig, comp, result):
+    c1 = Counter(extract_inline_codes(orig))
+    c2 = Counter(extract_inline_codes(comp))
+
+    if c1 != c2:
+        lost = set(c1.keys()) - set(c2.keys())
+        added = set(c2.keys()) - set(c1.keys())
+        for code, count in c1.items():
+            if code in c2 and c2[code] < count:
+                lost.add(f"{code} (lost {count - c2[code]} of {count} occurrences)")
+        if lost:
+            result.add_error(f"Inline code lost: {lost}")
+        if added:
+            result.add_warning(f"Inline code added: {added}")
+
+
+# ---------- Main ----------
+
+
+def validate(original_path: Path, compressed_path: Path) -> ValidationResult:
+    result = ValidationResult()
+
+    orig = read_file(original_path)
+    comp = read_file(compressed_path)
+
+    validate_headings(orig, comp, result)
+    validate_code_blocks(orig, comp, result)
+    validate_urls(orig, comp, result)
+    validate_paths(orig, comp, result)
+    validate_bullets(orig, comp, result)
+    validate_inline_codes(orig, comp, result)
+
+    return result
+
+
+# ---------- CLI ----------
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Usage: python validate.py <original> <compressed>")
+        sys.exit(1)
+
+    orig = Path(sys.argv[1]).resolve()
+    comp = Path(sys.argv[2]).resolve()
+
+    res = validate(orig, comp)
+
+    print(f"\nValid: {res.is_valid}")
+
+    if res.errors:
+        print("\nErrors:")
+        for e in res.errors:
+            print(f"  - {e}")
+
+    if res.warnings:
+        print("\nWarnings:")
+        for w in res.warnings:
+            print(f"  - {w}")

--- a/skills/caveman-help/SKILL.md
+++ b/skills/caveman-help/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: caveman-help
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user invokes /caveman-help, says "caveman help", asks
+  "what caveman commands", or asks "how do I use caveman". Displays a
+  one-shot quick-reference card for all caveman modes, skills, and
+  commands. Does not change mode or persist anything.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman-help/SKILL.md
+---
+
+# Caveman Help
+
+Display this reference card when invoked. One-shot — do NOT change mode, write flag files, or persist anything. Output in caveman style.
+
+## Modes
+
+| Mode | Trigger | What change |
+|------|---------|-------------|
+| **Lite** | `/caveman lite` | Drop filler. Keep sentence structure. |
+| **Full** | `/caveman` | Drop articles, filler, pleasantries, hedging. Fragments OK. Default. |
+| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. Tables over prose. |
+| **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
+| **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
+| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |
+
+Mode stick until changed or session end.
+
+## Skills
+
+| Skill | Trigger | What it do |
+|-------|---------|-----------|
+| **caveman-commit** | `/caveman-commit` | Terse commit messages. Conventional Commits. ≤50 char subject. |
+| **caveman-review** | `/caveman-review` | One-line PR comments: `L42: bug: user null. Add guard.` |
+| **caveman-compress** | `/caveman-compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
+| **caveman-help** | `/caveman-help` | This card. |
+
+## Deactivate
+
+Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.
+
+## Configure Default Mode
+
+Default mode = `full`. Change it:
+
+**Environment variable** (highest priority):
+```bash
+export CAVEMAN_DEFAULT_MODE=ultra
+```
+
+**Config file** (`~/.config/caveman/config.json`):
+```json
+{ "defaultMode": "lite" }
+```
+
+Set `"off"` to disable auto-activation on session start. The user can still activate manually with `/caveman`.
+
+Resolution: env var > config file > `full`.
+
+## More
+
+Full docs: https://github.com/JuliusBrussee/caveman

--- a/skills/caveman-review/SKILL.md
+++ b/skills/caveman-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: caveman-review
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user says "review this PR", "code review", "review the diff",
+  "/review", or invokes /caveman-review, or when reviewing pull requests.
+  Generates ultra-compressed code review comments — one line per finding:
+  location, problem, fix. Cuts noise while preserving actionable signal.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman-review/SKILL.md
+---
+
+# Caveman Review
+
+Write code review comments terse and actionable. One line per finding. Location, problem, fix. No throat-clearing.
+
+## Rules
+
+**Format:** `L<line>: <problem>. <fix>.` — or `<file>:L<line>: ...` when reviewing multi-file diffs.
+
+**Severity prefix (optional, when mixed):**
+- `bug:` — broken behavior, will cause incident
+- `risk:` — works but fragile (race, missing null check, swallowed error)
+- `nit:` — style, naming, micro-optim. Author can ignore
+- `q:` — genuine question, not a suggestion
+
+**Drop:**
+- "I noticed that...", "It seems like...", "You might want to consider..."
+- "This is just a suggestion but..." — use `nit:` instead
+- "Great work!", "Looks good overall but..." — say it once at the top, not per comment
+- Restating what the line does — the reviewer can read the diff
+- Hedging ("perhaps", "maybe", "I think") — if unsure use `q:`
+
+**Keep:**
+- Exact line numbers
+- Exact symbol/function/variable names in backticks
+- Concrete fix, not "consider refactoring this"
+- The *why* if the fix isn't obvious from the problem statement
+
+## Examples
+
+Bad: "I noticed that on line 42 you're not checking if the user object is null before accessing the email property. This could potentially cause a crash if the user is not found in the database. You might want to add a null check here."
+
+Good: `L42: bug: user can be null after .find(). Add guard before .email.`
+
+Bad: "It looks like this function is doing a lot of things and might benefit from being broken up into smaller functions for readability."
+
+Good: `L88-140: nit: 50-line fn does 4 things. Extract validate/normalize/persist.`
+
+Bad: "Have you considered what happens if the API returns a 429? I think we should probably handle that case."
+
+Good: `L23: risk: no retry on 429. Wrap in withBackoff(3).`
+
+## Auto-Clarity
+
+Drop terse mode for: security findings (CVE-class bugs need full explanation + reference), architectural disagreements (need rationale, not just a one-liner), and onboarding contexts where the author is new and needs the "why". In those cases write a normal paragraph, then resume terse for the rest.
+
+## Boundaries
+
+Reviews only — does not write the code fix, does not approve/request-changes, does not run linters. Output the comment(s) ready to paste into the PR. "stop caveman-review" or "normal mode": revert to verbose review style.

--- a/skills/caveman-stats/SKILL.md
+++ b/skills/caveman-stats/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: caveman-stats
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user invokes /caveman-stats or asks for caveman token-usage
+  stats. Shows real token usage and estimated savings for the current
+  session, read directly from the Claude Code session log — no AI
+  estimation. Output is normally injected by the upstream mode-tracker
+  hook; without that hook the model should explain that hook integration
+  is required.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman-stats/SKILL.md
+---
+
+# Caveman Stats
+
+This skill is normally delivered by `hooks/caveman-stats.js` (read by `hooks/caveman-mode-tracker.js` on `/caveman-stats`) from the upstream caveman pack. The model does not need to compute anything when this skill fires — the hook returns `decision: "block"` with the formatted stats as the reason. The user sees the numbers immediately.
+
+If the upstream hooks are not installed in this environment, surface that fact: tell the user that `/caveman-stats` reports real token counts from the Claude Code session log and requires the upstream hook to be active. Point them at the upstream caveman installer: https://github.com/JuliusBrussee/caveman

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: caveman
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: >-
+  Use when the user wants ultra-compressed responses — says "caveman mode",
+  "talk like caveman", "use caveman", "less tokens", "be brief", or invokes
+  /caveman. Cuts token usage ~75% by speaking like caveman while keeping
+  full technical accuracy. Supports intensity levels: lite, full (default),
+  ultra, wenyan-lite, wenyan-full, wenyan-ultra.
+category:
+  primary: economy
+license:
+  upstream: MIT
+  source: https://github.com/JuliusBrussee/caveman@63a91ec
+  path: skills/caveman/SKILL.md
+---
+
+# Caveman
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. Code symbols, function names, API names, error strings: never abbreviate |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.


### PR DESCRIPTION
## Summary

Force-load the session-level token savers on every outfit so they're opt-out, not opt-in.

- **rtk skills (12) + context-mode MCP** — added to all 16 outfits via \`skill_include\` and \`enable.mcps\`
- **caveman skills (7)** — added to 15 outfits via \`skill_include\`; **orchestrator excluded per spec** (orchestrator needs precise tone, not caveman-speak)
- **caveman pack vendored** from JuliusBrussee/caveman@63a91ec (MIT): \`caveman\`, \`caveman-commit\`, \`caveman-compress\`, \`caveman-help\`, \`caveman-review\`, \`caveman-stats\`, \`cavecrew\`
- **rtk-tooling accessory fix**: added \`rtk-pre-commit-format\` to its hook list (was previously missing)

## Schema limit surfaced

The outfit zod schema is \`.strict()\` and rejects an \`include:\` block (only accessories and cuts have one). That means **rtk hooks** (rtk-suggest, rtk-rewrite, rtk-pre-commit-format) and **rtk agents** (rtk-testing-specialist, rtk-rust-expert) cannot be force-loaded by outfit — they stay gated by the \`--accessory rtk-tooling\` flag.

In practice: skills + MCP are universal; hooks + agents are one CLI flag away. The token-rewrite hook is the most direct cost saver — recommend defaulting your launches to \`suit claude --outfit X --accessory rtk-tooling --accessory context-mode-tooling\` until/unless we change the outfit schema upstream.

## Follow-up suit issue candidate

If you want true universal hook/agent force-loading, the cleanest path is a suit-side change: relax the outfit schema to allow \`include.hooks\` / \`include.agents\` (matching what cuts and accessories already support). Mirror change to outfit composition pipeline. ~Similar shape to the fit-axis issue #60. Happy to file if you want.

Alternative: add a \`default_accessories: [...]\` field to outfit frontmatter so outfits can pin accessories at the YAML level. Same suit-side effort.

## Test plan

- [x] \`npm run validate\` → OK (167 components, 3 pre-existing warnings)
- [x] \`npm run build -- --target all --dry-run\` → 172 files across 4 targets
- [x] Orchestrator outfit confirmed: rtk skills present, caveman skills absent
- [ ] After merge: \`suit claude --outfit code\` shows the rtk skills auto-loaded
- [ ] After merge: \`suit claude --outfit orchestrator\` shows rtk skills but NO caveman skills
- [ ] Manual: confirm token savings on a real session vs. baseline

## Notes from the caveman vendor

- \`cavecrew\` (the orchestrator skill) has upstream subagent dependencies (\`cavecrew-investigator/builder/reviewer\`) that were NOT vendored — scope was skill-only. Body points at upstream for now. Vendor as follow-up if wanted.
- \`caveman-stats\` upstream relies on a \`caveman-mode-tracker.js\` hook also not vendored. Skill body has a fallback note. Could vendor the hook as a follow-up.