### PR TITLE
feat(outfits): force-load rtk hooks/agents universally + rename engineer fit

### DIFF
--- a/docs/plans/2026-05-14-fit-axis-seniority-tiers.md
+++ b/docs/plans/2026-05-14-fit-axis-seniority-tiers.md
@@ -41,7 +41,7 @@ include:
 ---
 ```
 
-**Composition semantics — Option A (decided).** Fit is a strict overlay layered onto outfit/cut/accessory composition. Set-algebra dedup (already implemented in suit) handles overlap. `--outfit engineer --fit engineer` is allowed and harmlessly redundant. A fit alone (no outfit) is allowed but uncommon. B/C alternatives discussed in the prior revision are deferred indefinitely — revisit only if real friction emerges.
+**Composition semantics — Option A (decided).** Fit is a strict overlay layered onto outfit/cut/accessory composition. Set-algebra dedup (already implemented in suit) handles overlap. `--outfit engineer --fit engineer-fit` is allowed and harmlessly redundant. A fit alone (no outfit) is allowed but uncommon. B/C alternatives discussed in the prior revision are deferred indefinitely — revisit only if real friction emerges.
 
 ## Skill loadout per fit
 
@@ -157,7 +157,7 @@ Replace these 10 wardrobe skills with no-git-scrubbed upstream versions of `obra
 
 ## Composition semantics — Option A (decided)
 
-Fit composes as a strict overlay onto the existing set-algebra pipeline (suit already runs this across outfit/cut/accessory; fit becomes a fourth axis fed in). `--outfit code --fit senior` = code's skills ∪ senior fit's additions, dedupe. Redundancy on `--outfit engineer --fit engineer` is accepted as harmless. Fit-alone launches are allowed but uncommon — outfit remains the conventional base.
+Fit composes as a strict overlay onto the existing set-algebra pipeline (suit already runs this across outfit/cut/accessory; fit becomes a fourth axis fed in). `--outfit code --fit senior` = code's skills ∪ senior fit's additions, dedupe. Redundancy on `--outfit engineer --fit engineer-fit` is accepted as harmless. Fit-alone launches are allowed but uncommon — outfit remains the conventional base.
 
 ## Tasks / sequence
 

--- a/fits/engineer-fit/fit.md
+++ b/fits/engineer-fit/fit.md
@@ -1,5 +1,5 @@
 ---
-name: engineer
+name: engineer-fit
 version: 1.0.0
 type: fit
 description: 'Standard engineering tier — the superpowers workflow scaffold (no-git): plan, execute, verify, review, dispatch. Use as default for fluent engineers shipping reasonably-scoped changes.'

--- a/outfits/aviation/outfit.md
+++ b/outfits/aviation/outfit.md
@@ -66,6 +66,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Aviation Outfit

--- a/outfits/backend/outfit.md
+++ b/outfits/backend/outfit.md
@@ -59,6 +59,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 permissions:
   claude-code:
     allow:

--- a/outfits/bones/outfit.md
+++ b/outfits/bones/outfit.md
@@ -58,6 +58,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Bones Outfit

--- a/outfits/code/outfit.md
+++ b/outfits/code/outfit.md
@@ -37,6 +37,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Code Outfit

--- a/outfits/engineer/outfit.md
+++ b/outfits/engineer/outfit.md
@@ -67,6 +67,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Engineer Outfit

--- a/outfits/frontend/outfit.md
+++ b/outfits/frontend/outfit.md
@@ -60,6 +60,14 @@ skill_include:
   - cavecrew
 skill_exclude:
   - golang-patterns
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Frontend Outfit

--- a/outfits/implementer/outfit.md
+++ b/outfits/implementer/outfit.md
@@ -49,6 +49,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Implementer Outfit

--- a/outfits/kb/outfit.md
+++ b/outfits/kb/outfit.md
@@ -73,6 +73,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # KB Outfit

--- a/outfits/meta/outfit.md
+++ b/outfits/meta/outfit.md
@@ -59,6 +59,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Meta Outfit

--- a/outfits/orchestrator/outfit.md
+++ b/outfits/orchestrator/outfit.md
@@ -39,6 +39,14 @@ skill_include:
 skill_exclude:
   - test-driven-development
   - executing-plans
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Orchestrator Outfit

--- a/outfits/personal/outfit.md
+++ b/outfits/personal/outfit.md
@@ -67,6 +67,14 @@ skill_exclude:
   - datastar-tao
   - datastar-patterns
   - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Personal Outfit

--- a/outfits/planner/outfit.md
+++ b/outfits/planner/outfit.md
@@ -48,6 +48,14 @@ skill_include:
   - cavecrew
 skill_exclude:
   - executing-plans
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Planner Outfit

--- a/outfits/quick/outfit.md
+++ b/outfits/quick/outfit.md
@@ -43,6 +43,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 compose:
   - implementer + planner + reviewer
 ---

--- a/outfits/reviewer/outfit.md
+++ b/outfits/reviewer/outfit.md
@@ -49,6 +49,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Reviewer Outfit

--- a/outfits/spy/outfit.md
+++ b/outfits/spy/outfit.md
@@ -45,6 +45,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Spy Outfit

--- a/outfits/stasi/outfit.md
+++ b/outfits/stasi/outfit.md
@@ -67,6 +67,14 @@ skill_include:
   - caveman-stats
   - cavecrew
 skill_exclude: []
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+    - rtk-pre-commit-format
+  agents:
+    - rtk-testing-specialist
+    - rtk-rust-expert
 ---
 
 # Stasi Outfit


### PR DESCRIPTION
## Summary

Two changes responding to suit 0.15.0 landing on npm with the new outfit \`include\` block (suit#63):

### 1. Force-load rtk hooks + agents on every outfit (universal)

Adds an \`include:\` block to all 16 outfits:

\`\`\`yaml
include:
  hooks:
    - rtk-suggest
    - rtk-rewrite
    - rtk-pre-commit-format
  agents:
    - rtk-testing-specialist
    - rtk-rust-expert
\`\`\`

Eliminates the need for \`--accessory rtk-tooling\` to activate the token-rewrite hooks and review agents — they fire universally now. Skills + MCP were already universal from PR #124; this closes the gap.

### 2. Rename fit \`engineer\` → \`engineer-fit\`

Suit 0.15.0 has stricter duplicate-name validation. The outfit \`engineer\` and the fit \`engineer\` were colliding (validate error: \`duplicate component name "engineer"\`). Renamed the fit to disambiguate.

- \`fits/engineer/\` directory moved to \`fits/engineer-fit/\`
- Frontmatter \`name: engineer\` → \`name: engineer-fit\`
- 2 doc references updated in the plan doc

## Validate

- \`npm run validate\` → **OK (171 components, 7 warnings)**
- 7 warnings = 3 pre-existing (tts-announcer hook, design + wait-watch cut body sizes) + 4 new from suit 0.15.0 (fit-body-size warnings on all 4 fits — bodies are 2019–2794 bytes, threshold is 1024)

## Requires

\`@agent-ops/suit\` ≥ 0.15.0. Just published (https://github.com/danmestas/suit/pull/64).

## Test plan

- [x] Validate clean on suit 0.15.0
- [x] No new errors introduced (only the known 4 fit-body warnings, which are non-blocking style hints)
- [x] All 16 outfits got the include block
- [ ] After merge: \`suit claude --outfit code\` (no \`--accessory\` flag) should load rtk hooks + agents
- [ ] After merge: \`suit claude --fit engineer-fit\` (old \`--fit engineer\` no longer works — breaking change for anyone using that flag literal)

## Breaking change note

If you were using \`--fit engineer\` in any launchers or docs, switch to \`--fit engineer-fit\`. No other fits changed names.

## Follow-up (non-blocking)

The 4 fit-body-size warnings suggest trimming each fit's prompt body from 2-3kb down to <1kb. Worth doing for token economy but out of scope here.