### PR TITLE
Add publish-html-page skill

### DIFF
--- a/outfits/junior-frontend-engineer/orchestrator.md
+++ b/outfits/junior-frontend-engineer/orchestrator.md
@@ -1,0 +1,58 @@
+---
+name: junior-fe-orchestrator
+type: orchestrator
+registration: nats-micro
+service: waza.junior-frontend-engineer
+suggest_subject: waza.junior-frontend-engineer.suggest
+---
+
+# Junior Frontend Engineer Orchestrator
+
+This orchestrator registers as a NATS Micro service at session start and exposes a suggestion endpoint. It never executes skills.
+
+## Registration
+At session start it calls `nats micro add` (or SDK equivalent) on `waza.junior-frontend-engineer.suggest`. Inbound requests are situation descriptions; replies are skill suggestions.
+
+## Core Operating Behaviors
+These apply whenever the orchestrator is active.
+
+### 1. Surface Assumptions
+Before suggesting a skill, state the key assumptions about the current situation.
+
+### 2. Manage Confusion
+When signals are ambiguous, ask one clarifying question instead of guessing.
+
+### 3. Enforce Simplicity & Scope
+Recommend the smallest sufficient skill. Never suggest secondary skills unless the primary path is blocked.
+
+### 4. Verify Before Suggesting
+Only suggest a skill when the situation clearly matches its outcome contract.
+
+## FE Lifecycle Sequence
+1. New UI or visual work → design (direction-lock first)
+2. Diff / PR / pre-merge → check
+3. Something broke or regressed → hunt
+4. Config drift or instruction issues → health
+5. Planning or research needed → think / learn (secondary)
+
+## Skill Map
+| Situation | Primary skill | Invocation |
+|---|---|---|
+| Building or styling a component, page, or UI surface | design | /design |
+| Code review, PR readiness, or pre-merge check | check | /check |
+| Visual bug, regression, or something that used to work | hunt | /hunt |
+| Agent config drift, missing hooks/MCP, or AGENTS.md stale | health | /health |
+
+## Superpowers-Style Routing Hints
+- After design → consider check for visual regression review
+- After hunt → consider health if the root cause was config-related
+- After check → consider health if the review surfaced instruction drift
+
+## Subagent Activation
+This orchestrator is loaded per-outfit via suit/outfit mechanisms for spawned workers. It is not dependent on global session-start hooks alone.
+
+## Constraints
+- Suggest only. Never auto-invokes.
+- One skill per suggestion.
+- No escalation without signal.
+- References: references/orchestration-patterns.md and references/superpowers-routing.md.

--- a/outfits/junior-frontend-engineer/outfit.md
+++ b/outfits/junior-frontend-engineer/outfit.md
@@ -1,0 +1,47 @@
+---
+name: junior-frontend-engineer
+version: 0.2.0
+type: outfit
+description: Junior frontend engineer - full Waza skills + orchestrator with decision trees and core behaviors.
+targets:
+  - claude-code
+  - codex
+  - gemini
+  - pi
+categories:
+  - workflow
+  - backpressure
+  - tooling
+  - context-management
+enable:
+  mcps:
+    - context-mode
+include:
+  hooks:
+    - junior-fe-orchestrator
+  agents:
+    - junior-frontend-engineer
+---
+
+# Junior Frontend Engineer Outfit (v2)
+
+Complete outfit bundling the four primary Waza skills with a full orchestrator that includes core operating behaviors, FE lifecycle decision tree, and superpowers-style routing hints.
+
+## Orchestrator
+See `orchestrator.md` for the full routing logic, NATS registration, subagent activation model, and decision trees.
+
+## Primary Skills (Waza)
+- design (UI, tokens, direction-lock, a11y, screenshot iteration)
+- check (review, visual regression, release gates)
+- hunt (rendering bugs, DevTools diagnosis)
+- health (config drift, maintainability)
+
+## Secondary Skills
+think, learn, read, write available on request.
+
+## Activation
+- Main session: NATS Micro on `waza.junior-frontend-engineer.suggest`
+- Subagents: automatic via suit/outfit when spawned with this outfit
+- Cross-harness fallback: skill description + outfit context
+
+The orchestrator is suggest-only. No auto-execution.

--- a/outfits/junior-frontend-engineer/references/orchestration-patterns.md
+++ b/outfits/junior-frontend-engineer/references/orchestration-patterns.md
@@ -1,0 +1,15 @@
+# Orchestration Patterns (from agent-skills)
+
+## Pattern 1: Direct Invocation
+User types the skill trigger directly. Orchestrator is silent.
+
+## Pattern 2: Single-Persona Command
+A saved prompt or command that includes the orchestrator suggestion.
+
+## Pattern 3: Parallel Fan-out
+Multiple workers spawned with the same outfit; each gets the orchestrator.
+
+## Pattern 4: Sequential User-Driven
+User follows orchestrator suggestions one at a time (recommended for junior FE).
+
+The orchestrator in this outfit supports Pattern 4 by default and Pattern 3 when workers are spawned with the outfit.

--- a/outfits/junior-frontend-engineer/references/superpowers-routing.md
+++ b/outfits/junior-frontend-engineer/references/superpowers-routing.md
@@ -1,0 +1,10 @@
+# Superpowers-Style Routing Hints (from ECC)
+
+These are lightweight suggestions embedded in the orchestrator, not executable links.
+
+- After design → consider check for visual regression review
+- After hunt → consider health if the root cause was config-related
+- After check → consider health if the review surfaced instruction drift
+- health → design (when config issues affect UI consistency)
+
+Use these only as follow-on suggestions after the primary skill completes.

--- a/personas/junior-frontend-engineer.md
+++ b/personas/junior-frontend-engineer.md
@@ -1,0 +1,21 @@
+---
+name: junior-frontend-engineer
+role: junior frontend engineer
+outfit: junior-frontend-engineer
+orchestrator: orchestrator.md
+description: Persona for junior frontend work using the four primary Waza skills with orchestrator routing.
+---
+
+# Junior Frontend Engineer Persona
+
+## Composition Rule
+This persona routes situations to the appropriate Waza skill via the orchestrator. It never executes skills itself. The user or operator decides when to invoke the suggested skill.
+
+## When Active
+Use this persona when the work is primarily frontend UI, component work, visual review, debugging of rendering issues, or agent config health for a junior engineer.
+
+## Primary Skills
+design, check, hunt, health (see orchestrator.md for mapping)
+
+## Secondary Skills
+think, learn, read, write (available on explicit request)

--- a/skills/publish-html-page/SKILL.md
+++ b/skills/publish-html-page/SKILL.md
@@ -3,6 +3,8 @@ name: publish-html-page
 version: 1.0.0
 type: skill
 targets: [claude-code, codex, gemini, pi]
+category:
+  primary: integrations
 description: Publish a self-contained HTML file to a shareable encrypted Cloudflare-hosted artifact URL using html-artifact-publisher. Use when asked to upload, publish, share, or host a generated HTML page/artifact/explainer via artifacts.craftdesign.group or the HTML artifact publisher.
 ---
 

--- a/skills/publish-html-page/SKILL.md
+++ b/skills/publish-html-page/SKILL.md
@@ -4,15 +4,6 @@ version: 1.0.0
 type: skill
 targets: [claude-code, codex, gemini, pi]
 description: Publish a self-contained HTML file to a shareable encrypted Cloudflare-hosted artifact URL using html-artifact-publisher. Use when asked to upload, publish, share, or host a generated HTML page/artifact/explainer via artifacts.craftdesign.group or the HTML artifact publisher.
-triggers:
-  - publish html artifact
-  - share html explainer
-  - upload html to cloudflare
-  - upload html to an artifact publisher
-  - generate and share html
-env_required:
-  - HTML_PUBLISHER_URL
-  - HTML_PUBLISHER_TOKEN
 ---
 
 # publish-html-page

--- a/skills/publish-html-page/SKILL.md
+++ b/skills/publish-html-page/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: publish-html-page
+version: 1.0.0
+type: skill
+targets: [claude-code, codex, gemini, pi]
+description: Publish a self-contained HTML file to a shareable encrypted Cloudflare-hosted artifact URL using html-artifact-publisher. Use when asked to upload, publish, share, or host a generated HTML page/artifact/explainer via artifacts.craftdesign.group or the HTML artifact publisher.
+triggers:
+  - publish html artifact
+  - share html explainer
+  - upload html to cloudflare
+  - upload html to an artifact publisher
+  - generate and share html
+env_required:
+  - HTML_PUBLISHER_URL
+  - HTML_PUBLISHER_TOKEN
+---
+
+# publish-html-page
+
+Publish a self-contained HTML file to a shareable encrypted URL. The Worker stores encrypted HTML bytes; metadata such as title, source name, expiry, and slug remains plaintext. The decryption key lives only in the URL `#fragment` and never reaches the server.
+
+## Use when
+
+Use after generating a standalone HTML explainer, report, prototype, or artifact file that should be viewable by URL. Confirm the file is self-contained first: inline assets are preferred; external URLs may leak referrer data or fail offline.
+
+## Implementation location
+
+Run the colocated publisher from the wardrobe repo root (Node 22+ required):
+
+```bash
+node skills/publish-html-page/scripts/publish-html.mjs [options] <file.html>
+```
+
+Required environment:
+
+```bash
+HTML_PUBLISHER_URL=https://artifacts.craftdesign.group
+HTML_PUBLISHER_TOKEN=<bearer token>
+```
+
+Never print, persist, or pass the bearer token in a way that exposes it in logs.
+
+## CLI reference
+
+```bash
+node skills/publish-html-page/scripts/publish-html.mjs [options] <file.html>
+
+  --title <text>     Human-readable title (default: filename)
+  --ttl <duration>   1h | 6h | 24h | 7d | 30d | never  (default: 7d)
+  --slug <slug>      Optional vanity slug
+  --delete-local     Delete local HTML only after confirmed successful upload
+  --json             Machine-readable JSON output only
+  --copy             Copy viewer URL to clipboard even with --json
+  --no-clipboard     Never attempt clipboard copy
+```
+
+## Workflow
+
+1. Confirm the target file starts with `<!doctype html` or `<html`.
+2. Prefer `--json` when running as an agent so stdout is parseable.
+3. Set `HTML_PUBLISHER_URL` and `HTML_PUBLISHER_TOKEN` through the tool environment, not inline in prose.
+4. Run the publisher with a useful `--title` and appropriate `--ttl`.
+5. Return only `viewerUrl` unless the user needs deletion/revocation details.
+6. Preserve and report `warningMessages`; external-resource warnings matter.
+
+Example:
+
+```bash
+HTML_PUBLISHER_URL=https://artifacts.craftdesign.group \
+HTML_PUBLISHER_TOKEN="$HTML_PUBLISHER_TOKEN" \
+node skills/publish-html-page/scripts/publish-html.mjs /path/to/page.html --title "Artifact title" --ttl 30d --json
+```
+
+## Rules
+
+- Share the full `viewerUrl`, including the `#fragment`; without it the browser cannot decrypt.
+- Treat `viewerUrl` as a secret-bearing link: anyone with the full URL can read the artifact.
+- Do not expose `deleteToken` unless the user may need to revoke the artifact early.
+- Use `--delete-local` only for files generated in the current session and only after upload succeeds.
+- Never delete the source file manually before upload completes.
+- If upload fails, leave the file untouched and report the exact error.
+- Clipboard copy is best-effort; failure does not mean upload failed.
+
+## Success output
+
+```json
+{
+  "id": "abc123",
+  "viewerUrl": "https://artifacts.craftdesign.group/v/abc123#<base64url-key>",
+  "blobUrl": "https://artifacts.craftdesign.group/blob/abc123",
+  "expiresAt": "2026-07-23T00:00:00.000Z",
+  "deleteToken": "deadbeef…",
+  "warnings": 0,
+  "warningMessages": []
+}
+```

--- a/skills/publish-html-page/scripts/publish-html.mjs
+++ b/skills/publish-html-page/scripts/publish-html.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// publish-html.mjs — upload a standalone HTML file to an encrypted artifact Worker
+// Node 22+ required (Wrangler 4.x tooling requires Node 22+; CI uses Node 24)
+
+import { readFileSync, unlinkSync } from 'node:fs';
+import { basename } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+function hasFlag(flag) {
+  return args.includes(flag);
+}
+
+function flagValue(flag) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+if (hasFlag('--help') || hasFlag('-h')) {
+  console.log(`
+Usage: node scripts/publish-html.mjs [options] <file.html>
+
+Options:
+  --title <text>     Title for the artifact (default: filename)
+  --ttl <duration>   Time-to-live: 1h, 6h, 24h, 7d, 30d, never (default: 7d)
+  --slug <slug>      Optional vanity slug
+  --delete-local     Delete the local HTML file after a successful upload
+  --json             Print only machine-readable JSON (no friendly output)
+  --copy             Copy the viewer URL to clipboard even with --json
+  --no-clipboard     Never attempt to copy the viewer URL to clipboard
+  --help             Show this help
+
+Environment variables (required):
+  HTML_PUBLISHER_URL    Base URL of the publisher Worker
+  HTML_PUBLISHER_TOKEN  Bearer token for the Worker API
+
+Clipboard:
+  Human output (no --json): viewer URL is copied to clipboard automatically.
+  Machine output (--json): clipboard is skipped unless --copy is also given.
+  Use --no-clipboard to suppress clipboard in any mode.
+
+Share URL format:
+  https://<your-domain>/v/<id>#<base64url-key>
+  The decryption key lives only in the URL fragment — the server never sees it.
+`);
+  process.exit(0);
+}
+
+const jsonOnly    = hasFlag('--json');
+const deleteLocal = hasFlag('--delete-local');
+const copyFlag    = hasFlag('--copy');
+const noClipboard = hasFlag('--no-clipboard');
+const titleFlag   = flagValue('--title');
+const ttlFlag     = flagValue('--ttl') ?? '7d';
+const slugFlag    = flagValue('--slug');
+
+// Copy to clipboard unless: explicitly suppressed, or machine mode without --copy
+const shouldCopy = !noClipboard && (!jsonOnly || copyFlag);
+
+// Collect positional arguments (not flags and not their values)
+const flagsWithValues = new Set(['--title', '--ttl', '--slug']);
+const positional = [];
+for (let i = 0; i < args.length; i++) {
+  if (flagsWithValues.has(args[i])) { i++; continue; }
+  if (args[i].startsWith('-'))       continue;
+  positional.push(args[i]);
+}
+
+const filePath = positional[0];
+if (!filePath) {
+  console.error('Error: HTML file path is required.\nRun with --help for usage.');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// TTL parsing
+// ---------------------------------------------------------------------------
+
+function parseTtl(raw) {
+  if (raw === 'never') return 0;
+  const m = raw.match(/^(\d+)(h|d)$/);
+  if (!m) {
+    console.error(`Error: invalid --ttl "${raw}". Expected e.g. 1h, 6h, 24h, 7d, 30d, never`);
+    process.exit(1);
+  }
+  const n = parseInt(m[1], 10);
+  return m[2] === 'h' ? n * 3_600 : n * 86_400;
+}
+
+const ttlSeconds = parseTtl(ttlFlag);
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+const baseUrl = process.env.HTML_PUBLISHER_URL?.replace(/\/$/, '');
+const token   = process.env.HTML_PUBLISHER_TOKEN;
+
+if (!baseUrl) {
+  console.error('Error: HTML_PUBLISHER_URL environment variable is required');
+  process.exit(1);
+}
+if (!token) {
+  console.error('Error: HTML_PUBLISHER_TOKEN environment variable is required');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Read & validate
+// ---------------------------------------------------------------------------
+
+let html;
+try {
+  html = readFileSync(filePath, 'utf8');
+} catch (err) {
+  console.error(`Error reading file: ${err.message}`);
+  process.exit(1);
+}
+
+const trimmedLower = html.trimStart().toLowerCase();
+if (!trimmedLower.startsWith('<!doctype html') && !trimmedLower.startsWith('<html')) {
+  console.error(
+    'Error: file does not appear to be a standalone HTML document.\n' +
+    '  Expected content to start with <!doctype html or <html',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Scan for external references
+// ---------------------------------------------------------------------------
+
+const warnings = [];
+
+// Catch all http/https URLs anywhere in the document
+const urlMatches = html.match(/https?:\/\/[^\s"'>)\]]+/g) ?? [];
+const uniqueUrls = [...new Set(urlMatches)];
+for (const url of uniqueUrls) {
+  warnings.push(`external URL: ${url}`);
+}
+
+if (warnings.length > 0 && !jsonOnly) {
+  console.warn(`\nWarning: ${warnings.length} external reference(s) detected.`);
+  const sample = warnings.slice(0, 10);
+  for (const w of sample) console.warn(`  Warning: ${w}`);
+  if (warnings.length > 10) console.warn(`  … and ${warnings.length - 10} more`);
+  console.warn(
+    '  Artifact may not render offline and could leak referrer information.\n',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt with AES-256-GCM (Web Crypto — no import needed in Node 20+)
+// ---------------------------------------------------------------------------
+
+const plaintext = new TextEncoder().encode(html);
+
+const key = await globalThis.crypto.subtle.generateKey(
+  { name: 'AES-GCM', length: 256 },
+  /* extractable */ true,
+  ['encrypt', 'decrypt'],
+);
+
+const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+
+const ciphertextBuf = await globalThis.crypto.subtle.encrypt(
+  { name: 'AES-GCM', iv },
+  key,
+  plaintext,
+);
+
+const rawKey = await globalThis.crypto.subtle.exportKey('raw', key);
+
+// SHA-256 of ciphertext — the Worker can verify this without decrypting.
+const sha256Buf = await globalThis.crypto.subtle.digest('SHA-256', ciphertextBuf);
+const sha256Hex = Array.from(new Uint8Array(sha256Buf))
+  .map((b) => b.toString(16).padStart(2, '0'))
+  .join('');
+
+// Base64url encode (Buffer.from supports 'base64url' in Node 16+)
+const toB64u = (buf) => Buffer.from(buf).toString('base64url');
+
+const encryptedPayload = toB64u(ciphertextBuf);
+const ivB64u           = toB64u(iv);
+const keyB64u          = toB64u(rawKey);
+
+// ---------------------------------------------------------------------------
+// POST /api/pages
+// ---------------------------------------------------------------------------
+
+const sourceName = basename(filePath);
+const title      = titleFlag ?? sourceName;
+
+const requestBody = {
+  encryptedPayload,
+  iv:         ivB64u,
+  sha256:     sha256Hex,
+  title,
+  sourceName,
+  ttlSeconds,
+  ...(slugFlag        ? { slug: slugFlag } : {}),
+};
+
+let response;
+try {
+  response = await fetch(`${baseUrl}/api/pages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+} catch (err) {
+  console.error(`Error: network request failed — ${err.message}`);
+  process.exit(1);
+}
+
+if (!response.ok) {
+  const body = await response.text().catch(() => '');
+  console.error(`Error: upload failed with HTTP ${response.status}`);
+  if (body) console.error(body);
+  process.exit(1);
+}
+
+const result = await response.json();
+
+// Append the key fragment — the server never receives it
+const viewerUrl = `${result.viewerUrl}#${keyB64u}`;
+
+// ---------------------------------------------------------------------------
+// Clipboard — best-effort, never fatal
+// ---------------------------------------------------------------------------
+
+function copyToClipboard(text) {
+  const { platform } = process;
+
+  if (platform === 'darwin') {
+    const r = spawnSync('pbcopy', { input: text });
+    return !r.error && r.status === 0;
+  }
+
+  if (platform === 'win32') {
+    // clip.exe reads from stdin; shell:true handles cmd.exe path resolution
+    const r = spawnSync('clip', { input: text, shell: true });
+    return !r.error && r.status === 0;
+  }
+
+  // Linux — try each tool in order; skip when not installed (ENOENT)
+  for (const [cmd, extra] of [
+    ['wl-copy', []],
+    ['xclip',   ['-selection', 'clipboard']],
+    ['xsel',    ['--clipboard', '--input']],
+  ]) {
+    const r = spawnSync(cmd, extra, { input: text });
+    if (!r.error && r.status === 0) return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+const output = {
+  id:          result.id,
+  viewerUrl,
+  blobUrl:     result.blobUrl,
+  expiresAt:   result.expiresAt ?? null,
+  deleteToken: result.deleteToken,
+  warnings:    warnings.length,
+  warningMessages: warnings,
+};
+
+if (jsonOnly) {
+  console.log(JSON.stringify(output));
+} else {
+  console.log(JSON.stringify(output, null, 2));
+  console.log(`\nPublished: ${viewerUrl}`);
+  if (result.expiresAt) {
+    console.log(`   Expires:   ${new Date(result.expiresAt).toLocaleString()}`);
+  }
+  if (warnings.length > 0) {
+    console.log(
+      `   Warning: ${warnings.length} external reference(s) — artifact may depend on live URLs`,
+    );
+  }
+}
+
+// Clipboard — best-effort; upload already succeeded, failure is non-fatal
+if (shouldCopy) {
+  const copied = copyToClipboard(viewerUrl);
+  if (jsonOnly) {
+    // --json --copy: stdout stays clean JSON; clipboard note goes to stderr
+    process.stderr.write(copied ? '# clipboard: copied\n' : '# clipboard: unavailable\n');
+  } else {
+    console.log(copied ? '   Copied to clipboard' : '   Clipboard unavailable');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Delete local file — only after confirmed successful upload
+// ---------------------------------------------------------------------------
+
+if (deleteLocal) {
+  try {
+    unlinkSync(filePath);
+    if (!jsonOnly) console.log(`   Deleted:   ${filePath}`);
+  } catch (err) {
+    if (!jsonOnly) console.warn(`   Warning: could not delete ${filePath} — ${err.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add the `publish-html-page` skill to wardrobe storage
- colocate the self-contained `publish-html.mjs` helper under the skill directory
- point the skill instructions at the colocated script and note the Node 22+ runtime requirement

## Test plan
- node --check skills/publish-html-page/scripts/publish-html.mjs
- npm run validate
- npm run build -- --target all --dry-run
