### PR TITLE
Swap Kokoro for Supertonic in tts-announcer

### DIFF
--- a/hooks/tts-announcer/HOOK.md
+++ b/hooks/tts-announcer/HOOK.md
@@ -2,12 +2,12 @@
 name: tts-announcer
 version: 0.1.0
 description: >
-  Local, offline voice announcements for Claude Code and Pi via Kokoro-82M TTS.
+  Local, offline voice announcements for Claude Code and Pi via on-device TTS.
   Wires Notification + SubagentStop hooks so the terminal whispers progress
   instead of going *bing*. Useful when subagents run for minutes and you've
   wandered off. Use when the user wants TTS announcements, voice notifications,
   audible subagent feedback, or mentions "/tts", "speak", "announce", or
-  "Kokoro". Audio never leaves the machine; no API keys.
+  "Supertonic". Audio never leaves the machine; no API keys.
 type: hook
 targets:
   - claude-code
@@ -23,7 +23,7 @@ hooks:
 
 # tts-announcer
 
-Local, private voice announcements for Claude Code and Pi powered by [Kokoro-82M](https://github.com/hexgrad/kokoro). Audio never leaves your machine.
+Local, private voice announcements for Claude Code and Pi powered by [Supertonic](https://github.com/supertone-inc/supertonic). Audio never leaves your machine.
 
 ## How it works
 
@@ -38,11 +38,15 @@ The Pi adapter ships a parallel implementation under `extensions/pi-tts/` for th
 
 ## Install
 
-The hooks shell out to a Kokoro container (Docker). Install Kokoro once:
+The hooks POST to a Kokoro-compatible local TTS daemon at `KOKORO_URL` (default `http://localhost:8880`). Currently backed by [supertonic-tts-daemon](https://github.com/dmestas/supertonic-tts-daemon) (on-device ONNX, no Docker):
 
 ```bash
-docker run --name kokoro -d -p 8880:8880 ghcr.io/hexgrad/kokoro:latest
+git clone <supertonic-tts-daemon repo> ~/projects/supertonic-tts-daemon
+bash ~/projects/supertonic-tts-daemon/bin/start.sh   # first run downloads ~260MB
+# Or run in the background via the bundled launchctl plist — see daemon README.
 ```
+
+The endpoint shape is `POST /v1/audio/speech` (OpenAI-compatible). Any local TTS service that speaks that API will work — point `KOKORO_URL` at it. The historical Kokoro Docker (`ghcr.io/hexgrad/kokoro`) is also a valid backend.
 
 Then enable the hook through `suit-build build --target claude-code` (which emits the appropriate `.claude/settings.fragment.json` entries) or install manually with the legacy `install.sh` from the source repo.
 
@@ -52,7 +56,7 @@ A stable random voice is assigned per project on first use, so different repos s
 
 ## Files
 
-- `hooks/lib.sh` — shared TTS helpers (Kokoro endpoint, audio playback, debouncing)
+- `hooks/lib.sh` — shared TTS helpers (Kokoro-compatible endpoint, audio playback, debouncing)
 - `hooks/notify-tts.sh` — Notification hook entry point
 - `hooks/subagent-stop-tts.sh` — SubagentStop hook entry point
 - `extensions/pi-tts/` — Pi coding-agent hook variant (TS extension)

--- a/hooks/tts-announcer/extensions/pi-tts/index.ts
+++ b/hooks/tts-announcer/extensions/pi-tts/index.ts
@@ -34,11 +34,11 @@ async function speak(text: string, project: string) {
   const response = await fetch(`${kokoroUrl}/v1/audio/speech`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model: 'kokoro', voice, input: text, response_format: 'mp3' }),
+    body: JSON.stringify({ model: 'supertonic', voice, input: text, response_format: 'mp3' }),
   });
 
   if (!response.ok) {
-    throw new Error(`Kokoro request failed: ${response.status}`);
+    throw new Error(`TTS request failed: ${response.status}`);
   }
 
   const bytes = Buffer.from(await response.arrayBuffer());

--- a/hooks/tts-announcer/extensions/pi-tts/shared.mjs
+++ b/hooks/tts-announcer/extensions/pi-tts/shared.mjs
@@ -3,13 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 export const DEFAULT_KOKORO_URL = 'http://localhost:8880';
-export const DEFAULT_VOICE = 'af_bella';
+export const DEFAULT_VOICE = 'F1';
 export const DEFAULT_VOICES_FILE = path.join(os.homedir(), '.claude', 'tts-voices.json');
 export const VOICE_POOL = [
-  'af_bella', 'af_sarah', 'af_nicole', 'af_sky', 'af_heart', 'af_aoede', 'af_jessica',
-  'am_adam', 'am_michael', 'am_liam', 'am_puck', 'am_fenrir',
-  'bf_emma', 'bf_alice', 'bf_lily',
-  'bm_george', 'bm_lewis', 'bm_daniel',
+  'F1', 'F2', 'F3', 'F4', 'F5',
+  'M1', 'M2', 'M3', 'M4', 'M5',
 ];
 
 async function readVoiceMap(voicesFile) {

--- a/hooks/tts-announcer/hooks/lib.sh
+++ b/hooks/tts-announcer/hooks/lib.sh
@@ -4,13 +4,12 @@
 KOKORO_URL="${KOKORO_URL:-http://localhost:8880}"
 VOICES_FILE="${TTS_VOICES_FILE:-$HOME/.claude/tts-voices.json}"
 
-# Curated pool of distinct, high-quality Kokoro voices. Edit to taste.
+# Curated pool of Supertonic voice styles. Edit to taste.
 # First-time per-project assignment randomly picks from this list.
+# Backend: supertonic-tts-daemon (Kokoro-compatible API on localhost:8880).
 VOICE_POOL=(
-  af_bella af_sarah af_nicole af_sky af_heart af_aoede af_jessica
-  am_adam am_michael am_liam am_puck am_fenrir
-  bf_emma bf_alice bf_lily
-  bm_george bm_lewis bm_daniel
+  F1 F2 F3 F4 F5
+  M1 M2 M3 M4 M5
 )
 
 # get_voice_for_project <project_name> → echoes a voice id
@@ -19,14 +18,14 @@ VOICE_POOL=(
 #   1. $TTS_VOICE environment variable (global override)
 #   2. Existing mapping in $VOICES_FILE
 #   3. Random pick from $VOICE_POOL, persisted to $VOICES_FILE
-#   4. af_bella (hard fallback)
+#   4. F1 (hard fallback)
 get_voice_for_project() {
   local project="$1"
   if [[ -n "${TTS_VOICE:-}" ]]; then
     echo "$TTS_VOICE"; return
   fi
   if [[ -z "$project" ]]; then
-    echo "af_bella"; return
+    echo "F1"; return
   fi
   [[ -f "$VOICES_FILE" ]] || echo '{}' > "$VOICES_FILE"
   local voice
@@ -49,13 +48,14 @@ get_voice_for_project() {
 }
 
 # speak <voice> <text> [output_path]
-# Calls Kokoro and plays the resulting audio in the background (non-blocking).
+# POSTs to the Kokoro-compatible TTS daemon and plays the resulting audio
+# in the background (non-blocking).
 speak() {
   local voice="$1" text="$2" out="${3:-/tmp/claude-tts.mp3}"
   curl -sf --max-time 10 "$KOKORO_URL/v1/audio/speech" \
     -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg v "$voice" --arg t "$text" \
-          '{model:"kokoro", voice:$v, input:$t, response_format:"mp3"}')" \
+          '{model:"supertonic", voice:$v, input:$t, response_format:"mp3"}')" \
     -o "$out" \
     && afplay "$out" &
 }

--- a/hooks/tts-announcer/hooks/notify-tts.sh
+++ b/hooks/tts-announcer/hooks/notify-tts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Claude Code Notification hook — speaks the notification message via Kokoro TTS,
+# Claude Code Notification hook — speaks the notification message via local TTS,
 # prefixed with the project name so you can tell which session is calling when
 # multiple Claude sessions are running in parallel. The voice is assigned
 # per-project (first time → random pick, then stable) so voice + project name


### PR DESCRIPTION
## Summary

- Replaces the Kokoro Docker backend with an on-device Supertonic ONNX daemon (separate project at `~/projects/supertonic-tts-daemon`).
- Same wire contract: `POST /v1/audio/speech` on `KOKORO_URL` (default `:8880`), JSON body unchanged in shape. Any local TTS service that speaks that API will keep working.
- New voice pool: Supertonic's 10 styles (`F1`-`F5`, `M1`-`M5`) replacing Kokoro's 17 named voices. Default fallback `af_bella` → `F1`.
- `HOOK.md` install section now describes the daemon contract rather than the specific Kokoro container — kept as a valid fallback backend.
- `~/.claude/tts-voices.json` is backed up out-of-tree as part of the rollout (`*.kokoro-backup`) so each project re-picks once.

## Test plan

- [ ] Stop any running kokoro on `:8880` (`docker stop ...`)
- [ ] `bash ~/projects/supertonic-tts-daemon/bin/start.sh` (first run downloads ~260MB)
- [ ] `curl -sf -o /tmp/t.wav :8880/v1/audio/speech -H 'Content-Type: application/json' -d '{"voice":"F1","input":"online"}' && afplay /tmp/t.wav`
- [ ] Fire a Claude Code Notification (e.g. permission prompt) and confirm the chime plays via the new daemon
- [ ] Fire a SubagentStop and confirm the project-prefixed announcement plays
- [ ] Sample all 10 voices and trim the pool if any sound off
- [ ] Optional: load the launchctl plist for autostart