### PR TITLE
fix(tts): write to .wav so afplay opens it

### DIFF
--- a/hooks/tts-announcer/extensions/pi-tts/index.ts
+++ b/hooks/tts-announcer/extensions/pi-tts/index.ts
@@ -28,7 +28,7 @@ async function speak(text: string, project: string) {
   const voice = await chooseVoiceForProject(project);
   const kokoroUrl = process.env.KOKORO_URL || DEFAULT_KOKORO_URL;
   const outDir = path.join(os.tmpdir(), 'pi-tts');
-  const outFile = path.join(outDir, `${sanitizeFilePart(project)}.mp3`);
+  const outFile = path.join(outDir, `${sanitizeFilePart(project)}.wav`);
   await mkdir(outDir, { recursive: true });
 
   const response = await fetch(`${kokoroUrl}/v1/audio/speech`, {

--- a/hooks/tts-announcer/hooks/lib.sh
+++ b/hooks/tts-announcer/hooks/lib.sh
@@ -51,7 +51,7 @@ get_voice_for_project() {
 # POSTs to the Kokoro-compatible TTS daemon and plays the resulting audio
 # in the background (non-blocking).
 speak() {
-  local voice="$1" text="$2" out="${3:-/tmp/claude-tts.mp3}"
+  local voice="$1" text="$2" out="${3:-/tmp/claude-tts.wav}"
   curl -sf --max-time 10 "$KOKORO_URL/v1/audio/speech" \
     -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg v "$voice" --arg t "$text" \

--- a/hooks/tts-announcer/hooks/notify-tts.sh
+++ b/hooks/tts-announcer/hooks/notify-tts.sh
@@ -27,5 +27,5 @@ else
   text="$msg"
 fi
 
-speak "$voice" "$text" /tmp/claude-tts-notify.mp3
+speak "$voice" "$text" /tmp/claude-tts-notify.wav
 exit 0

--- a/hooks/tts-announcer/hooks/subagent-stop-tts.sh
+++ b/hooks/tts-announcer/hooks/subagent-stop-tts.sh
@@ -83,5 +83,5 @@ else
   text="A subagent just finished."
 fi
 
-speak "$voice" "$text" /tmp/claude-tts-subagent.mp3
+speak "$voice" "$text" /tmp/claude-tts-subagent.wav
 exit 0


### PR DESCRIPTION
## Summary

Follow-up to #129. After the Supertonic swap the daemon returns `audio/wav` bytes regardless of the client-requested `response_format`. The hooks were still saving the response to `/tmp/claude-tts-*.mp3`, and `afplay` refused with `AudioFileOpen failed ('dta?')` — macOS keys decoder selection off the file extension, not the magic bytes. End result: notifications fired, the WAV file got written, no sound came out.

Switching the output paths to `.wav` makes the hook end-to-end again with no other changes. The Kokoro Docker backend (which actually returned mp3) is still supported — `KOKORO_URL` is unchanged; only the local cache filename moves.

## Test plan

- [x] `echo '{"message":"test"}' | hooks/notify-tts.sh` plays via the running Supertonic daemon (verified locally)
- [ ] Fire a Claude Code Notification (e.g. permission prompt) end-to-end
- [ ] Fire a SubagentStop event end-to-end
- [ ] Pi extension (`extensions/pi-tts/`): write a per-project `.wav` file and play it