### PR TITLE
rtk-pre-commit-format: gate on git-commit-in-a-Cargo-project

### DIFF
--- a/hooks/rtk-pre-commit-format/HOOK.md
+++ b/hooks/rtk-pre-commit-format/HOOK.md
@@ -1,12 +1,12 @@
 ---
 name: rtk-pre-commit-format
-version: 1.0.0
+version: 1.1.0
 description: >
   Auto-formats Rust code with `cargo fmt --all` and blocks the commit if
   `cargo clippy --all-targets` finds compilation errors (warnings still pass).
-  Wired to PreToolUse:Bash and triggers when Claude Code is about to run a
-  `git commit`. Use only in Rust projects with rtk-style discipline — the hook
-  bails noisily if cargo is missing.
+  Wired to PreToolUse:Bash; self-gates to `git commit` inside a Cargo project
+  and is a silent no-op everywhere else. Only useful in Rust projects with
+  rtk-style discipline, but harmless in any repo.
 type: hook
 targets:
   - claude-code
@@ -33,9 +33,24 @@ Clippy warnings are allowed — only hard errors block.
 
 ## Activation
 
-This hook is intended to be installed only in Rust repos that follow rtk's discipline (zero clippy errors, `cargo fmt` clean tree). Outside Rust projects, leave it off — `cargo fmt` will fail with a non-Rust complaint and noise up every Bash invocation.
+The wardrobe build wires this hook to `PreToolUse:Bash` unconditionally, so it is invoked for every shell command in every repo. The script therefore gates itself and exits 0 without output unless **both** hold:
 
-The wardrobe build wires this hook to `PreToolUse:Bash` unconditionally; if your repo has no Cargo project, exclude it via your outfit or accessory selection.
+1. The command is a `git commit` — read from the hook payload, since a `PreToolUse` matcher cannot express it.
+2. The working directory is inside a Cargo project — a `Cargo.toml` is found by walking up from `pwd`, the same way cargo resolves its manifest.
+
+`cargo` missing from `PATH` is also a silent no-op rather than an error.
+
+Without those gates the hook ran `cargo fmt --all` and `cargo clippy --all-targets` on every Bash tool call, which failed loudly in any non-Cargo repo:
+
+```
+PreToolUse:Bash hook error
+Failed with non-blocking status code: `cargo metadata` exited with an error:
+error: could not find `Cargo.toml` in `/path/to/some/go/repo` or any parent directory
+```
+
+It is still only *useful* in Rust repos that follow rtk's discipline (zero clippy errors, `cargo fmt` clean tree), but it is now harmless everywhere else, so excluding it from non-Rust outfits is an optimisation rather than a requirement.
+
+Progress and failure messages go to **stderr**. `PreToolUse` stdout is a structured channel; plain text there risks being read as hook output.
 
 ## Files
 

--- a/hooks/rtk-pre-commit-format/hooks/rtk-pre-commit-format.sh
+++ b/hooks/rtk-pre-commit-format/hooks/rtk-pre-commit-format.sh
@@ -1,16 +1,61 @@
 #!/usr/bin/env bash
-# Auto-format Rust code before commits
-# Hook: PreToolUse for git commit
+# Auto-format Rust code before commits.
+# Hook: PreToolUse:Bash
+#
+# The matcher this hook is wired with is a blunt "Bash", so it is invoked for
+# every shell command in every repo, not just `git commit` in Rust projects.
+# Both gates below are load-bearing: without them the hook runs `cargo fmt` and
+# `cargo clippy` on every Bash tool call, which fails loudly in any non-Cargo
+# repo ("could not find `Cargo.toml` in ... or any parent directory") and is
+# needlessly slow even where it succeeds.
 
-echo "Running Rust pre-commit checks..."
+set -uo pipefail
 
-# Format code
+payload="$(cat 2>/dev/null || true)"
+
+# Gate 1: only act on an actual `git commit`. The command has to be read out of
+# the hook payload because a PreToolUse matcher cannot express it.
+command_text="$(
+  printf '%s' "$payload" | /usr/bin/python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("tool_input", {}).get("command", ""))
+except Exception:
+    print("")
+' 2>/dev/null || true
+)"
+
+case "$command_text" in
+  *"git commit"*|*"git "*" commit"*) ;;
+  *) exit 0 ;;
+esac
+
+# Gate 2: only act inside a Cargo project. Walking up from the working directory
+# for a Cargo.toml matches how cargo itself resolves the manifest, so the hook
+# activates exactly where `cargo fmt` would have worked anyway.
+dir="$(pwd -P)"
+manifest=""
+while [ -n "$dir" ]; do
+  if [ -f "$dir/Cargo.toml" ]; then
+    manifest="$dir/Cargo.toml"
+    break
+  fi
+  [ "$dir" = "/" ] && break
+  dir="$(dirname "$dir")"
+done
+[ -n "$manifest" ] || exit 0
+
+command -v cargo >/dev/null 2>&1 || exit 0
+
+# Progress and failure text go to stderr: PreToolUse stdout is a structured
+# channel, and stray plain text there risks being read as hook output.
+echo "Running Rust pre-commit checks..." >&2
+
 cargo fmt --all
 
-# Check for compilation errors only (warnings allowed)
 if cargo clippy --all-targets 2>&1 | grep -q "error:"; then
-    echo "Clippy found errors. Fix them before committing."
+    echo "Clippy found errors. Fix them before committing." >&2
     exit 1
 fi
 
-echo "Pre-commit checks passed (warnings allowed)"
+echo "Pre-commit checks passed (warnings allowed)" >&2


### PR DESCRIPTION
## Problem

`rtk-pre-commit-format` is wired to `PreToolUse:Bash`, which matches **every** shell command in **every** repo, and the script never inspected the payload. So it ran `cargo fmt --all` + `cargo clippy --all-targets` on every Bash tool call. In any non-Cargo repo that surfaced as:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: `cargo metadata` exited with an error:
error: could not find `Cargo.toml` in `/Users/…/projects/dagnats` or any parent directory
```

Hit while working in a Go repo — the error fires on every command, and the `cargo` invocations are slow even where they succeed.

## Why not just exclude it from the outfit

`HOOK.md` already predicted this failure ("Outside Rust projects, leave it off — `cargo fmt` will fail with a non-Rust complaint and noise up every Bash invocation") and pushed the problem onto outfit selection.

That puts the burden on every consumer to remember an exclusion, and it **fails open**: forget it once and every Bash call in that repo errors. The asset should be safe wherever it is wired.

## Fix

Gate inside the script:

1. **Parse `tool_input.command` from the hook payload; exit 0 unless it is a `git commit`.** A `PreToolUse` matcher cannot express "only git commit", so the payload is the only place this information exists. The script's own header comment always claimed it was a commit hook — it just never checked.
2. **Walk up from `pwd` for a `Cargo.toml`; exit 0 if absent.** This mirrors how cargo resolves its manifest, so the hook activates exactly where `cargo fmt` would have worked anyway.
3. **Treat missing `cargo` as a no-op** rather than an error.

Also moved progress/failure text to **stderr** — `PreToolUse` stdout is a structured channel, and plain text there risks being parsed as hook output.

`dist/` is gitignored, so only the source needed changing.

## Verification

| cwd | command | result |
| --- | --- | --- |
| non-Cargo repo (notify, Go) | `git status` | rc=0, no output |
| non-Cargo repo (notify, Go) | `git commit -m x` | rc=0, no output |
| non-Cargo repo (dagnats, Go) | `git commit -m x` | rc=0, no output |
| Cargo repo | `git status` | rc=0, no output |
| Cargo repo | `git commit -m x` | activates, runs fmt + clippy |

Reproduced the original error first, then confirmed each gate independently.

## Docs

`HOOK.md` bumped to 1.1.0. The "leave it off outside Rust projects" instruction is replaced with a description of the self-gating, since excluding it is now an optimisation rather than a requirement.