### PR TITLE
feat(spdd): Structured-Prompt-Driven Development bundle

### DIFF
--- a/accessories/spdd-skills/accessory.md
+++ b/accessories/spdd-skills/accessory.md
@@ -1,0 +1,48 @@
+---
+name: spdd-skills
+version: 0.1.0
+type: accessory
+description: Structured-Prompt-Driven Development skill bundle — REASONS Canvas, alignment, analysis, generation, review, prompt-update, and sync skills without changing the session cut.
+targets: [claude-code, codex, gemini, pi]
+include:
+  skills:
+    - using-spdd
+    - spdd-story
+    - spdd-alignment
+    - spdd-analysis
+    - spdd-reasons-canvas
+    - spdd-abstraction-first
+    - spdd-generate
+    - spdd-api-test
+    - spdd-iterative-review
+    - spdd-prompt-update
+    - spdd-sync
+  rules: []
+  hooks: []
+  agents: []
+  commands: []
+---
+
+# SPDD Skills Accessory
+
+Layer this accessory onto another outfit/cut when you want the SPDD skill surface available without switching the whole session into SPDD mode. The full methodology now lives in the `spdd` cut; this accessory is the lighter skill bundle.
+
+## What it bundles
+
+- **`using-spdd`** — session-level workflow contract as a callable skill.
+- **`spdd-story`** — optional story slicing for large requirements.
+- **`spdd-alignment`** — business intent, domain language, scope, acceptance criteria, and constraints.
+- **`spdd-analysis`** — grounded domain/code analysis before design.
+- **`spdd-reasons-canvas`** — Requirements, Entities, Approach, Structure, Operations, Norms, Safeguards.
+- **`spdd-abstraction-first`** — prompt/design review before generation.
+- **`spdd-generate`** — implementation strictly from the approved canvas.
+- **`spdd-api-test`** — boundary-level executable scenarios.
+- **`spdd-iterative-review`** — behavior-first review and feedback classification.
+- **`spdd-prompt-update`** — requirements-to-prompt-to-code loop for behavior changes.
+- **`spdd-sync`** — code-to-prompt sync for behavior-preserving refactors.
+
+## Pairing
+
+Use `--cut spdd` when you want the full methodology enforced as the session work shape. Use this accessory when another cut should remain in charge, but the SPDD skills should still be within reach.
+
+Avoid this accessory for urgent incident recovery, disposable scripts, visual/taste exploration, or raw brainstorming where prompt governance would slow the wrong work.

--- a/cuts/spdd/cut.md
+++ b/cuts/spdd/cut.md
@@ -1,0 +1,42 @@
+---
+name: spdd
+version: 0.1.0
+type: cut
+description: 'Structured-Prompt-Driven Development — align intent, analyze context, write a REASONS Canvas, generate inside the spec, and keep prompt and code synchronized.'
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - backpressure
+enable:
+  plugins:
+    - superpowers
+    - superpowers-codex
+skill_include: []
+skill_exclude: []
+include:
+  skills:
+    - using-spdd
+    - spdd-story
+    - spdd-alignment
+    - spdd-analysis
+    - spdd-reasons-canvas
+    - spdd-abstraction-first
+    - spdd-generate
+    - spdd-api-test
+    - spdd-iterative-review
+    - spdd-prompt-update
+    - spdd-sync
+  rules: []
+  hooks:
+    - spdd-workflow
+  agents: []
+  commands: []
+---
+
+Structured-Prompt-Driven Development. Treat prompts/specs as first-class delivery artifacts: versioned, reviewed, reused, and kept synchronized with code.
+
+You are in SPDD cut. Work prompt-first, not diff-first. Lock intent with alignment, ground it with analysis, turn it into a REASONS Canvas, and generate only inside that boundary. Validate behavior before deep code review. When reality diverges, classify it before editing: behavior or business-rule changes go prompt first then code (`spdd-prompt-update`), while behavior-preserving refactors go code first then prompt sync (`spdd-sync`). Keep the prompt artifact, verification evidence, and code on the same branch so reviewers can check intent before they check the diff.

--- a/hooks/spdd-workflow/HOOK.md
+++ b/hooks/spdd-workflow/HOOK.md
@@ -1,0 +1,39 @@
+---
+name: spdd-workflow
+version: 0.1.0
+description: >
+  SessionStart hook for the SPDD cut. Injects the using-spdd workflow contract
+  as additional context so Claude Code sessions follow the
+  Structured-Prompt-Driven Development loop from prompt artifact to code and
+  back again. Opt out per project with `.agent-config/spdd.disabled`.
+type: hook
+targets:
+  - claude-code
+category:
+  primary: workflow
+  secondary:
+    - backpressure
+hooks:
+  SessionStart:
+    matcher: startup|clear|compact
+    command: hooks/spdd-workflow-session-start.sh
+---
+
+# spdd-workflow hook
+
+Injects `skills/using-spdd/SKILL.md` at `SessionStart` so SPDD-cut Claude Code sessions begin with the prompt-first workflow in context.
+
+## Behavior
+
+- Emits Claude Code `SessionStart` additional context containing the `using-spdd` skill.
+- Fails open with no output if the skill file cannot be found.
+- Exits silently when `.agent-config/spdd.disabled` exists in the current working directory.
+- Never blocks the host session on hook errors.
+
+## Files
+
+- `hooks/spdd-workflow-session-start.sh` — fail-safe SessionStart implementation.
+
+## Bundled with
+
+Included by the `spdd` cut. The `spdd-skills` accessory leaves this hook out on purpose so the skill bundle can be layered onto other cuts without changing startup behavior.

--- a/hooks/spdd-workflow/hooks/spdd-workflow-session-start.sh
+++ b/hooks/spdd-workflow/hooks/spdd-workflow-session-start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SessionStart hook for SPDD. Injects the using-spdd skill as additional context.
+# Reads hook JSON from stdin, writes hook JSON to stdout, and always exits 0.
+
+# shellcheck shell=bash
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../_lib/fail-safe.sh
+source "${SCRIPT_DIR}/../../_lib/fail-safe.sh" 2>/dev/null || {
+  trap 'exit 0' ERR
+}
+failsafe::trap_errors 2>/dev/null || true
+
+input="$(cat 2>/dev/null || true)"
+cwd="${PWD}"
+if command -v jq >/dev/null 2>&1; then
+  parsed_cwd="$(printf '%s' "${input}" | jq -r '.cwd // empty' 2>/dev/null || true)"
+  if [[ -n "${parsed_cwd}" ]]; then
+    cwd="${parsed_cwd}"
+  fi
+fi
+
+if [[ -f "${cwd}/.agent-config/spdd.disabled" ]]; then
+  exit 0
+fi
+
+skill_file=""
+candidates=(
+  "${cwd}/.claude/skills/using-spdd/SKILL.md"
+  "${SCRIPT_DIR}/../skills/using-spdd/SKILL.md"
+  "${SCRIPT_DIR}/../../../skills/using-spdd/SKILL.md"
+)
+[[ -n "${CLAUDE_PROJECT_DIR:-}" ]] && candidates=("${CLAUDE_PROJECT_DIR}/.claude/skills/using-spdd/SKILL.md" "${candidates[@]}")
+[[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && candidates+=("${CLAUDE_PLUGIN_ROOT}/skills/using-spdd/SKILL.md")
+[[ -n "${CURSOR_PLUGIN_ROOT:-}" ]] && candidates+=("${CURSOR_PLUGIN_ROOT}/skills/using-spdd/SKILL.md")
+
+for candidate in "${candidates[@]}"; do
+  if [[ -n "${candidate}" && -f "${candidate}" ]]; then
+    skill_file="${candidate}"
+    break
+  fi
+done
+
+if [[ -z "${skill_file}" ]]; then
+  exit 0
+fi
+
+skill_content="$(cat "${skill_file}" 2>/dev/null || true)"
+if [[ -z "${skill_content}" ]]; then
+  exit 0
+fi
+
+escape_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "${s}"
+}
+
+context="$(escape_json "${skill_content}")"
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "${context}"
+
+exit 0

--- a/skills/spdd-abstraction-first/SKILL.md
+++ b/skills/spdd-abstraction-first/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: spdd-abstraction-first
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use during SPDD design review before generation to validate entities, responsibilities, interfaces, boundaries, dependencies, and task granularity.
+category:
+  primary: backpressure
+  secondary: [workflow]
+---
+
+# SPDD Abstraction First
+
+Design before generation. Make the model of the solution explicit before letting an agent fill in implementation details.
+
+**Announce at start:** "I'm using the spdd-abstraction-first skill to check the domain model and boundaries before generation."
+
+## Review the model
+
+### Requirement fidelity
+
+- Requirements section captures the user story and definition of done.
+- Acceptance criteria are fully represented without invented scope.
+- Domain terms match the aligned glossary.
+
+### Entity and responsibility model
+
+- Entities, value objects, services, commands, events, and external systems reflect the real domain.
+- Responsibilities have clear owners; no concept is split arbitrarily across layers.
+- Relationships and lifecycle rules are explicit.
+
+### Approach and structure
+
+- The design strategy solves the core problem, not a nearby easier problem.
+- Components fit the existing architecture and dependency direction.
+- Interface contracts are named before implementation details are written.
+
+### Operations granularity
+
+- Tasks are independent, testable, and acceptance-ready.
+- Each task has exact files/symbols where possible.
+- No task says "handle edge cases" without naming the edge cases.
+
+## Diagram rule
+
+For non-trivial domains, add one lightweight diagram to the prompt artifact before implementation:
+
+- Mermaid class diagram for entities and relationships.
+- Sequence diagram for cross-component flows.
+- Flow chart for decision logic.
+
+## Output
+
+Append an abstraction review to the REASONS Canvas or analysis artifact:
+
+- Model accepted / rejected.
+- Required corrections.
+- Diagram, if useful.
+- Risks that must become Norms or Safeguards.
+
+If the model is rejected, return to `spdd-reasons-canvas` instead of coding around it.

--- a/skills/spdd-alignment/SKILL.md
+++ b/skills/spdd-alignment/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: spdd-alignment
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use before SPDD analysis or implementation to lock business intent, domain language, scope boundaries, acceptance criteria, dependencies, and hard constraints.
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# SPDD Alignment
+
+Lock intent before design or code. This skill turns raw input into a shared, testable problem statement.
+
+**Announce at start:** "I'm using the spdd-alignment skill to lock intent before writing the prompt or code."
+
+## Hard gate
+
+Do not invoke implementation skills, edit product code, or generate a REASONS Canvas until the alignment questions below have concrete answers. If a question is answerable from repository context, answer it by inspection rather than asking the user.
+
+## Alignment checks
+
+### Business value
+
+- What user/business problem is being solved?
+- What outcome would prove the change mattered?
+- Which behavior is explicitly out of scope?
+
+### Domain language
+
+- Define the key nouns and verbs in the user's language.
+- Identify same-word/different-meaning risks.
+- Prefer existing repository terminology unless the requirement intentionally changes it.
+
+### Acceptance criteria
+
+- Convert vague success statements into Given/When/Then or equivalent observable checks.
+- Cover happy path, important boundaries, and invalid inputs.
+- Separate business acceptance from implementation detail.
+
+### Constraints and dependencies
+
+- Identify upstream systems, unfinished modules, migration order, data compatibility, security, performance, compliance, and operational constraints.
+- Preserve legacy behavior unless the aligned requirement explicitly changes it.
+
+## Output
+
+Produce an `alignment.md` section or artifact with:
+
+1. Problem statement.
+2. Business value.
+3. Scope in/out.
+4. Domain glossary.
+5. Acceptance criteria.
+6. Constraints and dependencies.
+7. Open questions that are truly blocking.
+
+If blockers remain, do not proceed to `spdd-analysis` until they are resolved or explicitly deferred by the user.

--- a/skills/spdd-analysis/SKILL.md
+++ b/skills/spdd-analysis/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: spdd-analysis
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use after SPDD alignment to analyze requirements against relevant code, domain concepts, risks, gaps, strategy, and acceptance coverage before writing a REASONS Canvas.
+category:
+  primary: workflow
+  secondary: [context-management]
+---
+
+# SPDD Analysis
+
+Create the context-rich analysis that feeds the REASONS Canvas. Analyze enough to ground the prompt; do not design method-level operations yet.
+
+**Announce at start:** "I'm using the spdd-analysis skill to ground the requirement in existing domain and code context."
+
+## Inputs
+
+- Aligned story or requirement.
+- Existing specs, ADRs, prompts, and tests relevant to the same domain.
+- Repository code discovered by domain keywords and symbols, not by blind whole-repo reading.
+
+## Process
+
+1. Extract domain keywords from the requirement and glossary.
+2. Search for matching code, tests, schemas, APIs, docs, and prior prompt artifacts.
+3. Identify existing concepts and whether they should be reused, extended, or left untouched.
+4. Identify new concepts and how they relate to existing ones.
+5. Surface risks, gaps, ambiguous rules, and hidden constraints.
+6. Recommend the strategic direction at a high level only.
+
+## Output sections
+
+```markdown
+# <Story> Analysis
+
+## Requirement summary
+
+## Domain concepts
+### Existing
+### New
+### Relationships and business rules
+
+## Relevant system context
+- Files/symbols examined:
+- Existing tests/contracts:
+- External dependencies:
+
+## Strategic direction
+
+## Risks and gaps
+
+## Acceptance coverage map
+| Acceptance criterion | Evidence / design implication | Risk |
+```
+
+## Gate
+
+Review the analysis for alignment before writing the REASONS Canvas. If the analysis misses a key domain term, risk, or boundary, fix the analysis first.

--- a/skills/spdd-api-test/SKILL.md
+++ b/skills/spdd-api-test/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: spdd-api-test
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use in SPDD when API or system-boundary behavior must be verified with executable scenarios covering normal, boundary, and error cases from the REASONS Canvas.
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# SPDD API Test
+
+Generate and run boundary-level functional tests from the canvas acceptance criteria.
+
+**Announce at start:** "I'm using the spdd-api-test skill to verify behavior at the system boundary."
+
+## When to use
+
+Use for HTTP APIs, CLIs, message handlers, webhooks, workers, or other externally observable contracts. Skip when the change has no runnable boundary surface; use focused unit/integration tests instead.
+
+## Test design
+
+Create a scenario table before code or script:
+
+| ID | Scenario | Input | Expected output | Source AC |
+| --- | --- | --- | --- | --- |
+| T1 | Happy path | ... | ... | AC1 |
+| T2 | Boundary | ... | ... | AC2 |
+| T3 | Error | ... | ... | AC3 |
+
+Cover:
+
+- Normal business flow.
+- Boundary values and limits named in the canvas.
+- Invalid input and not-found paths.
+- Backward compatibility expectations.
+- Response shape or emitted side effects.
+
+## Script rules
+
+- Prefer existing project test harnesses over ad hoc scripts.
+- If a script is necessary, make expected-vs-actual output explicit.
+- Do not mock the system boundary the scenario is supposed to prove.
+- Keep credentials, production endpoints, and destructive operations out of generated scripts.
+
+## Gate
+
+Run the scenarios. If behavior fails because the canvas intent is wrong or incomplete, use `spdd-prompt-update` before changing code. If behavior fails because code violates the canvas, fix code under `spdd-generate`.

--- a/skills/spdd-generate/SKILL.md
+++ b/skills/spdd-generate/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: spdd-generate
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use when implementing code from an approved SPDD REASONS Canvas, following Operations in order and staying inside the canvas Norms and Safeguards.
+category:
+  primary: workflow
+  secondary: [context-management]
+---
+
+# SPDD Generate
+
+Translate an approved REASONS Canvas into code and tests without improvising outside the prompt/spec.
+
+**Announce at start:** "I'm using the spdd-generate skill to implement strictly from the approved REASONS Canvas."
+
+## Preconditions
+
+- `spdd-alignment`, `spdd-analysis`, and `spdd-reasons-canvas` artifacts exist or are included in the prompt.
+- The canvas has passed `spdd-abstraction-first` review.
+- Operations, Norms, and Safeguards are specific enough to execute.
+
+If any precondition fails, stop and repair the prompt artifact before editing code.
+
+## Execution rules
+
+1. Implement Operations in canvas order unless repository dependencies force a narrower order; record any deviation in the artifact.
+2. Modify only files required by Requirements and Operations.
+3. Preserve existing behavior not explicitly changed by the canvas.
+4. Add or update tests where the canvas says behavior must be proven.
+5. If implementation reveals a behavior/design mismatch, do not patch around it. Use `spdd-prompt-update` first.
+6. If implementation requires a harmless internal refactor, do it in a small step and later run `spdd-sync`.
+
+## Verification sequence
+
+- Run the smallest command that proves each operation's behavior.
+- For API or system-boundary changes, use `spdd-api-test` or an equivalent executable scenario.
+- After behavior passes, run `spdd-iterative-review` for prompt/code consistency and maintainability.
+
+## Output
+
+Report:
+
+- Canvas file/version used.
+- Operations completed.
+- Tests or scenarios run.
+- Any prompt updates or sync needed.

--- a/skills/spdd-iterative-review/SKILL.md
+++ b/skills/spdd-iterative-review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: spdd-iterative-review
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use after SPDD-generated changes to review behavior, prompt/code consistency, architecture boundaries, code quality, and whether to update prompt first or sync prompt after refactor.
+category:
+  primary: backpressure
+  secondary: [workflow]
+---
+
+# SPDD Iterative Review
+
+Turn generated output into a controlled loop. Behavior first, code review second, prompt/code sync always.
+
+**Announce at start:** "I'm using the spdd-iterative-review skill to classify feedback and keep the prompt and code synchronized."
+
+## Review order
+
+1. **Behavior:** Does the system satisfy acceptance criteria and safeguards?
+2. **Prompt/code consistency:** Does the code implement exactly what the canvas says?
+3. **Architecture:** Do layers, dependencies, interfaces, and responsibilities match Structure and Approach?
+4. **Code quality:** Check error handling, imports, dependency choices, magic values, long methods, duplication, and repository idioms.
+5. **Test adequacy:** Do tests cover normal, boundary, and error cases that can break?
+
+## Classify every finding
+
+### Logic correction
+
+Observable behavior, business rule, data contract, security rule, performance guarantee, or acceptance criterion changes.
+
+Action: run `spdd-prompt-update` first, then update code with `spdd-generate`.
+
+### Refactor
+
+Internal structure changes with no observable behavior change.
+
+Action: refactor code, prove behavior still passes, then run `spdd-sync`.
+
+### Prompt defect
+
+The canvas is ambiguous, incomplete, or internally inconsistent.
+
+Action: repair the canvas and re-review before code changes continue.
+
+### Code defect
+
+The canvas is right, but code violates it.
+
+Action: fix code under `spdd-generate` and rerun affected verification.
+
+## Output
+
+Use this format:
+
+```markdown
+## SPDD review
+
+### Behavior evidence
+- ...
+
+### Findings
+- [logic-correction|refactor|prompt-defect|code-defect] <finding> → <next skill/action>
+
+### Prompt/code sync status
+- Canvas describes current code: yes/no
+- Required update: spdd-prompt-update / spdd-sync / none
+```
+
+Do not declare the slice complete while canvas and code disagree.

--- a/skills/spdd-prompt-update/SKILL.md
+++ b/skills/spdd-prompt-update/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: spdd-prompt-update
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use in SPDD when requirements, behavior, acceptance criteria, business rules, or safeguards change; update the REASONS Canvas before changing code.
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# SPDD Prompt Update
+
+For behavior changes, update the prompt/spec first. Code follows the corrected intent.
+
+**Announce at start:** "I'm using the spdd-prompt-update skill to update the REASONS Canvas before changing code."
+
+## Use when
+
+- A requirement changes.
+- Acceptance criteria are wrong, incomplete, or newly discovered.
+- A bug fix changes observable behavior.
+- A data contract, validation rule, pricing rule, permission rule, or safeguard changes.
+- Generated code exposed a design gap in the canvas.
+
+Do not use this for pure refactors; use `spdd-sync` after the refactor instead.
+
+## Update discipline
+
+1. Identify the exact outdated canvas sections.
+2. Modify only affected REASONS dimensions.
+3. Preserve unrelated decisions and Operations.
+4. Add the reason for the update and the evidence that forced it.
+5. Re-run `spdd-abstraction-first` if Entities, Approach, Structure, or Operations changed.
+6. Use `spdd-generate` for targeted code updates from the changed canvas.
+
+## Patch note template
+
+```markdown
+## Prompt update: <date / change>
+
+### Trigger
+<requirement change, failing scenario, review finding>
+
+### Sections changed
+- R — Requirements:
+- E — Entities:
+- A — Approach:
+- S — Structure:
+- O — Operations:
+- N — Norms:
+- S — Safeguards:
+
+### Compatibility impact
+
+### Verification to rerun
+```
+
+## Gate
+
+Do not edit code for the behavior change until the updated canvas is saved or included in the current prompt context.

--- a/skills/spdd-reasons-canvas/SKILL.md
+++ b/skills/spdd-reasons-canvas/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: spdd-reasons-canvas
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: "Use to create or review a Structured-Prompt-Driven Development REASONS Canvas before code generation: Requirements, Entities, Approach, Structure, Operations, Norms, Safeguards."
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# SPDD REASONS Canvas
+
+Write the executable prompt/spec that governs code generation.
+
+**Announce at start:** "I'm using the spdd-reasons-canvas skill to turn the aligned analysis into an executable prompt."
+
+## Canvas template
+
+```markdown
+# <Change> REASONS Canvas
+
+## R — Requirements
+- Problem:
+- Definition of done:
+- Acceptance criteria:
+- Scope out:
+
+## E — Entities
+- Domain entities / value objects:
+- Relationships:
+- State and lifecycle rules:
+- External systems:
+
+## A — Approach
+- Strategy:
+- Trade-offs accepted:
+- Alternatives rejected:
+- Compatibility / migration approach:
+
+## S — Structure
+- Components and files:
+- Interfaces / contracts:
+- Dependency direction:
+- Data flow:
+
+## O — Operations
+1. <atomic, testable implementation operation>
+2. ...
+
+## N — Norms
+- Naming:
+- Error handling:
+- Observability:
+- Testing:
+- Repository conventions:
+
+## S — Safeguards
+- Security:
+- Data integrity:
+- Performance:
+- Backward compatibility:
+- Non-goals the agent must not cross:
+```
+
+## Quality bar
+
+- Requirements are traceable to aligned acceptance criteria.
+- Entities and Structure are grounded in existing code where code exists.
+- Operations are ordered, atomic, and testable.
+- Norms encode team conventions; Safeguards encode non-negotiable boundaries.
+- No placeholders, speculative APIs, or "similar to above" shortcuts.
+
+## Review gate
+
+Run `spdd-abstraction-first` against the canvas before `spdd-generate`. If review changes behavior or design intent, edit the canvas first and re-review the affected sections.

--- a/skills/spdd-story/SKILL.md
+++ b/skills/spdd-story/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: spdd-story
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use when a large SPDD requirement needs to be split into independent, deliverable user stories before analysis and REASONS Canvas work.
+category:
+  primary: workflow
+---
+
+# SPDD Story
+
+Break large requirements into independent, deliverable stories before deeper analysis.
+
+**Announce at start:** "I'm using the spdd-story skill to split the requirement into SPDD-ready stories."
+
+## When to use
+
+Use this when the input bundles multiple outcomes, personas, bounded contexts, delivery milestones, or acceptance surfaces. Skip it when the user already supplied a small, coherent story.
+
+## Story rules
+
+Each story must be:
+
+- **Independent:** can ship without relying on another unfinished story.
+- **Negotiable:** captures outcome, not implementation commands.
+- **Valuable:** has visible user/business value.
+- **Estimable:** bounded enough for a single implementation plan.
+- **Small:** one coherent behavior slice.
+- **Testable:** acceptance criteria are observable.
+
+## Output format
+
+For each story:
+
+```markdown
+## Story N: <title>
+
+### Background
+<why this matters>
+
+### Business value
+<what improves when this ships>
+
+### Scope in
+- ...
+
+### Scope out
+- ...
+
+### Acceptance criteria
+- Given ..., when ..., then ...
+```
+
+## Handoff
+
+After splitting, run `spdd-alignment` on the selected story before `spdd-analysis`. Do not generate architecture or code from the raw split output.

--- a/skills/spdd-sync/SKILL.md
+++ b/skills/spdd-sync/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: spdd-sync
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use after behavior-preserving refactors or implementation cleanup in SPDD to synchronize the REASONS Canvas back to the current code without changing business intent.
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# SPDD Sync
+
+Keep the prompt/spec accurate after code-side refactors. This is code-to-prompt, not requirements-to-code.
+
+**Announce at start:** "I'm using the spdd-sync skill to synchronize behavior-preserving code changes back into the canvas."
+
+## Use when
+
+- Names, files, modules, interfaces, constants, or internal decomposition changed.
+- A refactor improved maintainability without changing observable behavior.
+- Tests and boundary behavior still pass.
+- The canvas now describes an older internal structure.
+
+If behavior changed, stop and use `spdd-prompt-update` instead.
+
+## Sync process
+
+1. Read the current REASONS Canvas and the code diff.
+2. Confirm verification proves behavior is unchanged.
+3. Update only sections that describe internal implementation facts:
+   - Entities if names or responsibilities changed.
+   - Structure if files, modules, interfaces, or dependencies changed.
+   - Operations if implementation steps are now stale for future replay.
+   - Norms if a reusable convention emerged.
+4. Do not rewrite Requirements to match accidental behavior.
+5. Record why this was a refactor, not a logic correction.
+
+## Output
+
+```markdown
+## SPDD sync note
+
+### Refactor evidence
+- Behavior checks run:
+- Observable behavior changed: no
+
+### Canvas sections synchronized
+- E — Entities:
+- S — Structure:
+- O — Operations:
+- N — Norms:
+
+### Follow-up risk
+```
+
+## Completion gate
+
+The slice is not complete until `spdd-iterative-review` reports that the canvas describes the current code.

--- a/skills/using-spdd/SKILL.md
+++ b/skills/using-spdd/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: using-spdd
+version: 0.1.0
+targets: [claude-code, codex, gemini, pi]
+type: skill
+description: Use when a session is working under Structured-Prompt-Driven Development (SPDD), when prompts/specs must be versioned delivery artifacts, or when logic-heavy changes need a prompt-first closed loop.
+category:
+  primary: workflow
+  secondary: [backpressure]
+---
+
+# Using Structured-Prompt-Driven Development
+
+Structured-Prompt-Driven Development (SPDD) treats prompts as first-class delivery artifacts: versioned, reviewed, reused, and kept in sync with code.
+
+**Announce at start:** "I'm using the using-spdd skill to keep prompt assets and code in a closed loop."
+
+## Fit check
+
+Use SPDD for logic-heavy, audit-heavy, team-shared, or repeatable delivery work where intent drift is expensive. Avoid it for emergency recovery, throwaway spikes, one-off scripts, or taste-led creative work unless the user explicitly wants the governance overhead.
+
+## Non-negotiable loop
+
+1. **Clarify intent** with `spdd-alignment` before design or code.
+2. **Analyze context** with `spdd-analysis` against only relevant code and domain artifacts.
+3. **Write a REASONS Canvas** with `spdd-reasons-canvas` before implementation.
+4. **Generate/modify code from the canvas** with `spdd-generate`; no scope beyond Operations, Norms, and Safeguards.
+5. **Validate behavior first**, then review structure with `spdd-iterative-review`.
+6. **If behavior or business logic changes:** update the prompt first with `spdd-prompt-update`, then update code.
+7. **If only internal structure changes:** refactor code, prove behavior is unchanged, then sync back with `spdd-sync`.
+
+## Artifact discipline
+
+Default location: `docs/superpowers/spdd/YYYY-MM-DD-<slug>/`.
+
+A complete SPDD slice has:
+
+- `story.md` or linked requirement source.
+- `analysis.md` for domain concepts, risks, scope, and strategy.
+- `reasons-canvas.md` as the executable prompt/spec.
+- `verification.md` or test script notes mapping behavior to acceptance criteria.
+
+Keep artifacts current in the same branch as the code they govern. Never let chat-only instructions replace the canvas.
+
+## Prompt/code divergence rule
+
+When reality diverges, classify the divergence before changing anything:
+
+- **Logic correction / requirement change / acceptance mismatch:** prompt first, code second.
+- **Refactor / naming / decomposition with no observable behavior change:** code first, prompt sync second.
+- **Unclear intent:** stop implementation and return to alignment.
+
+## Required review stance
+
+Reviewers should check the intent artifact before the diff. A code change is not ready if the code passes tests but the canvas no longer describes what the system does.


### PR DESCRIPTION
Adds the SPDD bundle based on Martin Fowler's [Structured-Prompt-Driven Development](https://martinfowler.com/articles/structured-prompt-driven/) article, modeled on the superpowers bundle pattern.

## Composition

| Artifact | Name | Use |
|---|---|---|
| Cut | `spdd` | Full methodology as a work shape — `--cut spdd` |
| Accessory | `spdd-skills` | Skill-only layer for other cuts — `--accessory spdd-skills` |
| Hook | `spdd-workflow` | Claude Code SessionStart injection of `using-spdd` (included by the cut) |

The cut carries the operating frame (prompt body + hook). The accessory is the lighter option when you want the SPDD skills reachable without enforcing the work shape.

## Skills

| Skill | Purpose |
|---|---|
| `using-spdd` | Session-level workflow contract, injected by the hook |
| `spdd-story` | Optional story slicing for large requirements (INVEST) |
| `spdd-alignment` | Lock intent, domain language, scope, and acceptance criteria before design |
| `spdd-analysis` | Grounded domain/code analysis before writing the canvas |
| `spdd-reasons-canvas` | Full REASONS Canvas: Requirements, Entities, Approach, Structure, Operations, Norms, Safeguards |
| `spdd-abstraction-first` | Design review before generation — entities, responsibilities, task granularity |
| `spdd-generate` | Implement strictly inside the approved canvas boundary |
| `spdd-api-test` | Boundary-level executable scenarios covering normal, boundary, and error cases |
| `spdd-iterative-review` | Classify feedback as logic-correction or refactor before acting |
| `spdd-prompt-update` | Requirements→prompt→code for behavior changes |
| `spdd-sync` | Code→prompt sync for behavior-preserving refactors |

## SPDD loop

```
spdd-alignment → spdd-analysis → spdd-reasons-canvas
  ↓ (spdd-abstraction-first review)
spdd-generate → spdd-api-test → spdd-iterative-review
  ↓
behavior change?  → spdd-prompt-update → spdd-generate
refactor only?    → spdd-sync
```

## Hook

`spdd-workflow-session-start.sh` injects `using-spdd` at `SessionStart`. Fail-open; opt out per project with `.agent-config/spdd.disabled`. Resolves the skill from the Claude Code emitted layout first (`CLAUDE_PROJECT_DIR/.claude/skills/`), then source-tree fallbacks.

## Verified

- `bun run validate` ✅ (192 components, 4 pre-existing warnings unrelated to SPDD)
- `bun run build -- --target all --dry-run` ✅
- Hook JSON output validated in source-tree and simulated emitted Claude layouts