### PR TITLE
feat: junior-frontend-engineer outfit with Waza skills + orchestrator

### DIFF
--- a/outfits/junior-frontend-engineer/hooks/hooks.json
+++ b/outfits/junior-frontend-engineer/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/outfits/junior-frontend-engineer/hooks/session-start.sh
+++ b/outfits/junior-frontend-engineer/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# junior-frontend-engineer session start hook
+# Injects the orchestrator skill into every new session started with this outfit
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
+ORCHESTRATOR_SKILL="$SKILLS_DIR/orchestrator/SKILL.md"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"priority": "INFO", "message": "junior-frontend-engineer: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable orchestrator injection. The outfit is still active."}'
+  exit 0
+fi
+
+if [ -f "$ORCHESTRATOR_SKILL" ]; then
+  CONTENT=$(cat "$ORCHESTRATOR_SKILL")
+  jq -cn \
+    --arg message "junior-frontend-engineer outfit loaded. Orchestrator active:
+
+$CONTENT" \
+    '{priority: "IMPORTANT", message: $message}'
+else
+  echo '{"priority": "INFO", "message": "junior-frontend-engineer: orchestrator SKILL.md not found. Outfit is active but orchestrator knowledge was not injected."}'
+fi


### PR DESCRIPTION
## Summary
Adds `junior-frontend-engineer` outfit that bundles the four primary Waza skills (design, check, hunt, health) for junior FE work together with a lightweight orchestrator that lodges at session start and suggests the right skill for common FE situations.

## Changes
- New outfit directory with session-start hook (agent-skills pattern) and hooks.json
- Orchestrator registers NATS Micro service on `waza.junior-frontend-engineer.suggest`
- Maps FE situations to Waza skills (component → design, PR → check, regression → hunt, drift → health)
- Subagent activation via suit/outfit (not only global session-start)
- Cross-harness: NATS primary, suit/outfit fallback, pure skill description for harnesses without the bus

## Research Backing
- Waza AGENTS.md boundaries respected (orchestrator is deterministic router only)
- Session-start scope clarified (main harness vs subagent)
- Patterns taken from agent-skills (meta-skill, core behaviors, composition rule) and ECC (superpowers routing hints)
- Avoids global hook pollution for subagents

## Local CI
`npm run validate` and `npm run build -- --target all --dry-run` both green (only pre-existing warnings).

## Next
The outfit is the vehicle for the orchestrator pattern discussed in the plan. Further enrichment (core behaviors, personas, references) can land in follow-up PRs.