### PR TITLE
feat(tts): speak the subagent's reply summary

### DIFF
--- a/hooks/tts-announcer/extensions/pi-tts/index.ts
+++ b/hooks/tts-announcer/extensions/pi-tts/index.ts
@@ -28,7 +28,7 @@ async function speak(text: string, project: string) {
   const voice = await chooseVoiceForProject(project);
   const kokoroUrl = process.env.KOKORO_URL || DEFAULT_KOKORO_URL;
   const outDir = path.join(os.tmpdir(), 'pi-tts');
-  const outFile = path.join(outDir, `${sanitizeFilePart(project)}.mp3`);
+  const outFile = path.join(outDir, `${sanitizeFilePart(project)}.wav`);
   await mkdir(outDir, { recursive: true });
 
   const response = await fetch(`${kokoroUrl}/v1/audio/speech`, {

--- a/hooks/tts-announcer/hooks/lib.sh
+++ b/hooks/tts-announcer/hooks/lib.sh
@@ -51,7 +51,7 @@ get_voice_for_project() {
 # POSTs to the Kokoro-compatible TTS daemon and plays the resulting audio
 # in the background (non-blocking).
 speak() {
-  local voice="$1" text="$2" out="${3:-/tmp/claude-tts.mp3}"
+  local voice="$1" text="$2" out="${3:-/tmp/claude-tts.wav}"
   curl -sf --max-time 10 "$KOKORO_URL/v1/audio/speech" \
     -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg v "$voice" --arg t "$text" \

--- a/hooks/tts-announcer/hooks/notify-tts.sh
+++ b/hooks/tts-announcer/hooks/notify-tts.sh
@@ -27,5 +27,5 @@ else
   text="$msg"
 fi
 
-speak "$voice" "$text" /tmp/claude-tts-notify.mp3
+speak "$voice" "$text" /tmp/claude-tts-notify.wav
 exit 0

--- a/hooks/tts-announcer/hooks/subagent-stop-tts.sh
+++ b/hooks/tts-announcer/hooks/subagent-stop-tts.sh
@@ -83,5 +83,5 @@ else
   text="A subagent just finished."
 fi
 
-speak "$voice" "$text" /tmp/claude-tts-subagent.mp3
+speak "$voice" "$text" /tmp/claude-tts-subagent.wav
 exit 0

--- a/hooks/tts-announcer/hooks/subagent-stop-tts.sh
+++ b/hooks/tts-announcer/hooks/subagent-stop-tts.sh
@@ -34,7 +34,7 @@ if [[ -f "$parent_transcript" ]]; then
     # That turn also carries the tool_use_id, which we use to find the original
     # Agent tool_use and pull its description + subagent_type.
     tool_use_id="$(jq -r --arg id "$agent_id" '
-      select(.type=="user" and (.toolUseResult?.agentId // "") == $id)
+      select(.type=="user" and ((.toolUseResult? | objects | .agentId?) // "") == $id)
       | .message.content[]? | select(.type=="tool_result") | .tool_use_id
     ' "$parent_transcript" 2>/dev/null | head -1)"
 
@@ -52,11 +52,35 @@ if [[ -f "$parent_transcript" ]]; then
     # Fallback: grab agentType from the tool_result if the tool_use lookup missed
     if [[ -z "$agent_type" ]]; then
       agent_type="$(jq -r --arg id "$agent_id" '
-        select(.type=="user" and (.toolUseResult?.agentId // "") == $id)
-        | .toolUseResult.agentType // empty
+        select(.type=="user" and ((.toolUseResult? | objects | .agentId?) // "") == $id)
+        | ((.toolUseResult? | objects | .agentType?) // empty)
       ' "$parent_transcript" 2>/dev/null | head -1)"
     fi
+
+    # Pull the subagent's actual reply text (the "punchline") for TTS. Content
+    # can be a string OR an array of {type:"text", text:"..."} blocks.
+    result_text="$(jq -r --arg id "$agent_id" '
+      select(.type=="user" and ((.toolUseResult? | objects | .agentId?) // "") == $id)
+      | .message.content[]?
+      | select(.type=="tool_result")
+      | if (.content|type) == "string" then .content
+        else (.content | map(select(.type=="text") | .text) | join(" "))
+        end
+    ' "$parent_transcript" 2>/dev/null | head -1)"
   fi
+fi
+
+# Clean the reply for TTS: strip code fences, inline code, markdown link
+# syntax, heading/emphasis markers, table pipes; collapse whitespace; cap at
+# ~150 chars (≈10s of speech).
+summary=""
+if [[ -n "${result_text:-}" ]]; then
+  summary="$(printf '%s' "$result_text" \
+    | sed -E 's/```[^`]*```//g; s/`[^`]*`//g; s/\[([^]]+)\]\([^)]+\)/\1/g; s/[*_#>|~]//g' \
+    | tr '\n' ' ' \
+    | tr -s ' ' \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | cut -c 1-150)"
 fi
 
 # If parent transcript didn't yield a project name, fall back to the
@@ -71,7 +95,11 @@ agent_type_spoken="${agent_type//-/ }"
 project_prefix=""
 [[ -n "$project" ]] && project_prefix="In $project, "
 
-if [[ -n "$agent_type_spoken" && -n "$description" ]]; then
+if [[ -n "$agent_type_spoken" && -n "$summary" ]]; then
+  text="${project_prefix}the $agent_type_spoken agent reports: $summary"
+elif [[ -n "$summary" ]]; then
+  text="${project_prefix}a subagent reports: $summary"
+elif [[ -n "$agent_type_spoken" && -n "$description" ]]; then
   text="${project_prefix}the $agent_type_spoken agent finished: $description."
 elif [[ -n "$description" ]]; then
   text="${project_prefix}a subagent finished: $description."


### PR DESCRIPTION
## Summary

Two improvements to the SubagentStop announcer:

1. **Bug fix.** The existing jq queries indexed `.toolUseResult.agentId` and `.agentType` directly, which errored on tool-result records where `toolUseResult` is an _array_ rather than an object (real shape in current Claude Code transcripts — see e.g. tool-status arrays). Errors were silenced via `2>/dev/null` but caused jq to skip records, so an Agent record appearing _after_ a malformed one returned empty. Description/agent-type lookups silently degraded to "subagent finished" with no context. Replaced with the safe pattern `((.toolUseResult? | objects | .agentId?) // "")` in all three sites.

2. **Speak the actual reply.** Extract the subagent's final reply text from the parent transcript's matching `tool_result`, strip markdown / code fences / link syntax, collapse whitespace, cap at 150 chars (~10s of speech). New highest-priority spoken format is "the {agent_type} agent reports: {summary}", falling back to the prior "finished: {description}" chain when no reply text can be extracted.

Stacks on top of #130 (the `.mp3` → `.wav` fix) — that PR's commit is included in this branch. Once #130 is merged this PR's diff narrows to the single commit.

## Test plan

- [x] Replay the previously-failing jq filter against a real parent transcript — extraction succeeds for an Agent whose ID lives after a malformed `toolUseResult: [...]` record
- [x] Spawn a real `Agent` subagent in a live Claude Code session and confirm the announcement says "...the Explore agent reports: \<actual reply summary\>"
- [ ] Spawn a long-output agent and confirm the cap holds at ~150 chars without cutting awkwardly mid-token (it can cut mid-word; that's accepted)
- [ ] Verify fallback chain still works: spawn an agent that returns _only_ images / non-text content and confirm we fall through to "agent finished: \<description\>"