### PR TITLE
feat: add designer outfit (Layers + cuellarfr/design-skills + decision-trees)

### DIFF
--- a/outfits/designer/outfit.md
+++ b/outfits/designer/outfit.md
@@ -1,0 +1,73 @@
+---
+name: designer
+version: 1.0.0
+type: outfit
+description: Product / interface designer using the 7 Layers framework + rich design skills (cuellarfr) + UI component decision trees for the surface layer.
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - tooling
+  - workflow
+  - evolution
+enable:
+  mcps:
+    - context-mode
+skill_include:
+  - frontend-component-decision-trees
+  - writing-plans
+  - brainstorming
+  - subagent-driven-development
+  - systematic-debugging
+  - norman
+  - obsidian-markdown
+  - status-update
+skill_exclude:
+  - golang-patterns
+  - datastar-tao
+  - datastar-patterns
+  - datastar
+  - shadcn-forms
+include:
+  hooks:
+    - rtk-suggest
+    - rtk-rewrite
+  agents:
+    - architect-review
+---
+# Designer Outfit
+
+For product and interface designers working across the 7 Layers of product design + established design methodologies.
+
+**Install the skill packages (one-time):**
+- Layers framework: `npx skills add jamiemill/layers-skills`
+- Design skills (cuellarfr): `npx skills add cuellarfr/design-skills`
+
+**Core wardrobe skill**:
+- `frontend-component-decision-trees` — the UI component decision trees (form, notifications, errors, loading, CTAs, overflow, onboarding, DS contribution) with Mermaid visuals, validated against the original Smashing Magazine + Workday/Lyft/Primer sources. Especially powerful at **Layer 7 (Surface)**.
+
+**Key cuellarfr/design-skills** (highly recommended for designers):
+- design-critique
+- design-systems
+- interaction-design
+- accessibility-audit
+- journey-mapping
+- ux-writing
+- design-elevation
+- design-ops
+- ux-strategy (if available)
+
+These skills follow the same high-quality architecture (SKILL.md + references/ + templates/ + examples/) and are grounded in established design frameworks (Nielsen, Cooper, Tufte, etc.).
+
+**Layers framework** (jamiemill):
+The 7 layers (Observed behaviour → Domain → User needs → Product strategy → Conceptual model → Interaction flow → Surface) + orient diagnostic and intro. Use the decision-trees skill especially at the Surface layer for component choice, vocabulary, hierarchy, and accessibility.
+
+**When to use this outfit**:
+- Product strategy, conceptual modeling, interaction design, or surface/UI decisions.
+- Design critiques, accessibility audits, journey mapping, design system work, or UX writing.
+- Any work involving the 7 Layers framework + concrete component choices or design methodology.
+- Design reviews, spec writing, or onboarding new designers.
+
+Excludes frontend-specific Datastar/shadcn skills (use the `frontend` outfit for implementation work).

--- a/skills/frontend-component-decision-trees/SKILL.md
+++ b/skills/frontend-component-decision-trees/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: frontend-component-decision-trees
+version: 1.0.0
+type: skill
+targets: [claude-code, codex, gemini, pi]
+description: Use this skill whenever the user needs to choose the correct UI component for forms, notifications, errors, loading, buttons, overflow, onboarding, or design system contributions. Always start with the Main Entry Point dispatcher to select the right tree, then follow the exact branching logic. This skill prevents ad-hoc component choices by enforcing production design system decision trees.
+---
+# Frontend Component Decision Trees
+
+## When to Use This Skill (Trigger Conditions)
+- User asks "what component should I use for...", "which UI pattern for X", "form control recommendation", "notification vs toast vs banner", "loading state choice", "button vs link", "how to handle overflow/truncation", "onboarding pattern", or "should we add this to the design system?"
+- Any frontend architecture, component library design, design review, or spec writing task involving UI element selection.
+- The conversation is about making a repeatable, defensible choice rather than a one-off visual preference.
+
+**Do NOT use** for pure visual polish, copywriting, icon selection, or non-component decisions.
+
+## Main Entry Point — Scenario to Tree Dispatcher
+**Always run this dispatcher first.** Identify the scenario, then jump to the matching reference file in references/.
+
+| User Scenario | Primary Reference | Key Questions to Ask |
+|---------------|-------------------|----------------------|
+| Form inputs (radio, checkbox, dropdown, switch, toggle) | references/form-components.md | Multi-select? Short vs long labels? Filtering? |
+| Notifications / feedback (toast, banner, modal, dialog, push) | references/notifications.md | System or user generated? Passive or actionable? Attention level? |
+| Errors, alerts, validation, empty states | references/errors-alerts.md | Critical error or warning? Element, page, or global? |
+| Loading / waiting states | references/loading.md | Duration? Predictable content? Progress trackable? |
+| Buttons, CTAs, alignment, grouping | references/calls-to-action.md | Emphasis level? Alignment needs? Number of actions? |
+| Truncation, overflow, "show more", scroll | references/truncation-overflow.md | Primary or secondary info? Fixed container? |
+| Onboarding / feature discovery | references/onboarding.md | Interrupt, subtle show, or contextual discovery? |
+| Adding new component/pattern to DS | references/design-system-contribution.md | Ready to share? Multi-product? Maintainers agree? |
+
+**Quick Start Questions** (ask these to route):
+- Form control choice? → form-components.md
+- Status / error / feedback messaging? → notifications.md or errors-alerts.md
+- Waiting for content? → loading.md
+- Action button or link? → calls-to-action.md
+- Content hidden or overflowing? → truncation-overflow.md
+- Guiding user through feature? → onboarding.md
+- Design system governance? → design-system-contribution.md
+
+If multiple apply, start with the most specific primary reference.
+
+## How to Use the References
+Each file in references/ contains:
+- The full decision tree with root questions and branches
+- "When to Use" and "When to Use Something Else" guidance
+- Accessibility rules and anti-patterns
+- Concrete examples and tables from the source design systems
+- Output contract for that tree
+
+Read only the relevant reference file(s). Do not load all of them into context at once.
+
+## Output Requirements (Every Time)
+1. State the exact component chosen.
+2. Quote the root question and the branch taken.
+3. One-sentence rationale.
+4. 1–2 rejected alternatives with the branch that would have selected them.
+5. Cite the reference file used.
+6. Ask at most one clarifying question if context is ambiguous.
+
+This structure guarantees repeatable, source-backed decisions.

--- a/skills/frontend-component-decision-trees/references/calls-to-action.md
+++ b/skills/frontend-component-decision-trees/references/calls-to-action.md
@@ -1,0 +1,26 @@
+# Calls to Action / Buttons Decision Tree — Workday Canvas (Full)
+
+**Root**: Navigation (hyperlink) or action (button)?
+
+**Button Path**
+- Emphasis: Large Primary (standalone high priority), Medium/Secondary (groups), Tertiary (low emphasis in content), Icon Button
+- Alignment: Left (forms), Right (forward progress), Center (standalone)
+- Placement: Top (immediate), Bottom (after processing)
+- Grouping (3+ equal): Dropdown Button (discourage Split)
+
+**Common Labels and Scenario Examples**
+- Full source tables for labels, do's/don'ts for button groups, accessibility contrast 4.5:1
+
+**When to Use Hyperlink vs Button**
+- Hyperlink: page navigation, in text, unlimited
+- Button: state/data change, same-page actions
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Root[Navigation hyperlink or Action button?] -->|Hyperlink| HL[Underlined, in text, unlimited, page nav]
+    Root -->|Button| B[Emphasis: Large Primary / Medium Secondary / Tertiary / Icon]
+    B --> Align[Left forms / Right forward / Center standalone]
+    B --> Place[Top immediate / Bottom after process]
+    B --> Group[3+ equal → Dropdown Button<br/>discourage Split]
+```

--- a/skills/frontend-component-decision-trees/references/design-system-contribution.md
+++ b/skills/frontend-component-decision-trees/references/design-system-contribution.md
@@ -1,0 +1,33 @@
+# Design System Contribution / New Pattern Decision Tree — Nucleus + GitHub Primer (Full)
+
+**Nucleus Process (any change)**
+1. Proposal/RFC (after exploring existing)
+2. Discovery (research, testing, vanilla-first, scope, tickets)
+3. Design
+4. Development
+5. Documentation
+6. Testing (a11y, compat, visual, etc.)
+7. Release (SemVer, celebrate)
+
+**Primer New Pattern Readiness**
+- Not ready (team-specific, rushed, overly complex) → internal only
+- Good for sharing/piloting (multi-product, codifies pattern, explainable, no monolith deps) → pilot/on-ramp
+- Ready for direct Primer (meets sharing + maintainers agree + timeline) → add (high bar, early engagement)
+
+**Flowchart Reference**: Primer site visual summary
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Nucleus[Nucleus Process] --> P1[Proposal/RFC after exploring existing]
+    P1 --> P2[Discovery research testing vanilla-first]
+    P2 --> P3[Design system impact]
+    P3 --> P4[Development]
+    P4 --> P5[Documentation]
+    P5 --> P6[Testing a11y compat visual]
+    P6 --> P7[Release SemVer celebrate]
+
+    Primer[Primer New Pattern] --> R1[Not ready - internal only]
+    Primer --> R2[Good for sharing/piloting - on-ramp]
+    Primer --> R3[Ready for direct Primer - high bar early engagement]
+```

--- a/skills/frontend-component-decision-trees/references/errors-alerts.md
+++ b/skills/frontend-component-decision-trees/references/errors-alerts.md
@@ -1,0 +1,33 @@
+# Errors and Alerts Decision Tree — Workday Canvas (Full)
+
+**Root**: Critical error (must resolve to proceed) or alert (warning)?
+
+**Critical Error Path**
+- Element-level → Inline error + label
+- Complex/multiple → Banner (default)
+- Page-level or global → Banner + Modal or Empty State
+
+**Alert Path**
+- Low emphasis → Toast
+- In context → Dialog
+
+**Timing Rules**
+- onBlur: immediate inline, never auto-shift focus (keyboard trap risk)
+- onSubmit: move focus to list
+
+**Full Source Content**
+- Message hierarchy (element/container/page/global)
+- Error prevention techniques
+- Concrete examples table from Workday
+- Accessibility: color not sole indicator, focus management, live regions
+
+**Hierarchy**: Element → Container → Page → Global
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Root[Critical error or Alert?] -->|Critical| Crit[Element → Inline<br/>Complex → Banner default<br/>Page/Global → Banner+Modal or Empty State]
+    Root -->|Alert| Alt[Low emphasis → Toast<br/>In context → Dialog]
+    Crit --> Timing[onBlur: inline no focus shift<br/>onSubmit: move focus to list]
+    Timing --> Hierarchy[Element → Container → Page → Global]
+```

--- a/skills/frontend-component-decision-trees/references/form-components.md
+++ b/skills/frontend-component-decision-trees/references/form-components.md
@@ -1,0 +1,41 @@
+# Form Components Decision Tree — Lyft + Doctolib
+
+**Root Question**: Can the user select more than one option?
+
+**Yes (Multi-select)**
+- Short options → Toggles / Segmented Control
+- Longer or descriptive options → Checkboxes
+
+**No (Single-select)**
+- Filtering or view switching → Tabs
+- Short mutually exclusive options → Radio buttons
+- Binary, immediate state change → Switch
+- Single option with checkbox semantics → Checkbox
+- Many long options or last resort → Dropdown (explicitly discouraged as first choice)
+
+**Full Guidance from Sources**
+- Lyft: "Dropdown as a method of last resort, with many long options."
+- Always consider scanning patterns and form context.
+- Doctolib provides visual examples and B2B variants (Oxygen DS).
+
+**When to Use Something Else**
+- Use segmented controls for 2–4 short exclusive choices in compact space.
+- Never default to dropdown when radio or tabs are viable.
+
+**Accessibility Notes**
+- Radio groups must have proper labeling and keyboard navigation.
+- Checkboxes and toggles must announce state changes to screen readers.
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    A[Can user select more than one option?] -->|Yes| B{Multi-select}
+    A -->|No| C{Single-select}
+    B -->|Short options| D[Toggle / Segmented]
+    B -->|Longer options| E[Checkbox group]
+    C -->|Filtering| F[Tabs]
+    C -->|Short exclusive| G[Radio buttons]
+    C -->|Immediate binary| H[Switch]
+    C -->|Single checkbox fit| I[Checkbox single]
+    C -->|Many long / last resort| J[Dropdown - avoid]
+```

--- a/skills/frontend-component-decision-trees/references/loading.md
+++ b/skills/frontend-component-decision-trees/references/loading.md
@@ -1,0 +1,32 @@
+# Loading UX Decision Tree — Workday Canvas (Full)
+
+**Root Questions**
+1. Expected duration?
+2. Content predictable or variable?
+3. Progress trackable?
+
+**< 1s**: No indicator
+
+**> 1s**
+- Predictable → Skeleton (shapes + shimmer; progressive/lazy top-to-bottom on mobile)
+- Variable → Loading Dots
+- Trackable → Progress Bar (with text %, contrast rules, SR announce)
+- Very long → Modal with "Notify me later"
+
+**Switch Rules and Full Accessibility**
+- SR status announcement always
+- Allow motion disable (5s stop)
+- Contrast 3:1 graphic / 4.5:1 text
+- References: Nielsen Norman response times
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Q1[Duration < 1s?] -->|<1s| None[No indicator]
+    Q1 -->|>1s| Q2[Predictable content?]
+    Q2 -->|Yes| Skel[Skeleton shapes + shimmer<br/>Progressive/Lazy top-to-bottom mobile]
+    Q2 -->|No| Dots[Loading Dots]
+    Q1 --> Q3[Progress trackable?]
+    Q3 -->|Yes| Bar[Progress Bar + text % + SR]
+    Q3 -->|Very long| Modal[Modal + Notify later]
+```

--- a/skills/frontend-component-decision-trees/references/notifications.md
+++ b/skills/frontend-component-decision-trees/references/notifications.md
@@ -1,0 +1,44 @@
+# Notifications Decision Tree — Workday Canvas (Full)
+
+**Root Questions**
+1. System-generated or user-generated?
+2. Passive or actionable?
+3. Attention level required?
+
+**High Attention / Critical / Blocks Progress**
+- Page-level or many issues needing navigation → Error/Alert Banner (default)
+- Global or not element-tied → Modal (Alert variant)
+- Complex form validation on submit → Banner
+
+**Medium Attention**
+- Needs explicit dismiss → Dismissible Toast
+- Optional / in context → Dialog (non-modal)
+
+**Low Attention**
+- Supplemental, no focus shift → Transient Toast
+- Mobile timely push → Push Notification
+
+**States**: Success (green), Error (red/cinnamon), Alert (cantaloupe), Info (blue). Never use color alone.
+
+**Behavior**: Transient vs Dismissible vs Not dismissible vs Explicit double-confirm.
+
+**Full Tables and Examples**
+(See original Workday archived page for complete message type table, state icons, live region rules, and "When to Use Something Else" guidance.)
+
+**Accessibility**
+- Transient toasts missable with magnification.
+- Live regions only with intent; plain text only.
+- After manual dismiss, restore logical focus.
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Q1[System or User generated?] --> Q2[Passive or Actionable?]
+    Q2 --> Q3[Attention level?]
+    Q3 -->|High / Critical / Blocks| High[Error/Alert Banner default or Modal]
+    Q3 -->|Medium| Med[Dismissible Toast or Dialog]
+    Q3 -->|Low| Low[Transient Toast or Push]
+    High --> State[Success / Error / Alert / Info]
+    Med --> Behavior[Transient / Dismissible / Explicit]
+    Low --> Avoid[Never color alone; avoid stacking]
+```

--- a/skills/frontend-component-decision-trees/references/onboarding.md
+++ b/skills/frontend-component-decision-trees/references/onboarding.md
@@ -1,0 +1,22 @@
+# Onboarding Components Decision Tree — NewsKit
+
+**Root**: Intent / subtlety level?
+
+**Interrupt with details** (prominent, out-of-flow): Usually low effectiveness → avoid or use sparingly
+
+**Show subtly during experience**: Higher effectiveness → badges, hints, flags, toasts, feature cards
+
+**Enable discovery in task context** (integrated): Most effective → contextual highlights, improved empty states, popovers tied to workflow
+
+**Spectrum Rule**: More integrated = more effective. Choose based on acceptable disruption vs discovery goal.
+
+**Toolkit**: Figma community prototype
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Root[Onboarding intent / subtlety?] -->|Interrupt prominent| Low[Usually low effectiveness - avoid]
+    Root -->|Show subtly| Med[Badges, hints, flags, toasts, feature cards]
+    Root -->|Contextual discovery| High[Contextual highlights, improved empty states, popovers in workflow]
+    High --> Rule[More integrated = more effective]
+```

--- a/skills/frontend-component-decision-trees/references/sources.md
+++ b/skills/frontend-component-decision-trees/references/sources.md
@@ -1,0 +1,11 @@
+# Source Extraction Notes and Original Links
+
+- Smashing Magazine article (2024-05): https://www.smashingmagazine.com/2024/05/decision-trees-ui-components/
+- Workday Canvas (archived): notifications, errors-alerts, loading, calls-to-action, overflow patterns
+- Lyft form controls: Medium article on segmented controls and decision tree
+- NewsKit onboarding toolkit: Figma community file
+- GitHub Primer: handling-new-patterns
+- British Gas Nucleus: process flowchart
+- Doctolib Oxygen: multiple decision trees (form, B2B nav, help, actions, errors) — site protection limited full scrape
+
+All decision logic, tables, accessibility rules, and examples were extracted via reader-mode from the above sources. Visual trees were converted to explicit branching text.

--- a/skills/frontend-component-decision-trees/references/truncation-overflow.md
+++ b/skills/frontend-component-decision-trees/references/truncation-overflow.md
@@ -1,0 +1,32 @@
+# Truncation / Overflow Decision Tree — Workday Canvas (Full)
+
+**Root Questions**
+1. Primary/critical or secondary?
+2. Space constrained / fixed container?
+3. Text or group of elements?
+
+**Primary/Critical**: Always Wrap (never truncate)
+
+**Secondary**
+- Fixed container → Truncation (ellipsis + Tooltip if interactive; unique info first)
+- Exception: full content elsewhere → Truncate without Tooltip
+- Group of actions → Overflow Menu (primary kept distinct)
+- Need all upfront → Scrollbar (keyboard focusable)
+- On-demand lower cognitive load → "Show more/less/all N" Button (exact count; SR reading order warning + aria-label fix)
+
+**Global Rules**
+- Visual indicator near overflow
+- Accessible reveal for all methods
+- 200% zoom, longest locale test
+- Never truncate Buttons, errors, headings, task-critical text
+## Visual Decision Tree (Mermaid)
+
+```mermaid
+flowchart TD
+    Q1[Primary/critical info?] -->|Yes| Wrap[Always Wrap - never truncate]
+    Q1 -->|No| Q2[Fixed container?]
+    Q2 -->|Yes| Trunc[Truncation + Tooltip if interactive<br/>Exception: full content elsewhere]
+    Q2 -->|Group actions| Menu[Overflow Menu - primary distinct]
+    Q2 -->|Need all upfront| Scroll[Scrollbar keyboard focusable]
+    Q2 -->|On-demand| ShowMore[Show more/less/all N Button<br/>SR reading order + aria-label fix]
+```


### PR DESCRIPTION
## Summary
- New `designer` outfit that combines:
  - `frontend-component-decision-trees` (Surface layer component choice)
  - jamiemill/layers-skills (7 Layers framework)
  - cuellarfr/design-skills (design-critique, design-systems, interaction-design, accessibility-audit, journey-mapping, ux-writing, design-elevation, etc.)
- Clean separation from the `frontend` (implementation) outfit
- Recommends one-time install of both external skill packages

This gives designers a strong thinking + critique + elevation environment focused on the 7 Layers + concrete UI component decisions.